### PR TITLE
Add issue triage dispatch workflow

### DIFF
--- a/.github/workflows/triage_dispatch.yml
+++ b/.github/workflows/triage_dispatch.yml
@@ -1,0 +1,24 @@
+# .github/workflows/triage_dispatch.yml
+# Fires a repository_dispatch to Xaloqi/automation when a new issue is opened.
+# The automation repo runs the triage agent and posts the label/response.
+
+name: "Trigger — Issue Triage"
+
+on:
+  issues:
+    types: [opened, reopened]
+
+jobs:
+  dispatch:
+    name: "Dispatch to triage agent"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger triage agent
+        run: |
+          curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.DISPATCH_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/Xaloqi/automation/dispatches \
+            -d "{\"event_type\":\"github-issue\",\"client_payload\":{\"repo\":\"${{ github.repository }}\",\"issue\":$(echo '${{ toJson(github.event.issue) }}' | tr -d '\n')}}"


### PR DESCRIPTION
## Summary
- Adds triage_dispatch.yml — fires repository_dispatch to Xaloqi/automation when a new issue is opened, triggering the triage agent to classify and respond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)