### PR TITLE
Develop

### DIFF
--- a/examples/basic_ecu/generated/uds_init.c
+++ b/examples/basic_ecu/generated/uds_init.c
@@ -1,3 +1,5 @@
+
+
 /*
  * =============================================================================
  * Xaloqi EDS
@@ -63,10 +65,13 @@
 #include "dtc_database.h"
 #include "dtc_mirror.h"
 #include "routine_database.h"
+#ifndef EDS_DOIP_ONLY_BUILD
 #include "isotp.h"
 #include "can_transport.h"
+#endif /* EDS_DOIP_ONLY_BUILD */
 #include "generated_config.h"
 #include "safety_config.h"
+
 
 #include <stddef.h>
 #include <stdbool.h>
@@ -82,7 +87,9 @@
 static uds_session_ctx_t  s_session_ctx;
 static uds_security_ctx_t s_security_ctx;
 static uds_server_ctx_t   s_server_ctx;
+#ifndef EDS_DOIP_ONLY_BUILD
 static isotp_ctx_t        s_isotp_ctx;
+#endif /* EDS_DOIP_ONLY_BUILD */
 
 /** Guard: true once uds_generated_init() has completed successfully. */
 static bool s_initialized = false;
@@ -103,16 +110,22 @@ static bool s_initialized = false;
  * @return UDS_STATUS_ERR_ALREADY_INITIALIZED if called more than once.
  * @return Propagated UDS_STATUS_ERR_* on any sub-init failure.
  */
+#ifndef EDS_DOIP_ONLY_BUILD
 uds_status_t uds_generated_init(
     can_transport_t *can,
     uint32_t         rx_can_id,
     uint32_t         tx_can_id)
+#else
+uds_status_t uds_generated_init(
+    void    *can,
+    uint32_t rx_can_id,
+    uint32_t tx_can_id)
+#endif /* EDS_DOIP_ONLY_BUILD */
 {
     uds_status_t status;
 
-    if (can == NULL) {
-        return UDS_STATUS_ERR_NULL_PTR;
-    }
+    /* can == NULL is valid for DoIP-only builds (transport: doip).
+     * ISO-TP init is skipped below when no CAN transport is provided. */
 
     if (s_initialized) {
         return UDS_STATUS_ERR_ALREADY_INITIALIZED;
@@ -234,6 +247,8 @@ uds_status_t uds_generated_init(
      *   0x40 = maintenance_only
      */
     {
+
+
         status = dtc_database_register(
             (uint32_t)12583168UL,
             (uint8_t)0x20U,
@@ -243,6 +258,8 @@ uds_status_t uds_generated_init(
             return status;
         }
 
+
+
         status = dtc_database_register(
             (uint32_t)12583424UL,
             (uint8_t)0x40U,
@@ -251,6 +268,7 @@ uds_status_t uds_generated_init(
         if (status != UDS_STATUS_OK) {
             return status;
         }
+
 
     }
 
@@ -291,12 +309,15 @@ uds_status_t uds_generated_init(
      * Only executed when routines are declared in the YAML config.
      * Defined in generated/routine_handlers.c.
      */
+
     status = routine_handlers_register_all();
     if (status != UDS_STATUS_OK) {
         return status;
     }
 
+
     /* ── Step 5.7: Flash operations (SafeBoot — MCUboot DFU) ──────────────
+
      *
      * SafeBoot is DISABLED (safeboot.enabled not set in diagnostics_config.yaml).
      *
@@ -310,7 +331,9 @@ uds_status_t uds_generated_init(
      *
      * Then regenerate: python3 tools/codegen.py --config <yaml> --out generated/
      *                                            --safety-wrappers --asil-level B
+
      */
+
     /* ── Step 6: Session layer ─────────────────────────────────────────────
      *
      * Starts in UDS_SESSION_DEFAULT. S3server timer armed.
@@ -436,7 +459,8 @@ uds_status_t uds_generated_init(
      * block_size = 0: no block size limit (tester decides segmentation pace).
      * stmin_ms   = 0: no minimum separation time enforced by this ECU.
      */
-    {
+#ifndef EDS_DOIP_ONLY_BUILD
+    if (can != NULL) {
         isotp_cfg_t isotp_cfg;
         (void)memset(&isotp_cfg, 0, sizeof(isotp_cfg));
 
@@ -451,6 +475,7 @@ uds_status_t uds_generated_init(
             return status;
         }
     }
+#endif /* EDS_DOIP_ONLY_BUILD */
 
     s_initialized = true;
 
@@ -475,6 +500,7 @@ uds_server_ctx_t *uds_generated_get_server(void)
 /**
  * @brief Return pointer to the statically allocated ISO-TP context.
  */
+#ifndef EDS_DOIP_ONLY_BUILD
 isotp_ctx_t *uds_generated_get_isotp(void)
 {
     if (!s_initialized) {
@@ -482,5 +508,6 @@ isotp_ctx_t *uds_generated_get_isotp(void)
     }
     return &s_isotp_ctx;
 }
+#endif /* EDS_DOIP_ONLY_BUILD */
 
 /* End of uds_init.c */

--- a/examples/basic_ecu/generated/uds_init.h
+++ b/examples/basic_ecu/generated/uds_init.h
@@ -1,3 +1,5 @@
+
+
 /*
  * =============================================================================
  * Xaloqi EDS
@@ -23,8 +25,10 @@
 #include "uds_server.h"
 #include "uds_safety.h"
 #include "safety_config.h"
+#ifndef EDS_DOIP_ONLY_BUILD
 #include "isotp.h"
 #include "can_transport.h"
+#endif /* EDS_DOIP_ONLY_BUILD */
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,11 +60,20 @@ extern "C" {
  *
  * @note SAFETY: Must be called from initialisation context, not from ISR.
  */
+#ifndef EDS_DOIP_ONLY_BUILD
 uds_status_t uds_generated_init(
     can_transport_t *can,
     uint32_t         rx_can_id,
     uint32_t         tx_can_id
 );
+#else
+/* DoIP-only build: can parameter is unused (pass NULL). */
+uds_status_t uds_generated_init(
+    void    *can,
+    uint32_t rx_can_id,
+    uint32_t tx_can_id
+);
+#endif /* EDS_DOIP_ONLY_BUILD */
 
 /**
  * @brief Return a pointer to the generated UDS server context.
@@ -82,7 +95,12 @@ uds_server_ctx_t *uds_generated_get_server(void);
  * @return Non-NULL pointer to the statically allocated ISO-TP context.
  *         Returns NULL if uds_generated_init() has not been called.
  */
+#ifndef EDS_DOIP_ONLY_BUILD
 isotp_ctx_t *uds_generated_get_isotp(void);
+#else
+/* DoIP-only build: returns NULL, isotp_ctx_t unavailable */
+static inline void *uds_generated_get_isotp(void) { return ((void *)0); }
+#endif /* EDS_DOIP_ONLY_BUILD */
 
 /**
  * @brief Application-provided security seed generation callback.

--- a/examples/basic_ecu_freertos/generated/uds_init.c
+++ b/examples/basic_ecu_freertos/generated/uds_init.c
@@ -1,3 +1,5 @@
+
+
 /*
  * =============================================================================
  * Xaloqi EDS
@@ -63,10 +65,13 @@
 #include "dtc_database.h"
 #include "dtc_mirror.h"
 #include "routine_database.h"
+#ifndef EDS_DOIP_ONLY_BUILD
 #include "isotp.h"
 #include "can_transport.h"
+#endif /* EDS_DOIP_ONLY_BUILD */
 #include "generated_config.h"
 #include "safety_config.h"
+
 
 #include <stddef.h>
 #include <stdbool.h>
@@ -82,7 +87,9 @@
 static uds_session_ctx_t  s_session_ctx;
 static uds_security_ctx_t s_security_ctx;
 static uds_server_ctx_t   s_server_ctx;
+#ifndef EDS_DOIP_ONLY_BUILD
 static isotp_ctx_t        s_isotp_ctx;
+#endif /* EDS_DOIP_ONLY_BUILD */
 
 /** Guard: true once uds_generated_init() has completed successfully. */
 static bool s_initialized = false;
@@ -103,16 +110,22 @@ static bool s_initialized = false;
  * @return UDS_STATUS_ERR_ALREADY_INITIALIZED if called more than once.
  * @return Propagated UDS_STATUS_ERR_* on any sub-init failure.
  */
+#ifndef EDS_DOIP_ONLY_BUILD
 uds_status_t uds_generated_init(
     can_transport_t *can,
     uint32_t         rx_can_id,
     uint32_t         tx_can_id)
+#else
+uds_status_t uds_generated_init(
+    void    *can,
+    uint32_t rx_can_id,
+    uint32_t tx_can_id)
+#endif /* EDS_DOIP_ONLY_BUILD */
 {
     uds_status_t status;
 
-    if (can == NULL) {
-        return UDS_STATUS_ERR_NULL_PTR;
-    }
+    /* can == NULL is valid for DoIP-only builds (transport: doip).
+     * ISO-TP init is skipped below when no CAN transport is provided. */
 
     if (s_initialized) {
         return UDS_STATUS_ERR_ALREADY_INITIALIZED;
@@ -234,6 +247,8 @@ uds_status_t uds_generated_init(
      *   0x40 = maintenance_only
      */
     {
+
+
         status = dtc_database_register(
             (uint32_t)12583168UL,
             (uint8_t)0x20U,
@@ -243,6 +258,8 @@ uds_status_t uds_generated_init(
             return status;
         }
 
+
+
         status = dtc_database_register(
             (uint32_t)12583424UL,
             (uint8_t)0x40U,
@@ -251,6 +268,7 @@ uds_status_t uds_generated_init(
         if (status != UDS_STATUS_OK) {
             return status;
         }
+
 
     }
 
@@ -291,12 +309,15 @@ uds_status_t uds_generated_init(
      * Only executed when routines are declared in the YAML config.
      * Defined in generated/routine_handlers.c.
      */
+
     status = routine_handlers_register_all();
     if (status != UDS_STATUS_OK) {
         return status;
     }
 
+
     /* ── Step 5.7: Flash operations (SafeBoot — MCUboot DFU) ──────────────
+
      *
      * SafeBoot is DISABLED (safeboot.enabled not set in diagnostics_config.yaml).
      *
@@ -310,7 +331,9 @@ uds_status_t uds_generated_init(
      *
      * Then regenerate: python3 tools/codegen.py --config <yaml> --out generated/
      *                                            --safety-wrappers --asil-level B
+
      */
+
     /* ── Step 6: Session layer ─────────────────────────────────────────────
      *
      * Starts in UDS_SESSION_DEFAULT. S3server timer armed.
@@ -436,7 +459,8 @@ uds_status_t uds_generated_init(
      * block_size = 0: no block size limit (tester decides segmentation pace).
      * stmin_ms   = 0: no minimum separation time enforced by this ECU.
      */
-    {
+#ifndef EDS_DOIP_ONLY_BUILD
+    if (can != NULL) {
         isotp_cfg_t isotp_cfg;
         (void)memset(&isotp_cfg, 0, sizeof(isotp_cfg));
 
@@ -451,6 +475,7 @@ uds_status_t uds_generated_init(
             return status;
         }
     }
+#endif /* EDS_DOIP_ONLY_BUILD */
 
     s_initialized = true;
 
@@ -475,6 +500,7 @@ uds_server_ctx_t *uds_generated_get_server(void)
 /**
  * @brief Return pointer to the statically allocated ISO-TP context.
  */
+#ifndef EDS_DOIP_ONLY_BUILD
 isotp_ctx_t *uds_generated_get_isotp(void)
 {
     if (!s_initialized) {
@@ -482,5 +508,6 @@ isotp_ctx_t *uds_generated_get_isotp(void)
     }
     return &s_isotp_ctx;
 }
+#endif /* EDS_DOIP_ONLY_BUILD */
 
 /* End of uds_init.c */

--- a/examples/basic_ecu_freertos/generated/uds_init.h
+++ b/examples/basic_ecu_freertos/generated/uds_init.h
@@ -1,3 +1,5 @@
+
+
 /*
  * =============================================================================
  * Xaloqi EDS
@@ -23,8 +25,10 @@
 #include "uds_server.h"
 #include "uds_safety.h"
 #include "safety_config.h"
+#ifndef EDS_DOIP_ONLY_BUILD
 #include "isotp.h"
 #include "can_transport.h"
+#endif /* EDS_DOIP_ONLY_BUILD */
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,11 +60,20 @@ extern "C" {
  *
  * @note SAFETY: Must be called from initialisation context, not from ISR.
  */
+#ifndef EDS_DOIP_ONLY_BUILD
 uds_status_t uds_generated_init(
     can_transport_t *can,
     uint32_t         rx_can_id,
     uint32_t         tx_can_id
 );
+#else
+/* DoIP-only build: can parameter is unused (pass NULL). */
+uds_status_t uds_generated_init(
+    void    *can,
+    uint32_t rx_can_id,
+    uint32_t tx_can_id
+);
+#endif /* EDS_DOIP_ONLY_BUILD */
 
 /**
  * @brief Return a pointer to the generated UDS server context.
@@ -82,7 +95,12 @@ uds_server_ctx_t *uds_generated_get_server(void);
  * @return Non-NULL pointer to the statically allocated ISO-TP context.
  *         Returns NULL if uds_generated_init() has not been called.
  */
+#ifndef EDS_DOIP_ONLY_BUILD
 isotp_ctx_t *uds_generated_get_isotp(void);
+#else
+/* DoIP-only build: returns NULL, isotp_ctx_t unavailable */
+static inline void *uds_generated_get_isotp(void) { return ((void *)0); }
+#endif /* EDS_DOIP_ONLY_BUILD */
 
 /**
  * @brief Application-provided security seed generation callback.

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -792,6 +792,18 @@ def build_uds_init_context(cfg: Dict[str, Any]) -> Dict[str, Any]:
     safeboot_platform = safeboot_block.get("platform", "zephyr")
     safeboot_max_block = int(safeboot_block.get("max_block_length", 256))
 
+    # Transport configuration (v1.6.0 — additive, optional)
+    # transport: can   — ISO-TP over CAN only (default when ecu: block absent)
+    # transport: doip  — DoIP over Ethernet only (EDS_DOIP_ONLY_BUILD)
+    # transport: both  — ISO-TP CAN + DoIP simultaneously
+    ecu_block  = cfg.get("ecu", {}) or {}
+    transport  = ecu_block.get("transport", "can").lower()
+    doip_block = ecu_block.get("doip", {}) or {}
+    doip_logical_address = doip_block.get("logical_address", "0xE400")
+    doip_source_address  = doip_block.get("source_address", "0x0E00")
+    doip_port            = int(doip_block.get("port", 13400))
+    is_doip = transport in ("doip", "both")
+
     return {
         "ecu_name":              meta["ecu_name"],
         "version":               meta["version"],
@@ -807,6 +819,12 @@ def build_uds_init_context(cfg: Dict[str, Any]) -> Dict[str, Any]:
         "safeboot_enabled":      safeboot_enabled,
         "safeboot_platform":     safeboot_platform,
         "safeboot_max_block":    safeboot_max_block,
+        # Transport context (v1.6.0)
+        "transport":             transport,
+        "is_doip":               is_doip,
+        "doip_logical_address":  doip_logical_address,
+        "doip_source_address":   doip_source_address,
+        "doip_port":             doip_port,
     }
 
 


### PR DESCRIPTION
DoIP final step; 
EDS-toolchain repo
tools/templates/uds_init.c.j2 — 5 guard sites added:

#include "isotp.h" / #include "can_transport.h" wrapped in #ifndef EDS_DOIP_ONLY_BUILD
static isotp_ctx_t s_isotp_ctx; wrapped in #ifndef EDS_DOIP_ONLY_BUILD
Function signature split: CAN variant under #ifndef, DoIP void *can variant under #else
NULL pointer check removed (relaxed comment instead); isotp_init block wrapped in #ifndef EDS_DOIP_ONLY_BUILD with if (can != NULL)
uds_generated_get_isotp() implementation wrapped in #ifndef EDS_DOIP_ONLY_BUILD

tools/templates/uds_init.h.j2 — 3 guard sites added:

#include "isotp.h" / #include "can_transport.h" wrapped in #ifndef
uds_generated_init() declaration split into CAN / DoIP variants
uds_generated_get_isotp() declaration split: full decl or static inline void * stub

EDS repo (public)
tools/codegen.py — build_uds_init_context() now extracts transport context from ecu: block: transport, is_doip, doip_logical_address, doip_source_address, doip_port. These are available to templates as Jinja2 variables for future use.
examples/basic_ecu/generated/uds_init.c and uds_init.h — regenerated to match new templates. The guards are now present (they're static #ifndef blocks, so EDS_DOIP_ONLY_BUILD being undefined means the CAN path compiles unchanged — fully backward compatible).
examples/basic_ecu_freertos/generated/uds_init.c and uds_init.h — same regeneration. basic_ecu_doip/ and basic_ecu_doip_freertos/ were already hand-patched and match the new template output — no change needed there.
What was NOT changed
generated_config.h.j2 — the ground-truth file in basic_ecu_doip/generated/generated_config.h has no DoIP transport section, so the template stays as-is. DoIP constants (DOIP_ECU_LOGICAL_ADDR etc.) are defined directly in main.c for now.
ci.yml — -DDIAG_SKIP_CODEGEN=ON stays. The templates live in the private toolchain repo, so public CI can't run codegen. The pre-generated files in the public repo are the mechanism.

Verification summary
CheckResultuds_init.c.j2 rendered against DoIP YAML vs ground truthZero non-whitespace differencesuds_init.h.j2 rendered against DoIP YAML vs ground truthZero non-whitespace differencesCAN build backward compat: guards present, #ifndef path compilesOKbuild_uds_init_context extracts transport: doip correctlyOKis_doip=True for transport: doip, False for CAN buildsOK