### PR TITLE
Develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1029,69 +1029,72 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Python dependencies
-        run: pip install pyyaml jinja2
+        run: pip install pyyaml
 
-      - name: Checkout EDS-toolchain (for templates)
-        uses: actions/checkout@v4
-        with:
-          repository: Xaloqi/EDS-toolchain
-          token: ${{ secrets.TOOLCHAIN_TOKEN }}
-          path: EDS-toolchain
-
-      - name: Run codegen --sovd on basic_ecu (CAN transport)
-        env:
-          XALOQI_LICENSE_SKIP: "1"
-        run: |
-          python3 tools/codegen.py \
-            --config       examples/basic_ecu/diagnostics_config.yaml \
-            --out          /tmp/sovd_can/ \
-            --template-dir EDS-toolchain/tools/templates/ \
-            --safety-wrappers --asil-level B --sovd --no-manifest
-
-      - name: Validate basic_ecu CDA — valid JSON + counts
+      - name: Generate SOVD CDA — basic_ecu (CAN transport)
         run: |
           python3 - <<'EOF'
-          import json, sys
+          # build_sovd_cda() is pure Python — no Jinja2 templates needed.
+          # Import it directly from tools/codegen.py.
+          import sys, json
           from pathlib import Path
-          import yaml
+          sys.path.insert(0, "tools")
+          from codegen import build_sovd_cda, load_config
 
-          cda = json.loads(Path("/tmp/sovd_can/sovd_cda.json").read_text())
+          cfg = load_config(Path("examples/basic_ecu/diagnostics_config.yaml"))
+          cda = build_sovd_cda(cfg)
+          Path("/tmp/sovd_can.json").write_text(json.dumps(cda, indent=2) + "\n")
+          print("Generated /tmp/sovd_can.json")
+          EOF
+
+      - name: Validate basic_ecu CDA
+        run: |
+          python3 - <<'EOF'
+          import json, yaml
+          from pathlib import Path
+
+          cda = json.loads(Path("/tmp/sovd_can.json").read_text())
           cfg = yaml.safe_load(Path("examples/basic_ecu/diagnostics_config.yaml").read_text())
 
-          assert cda["transportInfo"]["protocol"] == "ISO-TP",  "Expected ISO-TP"
-          assert "logicalAddress" not in cda["ecuIdentification"], "CAN ECU must not have logicalAddress"
-          assert len(cda["dataIdentifiers"]) == len(cfg.get("dids", [])),     "DID count mismatch"
-          assert len(cda["dtcs"])            == len(cfg.get("dtcs", [])),     "DTC count mismatch"
+          assert cda["sovdVersion"] == "1.0.0",                              "Wrong sovdVersion"
+          assert cda["transportInfo"]["protocol"] == "ISO-TP",               "Expected ISO-TP"
+          assert "logicalAddress" not in cda["ecuIdentification"],           "CAN ECU must not have logicalAddress"
+          assert len(cda["dataIdentifiers"]) == len(cfg.get("dids", [])),    "DID count mismatch"
+          assert len(cda["dtcs"])            == len(cfg.get("dtcs", [])),    "DTC count mismatch"
           assert len(cda["routines"])        == len(cfg.get("routines", [])), "Routine count mismatch"
-          assert len(cda["diagnosticServices"]) == 14, "Expected 14 diagnostic services"
+          assert len(cda["diagnosticServices"]) == 14,                       "Expected 14 services"
           print("PASS: basic_ecu CDA valid")
           EOF
 
-      - name: Run codegen --sovd on basic_ecu_doip (DoIP transport)
-        env:
-          XALOQI_LICENSE_SKIP: "1"
-        run: |
-          python3 tools/codegen.py \
-            --config       examples/basic_ecu_doip/diagnostics_config.yaml \
-            --out          /tmp/sovd_doip/ \
-            --template-dir EDS-toolchain/tools/templates/ \
-            --safety-wrappers --asil-level B --sovd --no-manifest
-
-      - name: Validate basic_ecu_doip CDA — valid JSON + DoIP fields
+      - name: Generate SOVD CDA — basic_ecu_doip (DoIP transport)
         run: |
           python3 - <<'EOF'
-          import json, sys
+          import sys, json
           from pathlib import Path
-          import yaml
+          sys.path.insert(0, "tools")
+          from codegen import build_sovd_cda, load_config
 
-          cda = json.loads(Path("/tmp/sovd_doip/sovd_cda.json").read_text())
+          cfg = load_config(Path("examples/basic_ecu_doip/diagnostics_config.yaml"))
+          cda = build_sovd_cda(cfg)
+          Path("/tmp/sovd_doip.json").write_text(json.dumps(cda, indent=2) + "\n")
+          print("Generated /tmp/sovd_doip.json")
+          EOF
+
+      - name: Validate basic_ecu_doip CDA
+        run: |
+          python3 - <<'EOF'
+          import json, yaml
+          from pathlib import Path
+
+          cda = json.loads(Path("/tmp/sovd_doip.json").read_text())
           cfg = yaml.safe_load(Path("examples/basic_ecu_doip/diagnostics_config.yaml").read_text())
 
-          assert cda["transportInfo"]["protocol"] == "DoIP",   "Expected DoIP"
-          assert cda["transportInfo"]["port"]     == 13400,    "Wrong DoIP port"
-          assert cda["ecuIdentification"]["logicalAddress"] == "0xE400", "Wrong logical address"
-          assert len(cda["dataIdentifiers"]) == len(cfg.get("dids", [])),     "DID count mismatch"
-          assert len(cda["dtcs"])            == len(cfg.get("dtcs", [])),     "DTC count mismatch"
-          assert len(cda["routines"])        == len(cfg.get("routines", [])), "Routine count mismatch"
+          assert cda["sovdVersion"] == "1.0.0",                                       "Wrong sovdVersion"
+          assert cda["transportInfo"]["protocol"] == "DoIP",                          "Expected DoIP"
+          assert cda["transportInfo"]["port"]     == 13400,                           "Wrong DoIP port"
+          assert cda["ecuIdentification"]["logicalAddress"] == "0xE400",             "Wrong logical address"
+          assert len(cda["dataIdentifiers"]) == len(cfg.get("dids", [])),            "DID count mismatch"
+          assert len(cda["dtcs"])            == len(cfg.get("dtcs", [])),            "DTC count mismatch"
+          assert len(cda["routines"])        == len(cfg.get("routines", [])),        "Routine count mismatch"
           print("PASS: basic_ecu_doip CDA valid")
           EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
 
   # ── Job 1: Host unit tests ─────────────────────────────────────────────────
   unit-tests:
-    name: "Unit Tests (37 modules)"
+    name: "Unit Tests (36 modules)"
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -1008,7 +1008,11 @@ jobs:
           DOIP_STARTUP_DELAY_S: "2.0"
           DOIP_TEST_TIMEOUT_S: "10.0"
         run: |
-          pytest tests/test_doip_integration.py -v --timeout=60 || { rc=$?; [ $rc -eq 5 ] && echo "All tests skipped (xaloqi not installed) — OK" || exit $rc; }
+          # Exit code 5 = no tests collected (all skipped when xaloqi-tester
+          # is not installed). Treat as success — the ECU binary built correctly.
+          pytest tests/test_doip_integration.py -v --timeout=60 || {
+            rc=$?; [ $rc -eq 5 ] && echo "All tests skipped (xaloqi not installed) — OK" || exit $rc
+          }
 
       - name: Upload ECU binary artifact
         uses: actions/upload-artifact@v4
@@ -1016,3 +1020,78 @@ jobs:
         with:
           name: doip-native-sim-binary
           path: build/zephyr/zephyr.exe
+
+  sovd-codegen:
+    name: "SOVD CDA Generation"
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Python dependencies
+        run: pip install pyyaml jinja2
+
+      - name: Checkout EDS-toolchain (for templates)
+        uses: actions/checkout@v4
+        with:
+          repository: Xaloqi/EDS-toolchain
+          token: ${{ secrets.TOOLCHAIN_TOKEN }}
+          path: EDS-toolchain
+
+      - name: Run codegen --sovd on basic_ecu (CAN transport)
+        env:
+          XALOQI_LICENSE_SKIP: "1"
+        run: |
+          python3 tools/codegen.py \
+            --config       examples/basic_ecu/diagnostics_config.yaml \
+            --out          /tmp/sovd_can/ \
+            --template-dir EDS-toolchain/tools/templates/ \
+            --safety-wrappers --asil-level B --sovd --no-manifest
+
+      - name: Validate basic_ecu CDA — valid JSON + counts
+        run: |
+          python3 - <<'EOF'
+          import json, sys
+          from pathlib import Path
+          import yaml
+
+          cda = json.loads(Path("/tmp/sovd_can/sovd_cda.json").read_text())
+          cfg = yaml.safe_load(Path("examples/basic_ecu/diagnostics_config.yaml").read_text())
+
+          assert cda["transportInfo"]["protocol"] == "ISO-TP",  "Expected ISO-TP"
+          assert "logicalAddress" not in cda["ecuIdentification"], "CAN ECU must not have logicalAddress"
+          assert len(cda["dataIdentifiers"]) == len(cfg.get("dids", [])),     "DID count mismatch"
+          assert len(cda["dtcs"])            == len(cfg.get("dtcs", [])),     "DTC count mismatch"
+          assert len(cda["routines"])        == len(cfg.get("routines", [])), "Routine count mismatch"
+          assert len(cda["diagnosticServices"]) == 14, "Expected 14 diagnostic services"
+          print("PASS: basic_ecu CDA valid")
+          EOF
+
+      - name: Run codegen --sovd on basic_ecu_doip (DoIP transport)
+        env:
+          XALOQI_LICENSE_SKIP: "1"
+        run: |
+          python3 tools/codegen.py \
+            --config       examples/basic_ecu_doip/diagnostics_config.yaml \
+            --out          /tmp/sovd_doip/ \
+            --template-dir EDS-toolchain/tools/templates/ \
+            --safety-wrappers --asil-level B --sovd --no-manifest
+
+      - name: Validate basic_ecu_doip CDA — valid JSON + DoIP fields
+        run: |
+          python3 - <<'EOF'
+          import json, sys
+          from pathlib import Path
+          import yaml
+
+          cda = json.loads(Path("/tmp/sovd_doip/sovd_cda.json").read_text())
+          cfg = yaml.safe_load(Path("examples/basic_ecu_doip/diagnostics_config.yaml").read_text())
+
+          assert cda["transportInfo"]["protocol"] == "DoIP",   "Expected DoIP"
+          assert cda["transportInfo"]["port"]     == 13400,    "Wrong DoIP port"
+          assert cda["ecuIdentification"]["logicalAddress"] == "0xE400", "Wrong logical address"
+          assert len(cda["dataIdentifiers"]) == len(cfg.get("dids", [])),     "DID count mismatch"
+          assert len(cda["dtcs"])            == len(cfg.get("dtcs", [])),     "DTC count mismatch"
+          assert len(cda["routines"])        == len(cfg.get("routines", [])), "Routine count mismatch"
+          print("PASS: basic_ecu_doip CDA valid")
+          EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
+## [1.7.0] — SOVD Bridge (OpenSOVD CDA generation) — 2026-05-13
+
+### Added — SOVD CDA codegen output
+
+`tools/codegen.py --sovd`: new optional flag that generates a valid OpenSOVD 1.0
+Capability Description and Advertisement (CDA) JSON file (`sovd_cda.json`) alongside
+the standard C output. Pure-Python implementation — no Jinja2 template required.
+`build_sovd_cda(cfg)` builds the CDA dict directly; `render_sovd_cda()` writes it
+with `json.dumps(indent=2)`.
+
+The CDA captures the full ECU diagnostic profile from `diagnostics_config.yaml`:
+
+- All configured DIDs with `id`, `name`, `dataLengthBytes`, `access`, `minSession`,
+  `readSecurityLevel`, `writeSecurityLevel`
+- All configured DTCs with `code`, `description`, `severity`
+- All configured routines with `id`, `name`, `minSession`, `securityLevel`,
+  `supportedSubFunctions`
+- Static list of all 14 EDS UDS services (`diagnosticServices`)
+- `transportInfo.protocol`: `"DoIP"` or `"ISO-TP"` derived from `ecu.transport`
+- `ecuIdentification.logicalAddress`, `ecuIdentification.sourceAddress`,
+  `transportInfo.port`: present only when `transport` is `doip` or `both`
+
+Session names use semantic strings (`"default"`, `"extended"`, `"programming"`) —
+not internal C constants — so the JSON is directly readable by SOVD clients and
+Eclipse SDV tooling.
+
+### Changed — CI
+
+`.github/workflows/ci.yml`: added `sovd-codegen` job (job 14 of 14). Imports
+`build_sovd_cda` and `load_config` directly from `tools/codegen.py` — no template
+checkout required. Validates CDA structure, transport protocol, DID/DTC/routine
+counts, and presence/absence of `logicalAddress` for CAN vs DoIP ECUs.
+
+---
+
 ## [1.6.0] — DoIP (ISO 13400-2) transport — 2026-05-13
 
 ### Added — DoIP server for Zephyr and FreeRTOS

--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ The generator produces: DID handler stubs, ASIL-B safety wrappers, DTC registrat
 | **Code generation** | YAML → 14 C/H/py templates · CLI + React GUI · reproducible deterministic output |
 | **Test generation** | YAML → pytest suite per DID and DTC · simulator mode (no hardware) · firmware harness mode |
 | **CANoe CAPL** | YAML → `.can` scripts for CANoe import · per-DID, per-DTC, core services |
+| **SOVD CDA** | `--sovd` flag: YAML → OpenSOVD 1.0 `sovd_cda.json` — DIDs, DTCs, routines, transport, all 14 services · DoIP ECUs include `logicalAddress` and `port` · Eclipse SDV / OEM SOVD clients |
 | **VS Code extension** | Inline YAML validation · hover docs · one-click codegen · auto-run on save · status bar indicator |
 | **MCP server** | `tools/mcp_server.py` — exposes `generate_did_config`, `run_codegen`, `validate_asil_b`, `explain_uds_error` to Claude, Cursor, and any MCP host. Included with Developer and Professional licenses. |
 | **ECU examples** | basic · basic\_doip · basic\_freertos · basic\_doip\_freertos · BMS · motor controller · ARDEP · sensor · safeboot · robot joint — 5–35 DIDs each, Zephyr and FreeRTOS |
-| **CI pipeline** | 13-job GitHub Actions · codegen · unit tests · harness tests · Zephyr builds · FreeRTOS ARM builds · MISRA analysis · MCP server tests · DoIP integration (native_sim + DoipBus) |
+| **CI pipeline** | 14-job GitHub Actions · codegen · unit tests · harness tests · Zephyr builds · FreeRTOS ARM builds · MISRA analysis · MCP server tests · DoIP integration (native_sim + DoipBus) · SOVD CDA generation |
 
 **Safety properties verified by CI on every commit:**
 - Zero dynamic memory allocation (`malloc`/`free` grep gate)

--- a/docs/CODEGEN_ARCHITECTURE.md
+++ b/docs/CODEGEN_ARCHITECTURE.md
@@ -90,8 +90,11 @@ diagnostics_config.yaml
          ├─── Test Suite ─────────── generated/tests/*.py
          │                           (--test-gen flag)
          │
-         └─── GUI Catalog ─────────── gui/src/generated/catalog.ts
-                                      (--gui-types flag)
+         ├─── GUI Catalog ─────────── gui/src/generated/catalog.ts
+         │                           (--gui-types flag)
+         │
+         └─── SOVD CDA ───────────── generated/sovd_cda.json
+                                      (--sovd flag, pure Python — no template)
 ```
 
 ---
@@ -221,6 +224,10 @@ routines:
 ## 6. Template Catalogue
 
 All 14 templates in `tools/templates/`:
+
+Note: the SOVD CDA output (`--sovd`) is generated directly by `build_sovd_cda()` in
+`codegen.py` — it uses no Jinja2 template. `json.dumps(indent=2)` is used instead to
+avoid JSON-escaping issues.
 
 | Template | Output file | Description |
 |---|---|---|
@@ -421,12 +428,13 @@ python3 tools/codegen.py \
   --test-gen               Generate pytest suite in <out>/tests/
   --gui-types              Generate gui/src/generated/catalog.ts
   --gui-out     <dir>      Override GUI output directory
+  --sovd                   Generate OpenSOVD 1.0 CDA JSON (sovd_cda.json)
   --no-manifest            Skip manifest.json (use in CI)
   --dry-run                Validate config only; write no files
   --template-dir <dir>     Override tools/templates/ location
 ```
 
-Example — DoIP ECU with safety wrappers:
+Example — DoIP ECU with safety wrappers and SOVD CDA:
 
 ```bash
 python3 tools/codegen.py \
@@ -434,7 +442,9 @@ python3 tools/codegen.py \
   --out     examples/basic_ecu_doip/generated/ \
   --safety-wrappers \
   --asil-level B \
+  --sovd \
   --no-manifest
+# Produces generated/sovd_cda.json alongside the standard C files.
 ```
 
 Example — BMS ECU with full test generation:
@@ -521,6 +531,62 @@ Generated files must not be manually edited. Any manual change will be overwritt
 ```
 
 ---
+
+---
+
+## 13b. SOVD CDA Output (--sovd)
+
+When `--sovd` is passed, codegen writes `<out>/sovd_cda.json` — a valid
+OpenSOVD 1.0 Capability Description and Advertisement document describing
+the ECU's complete diagnostic profile. This file can be consumed by Eclipse
+SDV tooling, OEM SOVD clients, or any tool that understands the OpenSOVD
+1.0 schema.
+
+### Structure
+
+```json
+{
+  "sovdVersion": "1.0.0",
+  "generatedBy":  "Xaloqi EDS codegen v1.6.0",
+  "generatedAt":  "<ISO 8601 UTC>",
+  "ecuIdentification": {
+    "name":    "<ecu_name>",
+    "version": "<version>",
+    "logicalAddress": "0xE400",   // DoIP only
+    "sourceAddress":  "0x0E00"    // DoIP only
+  },
+  "transportInfo": {
+    "protocol": "DoIP",           // or "ISO-TP" for CAN
+    "port": 13400                 // DoIP only
+  },
+  "dataIdentifiers": [ ... ],
+  "dtcs":            [ ... ],
+  "routines":        [ ... ],
+  "diagnosticServices": [ ... ]   // static list of all 14 EDS services
+}
+```
+
+### Key design choices
+
+- `ecuIdentification.logicalAddress`, `ecuIdentification.sourceAddress`, and
+  `transportInfo.port` are **only emitted** when `ecu.transport` is `doip` or `both`.
+  CAN ECUs produce a clean CDA without these fields.
+- Session names use semantic strings (`"default"`, `"extended"`, `"programming"`) —
+  not the internal C constants (`UDS_SESSION_DEFAULT`) — so the JSON is directly
+  readable without knowledge of the EDS internals.
+- `writeSecurityLevel` is `null` for read-only DIDs (where `"write"` is absent from
+  the `access` list).
+- `diagnosticServices` is a static list of all 14 UDS services EDS implements; it
+  does not vary per ECU and is identical in every generated CDA.
+- Implementation is pure Python in `build_sovd_cda()` — `json.dumps(indent=2)` is
+  used directly rather than a Jinja2 template, which avoids JSON-escaping issues and
+  produces valid JSON by construction.
+
+### CI
+
+The `sovd-codegen` CI job validates the output for both `basic_ecu` (CAN) and
+`basic_ecu_doip` (DoIP) on every push, without requiring EDS-toolchain templates.
+It imports `build_sovd_cda` and `load_config` directly from `tools/codegen.py`.
 
 ## 14. Generated Code Constraints
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -19,14 +19,14 @@ EDS implements:
 - ISO 13400-2 (DoIP): ECU server — Routing Activation, DiagnosticMessage dispatch, Positive/Negative Ack, Alive Check; Zephyr (zsock_*) and FreeRTOS+LwIP bindings (v1.6.0)
 - ASIL-B safety wrapper chain: 5-step mandatory validation on every DID access
 - AES-128-CMAC SecurityAccess (0x27) with TRNG entropy requirement
-- YAML-driven codegen: diagnostics_config.yaml → 14 generated C/H files + test suite
+- YAML-driven codegen: diagnostics_config.yaml → 14 generated C/H files + test suite + optional OpenSOVD 1.0 CDA JSON (--sovd)
 - Auto-generated pytest test suites (per-DID, per-routine, service protocol, firmware harness)
 - Auto-generated CANoe CAPL test scripts
 - 11 reference ECU examples: basic_ecu, basic_ecu_doip, basic_ecu_freertos, basic_ecu_doip_freertos, bms_ecu, motor_controller_ecu, ardep_ecu, sensor_ecu, sensor_ecu_freertos, safeboot_ecu, robot_joint_controller_ecu
 - MCP server: exposes generate_did_config, run_codegen, validate_asil_b, explain_uds_error
 - React/TypeScript live dashboard GUI
 - VS Code extension (YAML validation, hover docs, one-click codegen)
-- 7-job CI pipeline: unit tests (37 modules) · integration · static analysis · Zephyr builds · FreeRTOS QEMU ARM · DoIP integration (native_sim + DoipBus)
+- 8-job CI pipeline: unit tests (37 modules) · integration · static analysis · Zephyr builds · FreeRTOS QEMU ARM · DoIP integration (native_sim + DoipBus) · SOVD CDA generation
 
 ## Licensing
 

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -121,6 +121,29 @@ SESSION_ORDINAL: Dict[str, int] = {
 }
 
 # =============================================================================
+# SOVD CDA — static service list (all 14 EDS services)
+# =============================================================================
+
+#: Static list of all 14 UDS services implemented by EDS.
+#: Used in SOVD CDA generation (--sovd flag).  Same for every ECU.
+SOVD_DIAGNOSTIC_SERVICES: List[Dict[str, str]] = [
+    {"sid": "0x10", "name": "DiagnosticSessionControl"},
+    {"sid": "0x11", "name": "ECUReset"},
+    {"sid": "0x14", "name": "ClearDiagnosticInformation"},
+    {"sid": "0x19", "name": "ReadDTCInformation"},
+    {"sid": "0x22", "name": "ReadDataByIdentifier"},
+    {"sid": "0x27", "name": "SecurityAccess"},
+    {"sid": "0x28", "name": "CommunicationControl"},
+    {"sid": "0x2E", "name": "WriteDataByIdentifier"},
+    {"sid": "0x31", "name": "RoutineControl"},
+    {"sid": "0x34", "name": "RequestDownload"},
+    {"sid": "0x36", "name": "TransferData"},
+    {"sid": "0x37", "name": "RequestTransferExit"},
+    {"sid": "0x3E", "name": "TesterPresent"},
+    {"sid": "0x85", "name": "ControlDTCSetting"},
+]
+
+# =============================================================================
 # Phase 3 — ASIL level configuration
 # =============================================================================
 
@@ -742,6 +765,102 @@ def _build_can_context(cfg: Dict[str, Any]) -> Dict[str, Any]:
         "rx_is_extended":  rx_val > CAN_ID_11BIT_MAX,
         "tx_is_extended":  tx_val > CAN_ID_11BIT_MAX,
     }
+
+
+# =============================================================================
+# SOVD CDA — context builder and renderer
+# =============================================================================
+
+def build_sovd_cda(cfg):
+    """
+    Build an OpenSOVD 1.0 CDA (Capability Description and Advertisement)
+    dict from a loaded diagnostics_config.yaml.
+
+    Serialised with json.dumps(indent=2) into generated/sovd_cda.json.
+    Building a Python dict avoids JSON escaping issues that a Jinja2
+    template would introduce for JSON output.
+    """
+    meta       = cfg["metadata"]
+    ecu_block  = cfg.get("ecu", {}) or {}
+    transport  = ecu_block.get("transport", "can").lower()
+    doip_block = ecu_block.get("doip", {}) or {}
+    is_doip    = transport in ("doip", "both")
+
+    # DID entries — use semantic session names, not internal C constants
+    did_entries = []
+    for did in cfg.get("dids", []):
+        access = did.get("access", [])
+        entry = {
+            "id":              _normalise_hex(did["id"]),
+            "name":            did["name"],
+            "dataLengthBytes": did.get("data_length", 4),
+            "access":          list(access),
+            "minSession":      did.get("min_session", "default"),
+            "readSecurityLevel":  did.get("read_security_level", 0),
+            "writeSecurityLevel": did.get("write_security_level", 0)
+                                  if "write" in access else None,
+        }
+        did_entries.append(entry)
+
+    dtc_entries = []
+    for dtc in cfg.get("dtcs", []):
+        dtc_entries.append({
+            "code":        _normalise_hex(dtc["code"]),
+            "description": dtc.get("description", ""),
+            "severity":    dtc.get("severity", "check_at_next_halt"),
+        })
+
+    routine_entries = []
+    for routine in cfg.get("routines", []):
+        support = list(routine.get("support", ["start"]))
+        routine_entries.append({
+            "id":                    _normalise_hex(routine["id"]),
+            "name":                  routine["name"],
+            "minSession":            routine.get("min_session", "extended"),
+            "securityLevel":         routine.get("security_level", 0),
+            "supportedSubFunctions": support,
+        })
+
+    cda = {
+        "sovdVersion": "1.0.0",
+        "generatedBy": "Xaloqi EDS codegen v1.6.0",
+        "generatedAt": _now_utc(),
+        "ecuIdentification": {
+            "name":    meta["ecu_name"],
+            "version": meta["version"],
+        },
+        "transportInfo": {
+            "protocol": "DoIP" if is_doip else "ISO-TP",
+        },
+        "dataIdentifiers":    did_entries,
+        "dtcs":               dtc_entries,
+        "routines":           routine_entries,
+        "diagnosticServices": SOVD_DIAGNOSTIC_SERVICES,
+    }
+
+    if is_doip:
+        cda["ecuIdentification"]["logicalAddress"] = doip_block.get(
+            "logical_address", "0xE400"
+        )
+        cda["ecuIdentification"]["sourceAddress"] = doip_block.get(
+            "source_address", "0x0E00"
+        )
+        cda["transportInfo"]["port"] = int(doip_block.get("port", 13400))
+
+    return cda
+
+
+def render_sovd_cda(cfg, output_dir):
+    """
+    Render a SOVD CDA JSON file into output_dir/sovd_cda.json.
+
+    Returns the absolute path string of the written file.
+    """
+    cda      = build_sovd_cda(cfg)
+    out_path = output_dir / "sovd_cda.json"
+    out_path.write_text(json.dumps(cda, indent=2) + "\n", encoding="utf-8")
+    print(f"  [OK]     {out_path}")
+    return str(out_path.resolve())
 
 
 def build_generated_config_context(cfg: Dict[str, Any]) -> Dict[str, Any]:
@@ -2003,6 +2122,19 @@ def main() -> None:
         ),
     )
 
+    # ── SOVD flag ────────────────────────────────────────────────────────────
+    parser.add_argument(
+        "--sovd",
+        action="store_true",
+        default=False,
+        help=(
+            "Generate an OpenSOVD 1.0 CDA JSON file (sovd_cda.json) alongside C "
+            "output.  Describes ECU diagnostic capabilities (DIDs, DTCs, routines, "
+            "transport) for Eclipse SDV tooling and OEM SOVD clients.  "
+            "Output: <out>/sovd_cda.json"
+        ),
+    )
+
     args = parser.parse_args()
 
     config_path  = Path(args.config).resolve()
@@ -2038,6 +2170,10 @@ def main() -> None:
         print(f"  GUITypes : ENABLED  → {_gui_out_dir}")
     else:
         print("  GUITypes : disabled  (pass --gui-types to enable)")
+    if args.sovd:
+        print(f"  SOVD     : ENABLED  → {output_dir / 'sovd_cda.json'}")
+    else:
+        print("  SOVD     : disabled  (pass --sovd to enable)")
     if args.dry_run:
         print("  Mode     : DRY RUN (no files will be written)")
     print()
@@ -2162,6 +2298,7 @@ def main() -> None:
         print("\n[3/5] DRY RUN — skipping standard file generation.")
         print("[4/5] DRY RUN — skipping safety wrapper generation.")
         print("[4B]  DRY RUN — skipping test generation.")
+        print("[4D]  DRY RUN — skipping SOVD CDA generation.")
         print("[5/5] DRY RUN — skipping manifest.")
         print("\nDry run complete. Config is valid.")
         return
@@ -2191,6 +2328,15 @@ def main() -> None:
               f"({routine_count} routine(s)).")
     else:
         print("[4C] No routines configured — routine_handlers skipped.")
+
+    # ── Step 4D: SOVD CDA generation (--sovd) ───────────────────────────────
+    if args.sovd:
+        print("[4D] Generating SOVD CDA (--sovd)...")
+        sovd_path = render_sovd_cda(cfg, output_dir)
+        written.append(sovd_path)
+        print(f"\n      SOVD CDA written: {output_dir / 'sovd_cda.json'}")
+    else:
+        print("[4D] SOVD CDA skipped (pass --sovd to enable).")
 
     # ── Step 4B: Test generation (Phase 4, optional) ────────────────────────
     if test_gen:


### PR DESCRIPTION
Documentation update; SOVD Bridge; FileDestinationChangesCHANGELOG.mdrepo rootNew [1.7.0] entry — SOVD CDA output + sovd-codegen CI jobREADME.mdrepo rootNew SOVD CDA feature row; CI job count 13 → 14docs/CODEGEN_ARCHITECTURE.mddocs/Pipeline diagram + template catalogue note + --sovd in CLI reference + DoIP example updated + new Section 13bdocs/llms.txtdocs/--sovd added to codegen capability line; CI job count 7 → 8