### PR TITLE
feat(isotp): CAN FD SF/FF escape sequences (ISO 15765-2 §9.8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
 
   # ── Job 1: Host unit tests ─────────────────────────────────────────────────
   unit-tests:
-    name: "Unit Tests (36 modules)"
+    name: "Unit Tests (37 modules)"
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,59 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
+## [1.7.1] — CAN FD ISO-TP support (ISO 15765-2 §9.8)
+
+### Added — CAN FD extensions to ISO-TP layer
+
+Four missing CAN FD paths from ISO 15765-2 §9.8, implemented in the GPL runtime.
+All paths are gated behind `isotp_cfg_t.use_fd = true` — existing Classic CAN
+configurations are unaffected (zero-initialised struct keeps `use_fd = false`).
+
+**API change**: `isotp_rx_complete_cb` length parameter and `isotp_transmit` length
+parameter widened from `uint16_t` to `uint32_t` for consistency with FD escape
+sequence ff_dl (32-bit). Internal state fields `rx_expected_len`, `rx_received_len`,
+`tx_total_len`, `tx_sent_len` also widened to `uint32_t`.
+
+| Gap | Frame type | Spec reference | Status |
+|-----|------------|----------------|--------|
+| SF RX escape  | `frame->is_fd && data[0]==0x00` → read `data[1]` as SF_DL (1–62 bytes) | §9.8.2 | Fixed |
+| FF RX escape  | `ff_dl==0` on FD frame → parse bytes 2–5 as 32-bit big-endian FF_DL | §9.8.3 | Fixed |
+| SF TX escape  | `use_fd && length ≤ 62` → emit `data[0]=0x00, data[1]=length, is_fd=true` | §9.8.2 | Fixed |
+| FF TX escape  | `use_fd && length > 4095` → emit `data[0..1]=0x10 0x00`, bytes 2–5 = 32-bit FF_DL | §9.8.3 | Fixed |
+
+New constants in `transport/isotp.h`:
+- `ISOTP_FD_SF_MAX_PAYLOAD_LEN (62U)` — max SF payload on CAN FD
+- `ISOTP_RX_BUF_LEN` — overridable compile-time RX buffer size (default: `UDS_MAX_PAYLOAD_LEN`)
+
+Added `bool use_fd` to both `isotp_cfg_t` and `isotp_ctx_t`. The Zephyr and FreeRTOS
+platform HAL bindings still target Classic CAN only; users enabling `use_fd=true`
+must supply a CAN FD-capable platform binding (tracked as a follow-up).
+
+### Added — 8 CAN FD unit tests
+
+New `ZTEST_SUITE(test_isotp_canfd)` in `tests/unit_runnable/test_isotp.c`:
+
+| Test | What it covers |
+|------|---------------|
+| `test_fd_sf_rx_10_bytes` | FD SF 10-byte payload RX |
+| `test_fd_sf_rx_62_bytes` | FD SF max 62-byte payload RX |
+| `test_fd_sf_rx_zero_dl` | SF_DL=0 → `UDS_STATUS_ERR_TP_FRAME_INVALID` |
+| `test_fd_sf_tx_10_bytes` | FD SF TX: byte 0=0x00, byte 1=10, `is_fd=true` |
+| `test_fd_ff_escape_rx_fits` | FF escape RX (ff_dl=100): RX_WAIT_CF + FC CTS sent |
+| `test_fd_ff_escape_rx_overflow` | FF escape RX (ff_dl=5000 > buffer) → FC OVFLW |
+| `test_fd_ff_escape_classic_can_rejected` | FF_DL=0 on Classic CAN → FRAME_INVALID |
+| `test_fd_ff_escape_tx` | FF escape TX (ff_dl=5000): bytes 0–5 encoding verified |
+
+### Changed — example callbacks
+
+All 7 example `on_isotp_rx_complete` callbacks updated:
+`uint16_t length` → `uint32_t length`; overflow guard updated from `(uint16_t)` to
+`(uint32_t)UDS_MAX_PAYLOAD_LEN`. Affects `basic_ecu`, `bms_ecu`, `sensor_ecu`,
+`sensor_ecu_freertos`, `ardep_ecu`, `robot_joint_controller_ecu`, `safeboot_ecu`.
+
+Reported in: https://github.com/Xaloqi/EDS/issues/14
+
+---
 ## [1.7.0] — Robustness Campaign + SOVD Bridge
 
 ### Fixed — Protocol compliance: suppress-response bit (ISO 14229-1 §7.5.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ sequence ff_dl (32-bit). Internal state fields `rx_expected_len`, `rx_received_l
 | FF TX escape  | `use_fd && length > 4095` → emit `data[0..1]=0x10 0x00`, bytes 2–5 = 32-bit FF_DL | §9.8.3 | Fixed |
 
 New constants in `transport/isotp.h`:
-- `ISOTP_FD_SF_MAX_PAYLOAD_LEN (62U)` — max SF payload on CAN FD
+- `ISOTP_ENABLE_CAN_FD (0)` — compile-time opt-in; set to 1 to enable FD paths. Default 0: Classic CAN only, no FD code in the binary.
+- `ISOTP_FD_SF_MAX_PAYLOAD_LEN (62U)` — max SF payload on CAN FD (only defined when `ISOTP_ENABLE_CAN_FD=1`)
 - `ISOTP_RX_BUF_LEN` — overridable compile-time RX buffer size (default: `UDS_MAX_PAYLOAD_LEN`)
 
 Added `bool use_fd` to both `isotp_cfg_t` and `isotp_ctx_t`. The Zephyr and FreeRTOS

--- a/build_tests.sh
+++ b/build_tests.sh
@@ -90,6 +90,9 @@ CFLAGS=(
     # Activate test-only hooks
     "-DUNIT_TEST=1"
     "-DNVM_STORE_HOST_MOCK=1"
+    # Enable CAN FD ISO-TP paths so the test_isotp_canfd suite runs.
+    # Production integrators set this flag themselves when FD is needed.
+    "-DISOTP_ENABLE_CAN_FD=1"
     # Zephyr shim: replaces <zephyr/kernel.h> includes with no-ops
     "-DZTEST_HOST_SHIM=1"
     # Suppress the uds_msg_buf_t stack-size _Static_assert on the host build.

--- a/examples/ardep_ecu/src/main.c
+++ b/examples/ardep_ecu/src/main.c
@@ -643,7 +643,7 @@ static int diag_security_algo_init(void)
 
 static void on_isotp_rx_complete(
     const uint8_t *data,
-    uint16_t       length,
+    uint32_t       length,
     void          *arg)
 {
     uds_server_ctx_t *srv = (uds_server_ctx_t *)arg;
@@ -652,10 +652,10 @@ static void on_isotp_rx_complete(
     uint16_t          i;
 
     if ((data == NULL) || (srv == NULL) || (tp == NULL)) { return; }
-    if ((length == 0U) || (length > (uint16_t)UDS_MAX_PAYLOAD_LEN)) { return; }
+    if ((length == 0U) || (length > (uint32_t)UDS_MAX_PAYLOAD_LEN)) { return; }
 
-    for (i = 0U; i < length; i++) { s_req_buf.data[i] = data[i]; }
-    s_req_buf.length  = length;
+    for (i = 0U; i < (uint16_t)length; i++) { s_req_buf.data[i] = data[i]; }
+    s_req_buf.length  = (uint16_t)length;
     s_resp_buf.length = 0U;
 
     LOG_DBG("UDS RX: SID=0x%02X len=%u", (unsigned)data[0], (unsigned)length);

--- a/examples/basic_ecu/src/main.c
+++ b/examples/basic_ecu/src/main.c
@@ -111,7 +111,7 @@ static diag_wdt_t   s_wdt;
 
 static void on_isotp_rx_complete(
     const uint8_t *data,
-    uint16_t       length,
+    uint32_t       length,
     void          *arg)
 {
     uds_server_ctx_t *srv = (uds_server_ctx_t *)arg;
@@ -124,14 +124,14 @@ static void on_isotp_rx_complete(
     uint16_t i;
 
     if ((data == NULL) || (srv == NULL) || (tp == NULL)) { return; }
-    if ((length == 0U) || (length > (uint16_t)UDS_MAX_PAYLOAD_LEN)) { return; }
+    if ((length == 0U) || (length > (uint32_t)UDS_MAX_PAYLOAD_LEN)) { return; }
 
     (void)diag_mutex_lock(&s_session_lock);
 
-    for (i = 0U; i < length; i++) {
+    for (i = 0U; i < (uint16_t)length; i++) {
         s_req.data[i] = data[i];
     }
-    s_req.length  = length;
+    s_req.length  = (uint16_t)length;
     s_resp.length = 0U;
 
     (void)uds_server_process_request(srv, &s_req, &s_resp);

--- a/examples/bms_ecu/src/main.c
+++ b/examples/bms_ecu/src/main.c
@@ -790,7 +790,7 @@ static int diag_security_algo_init(void)
  */
 static void on_isotp_rx_complete(
     const uint8_t *data,
-    uint16_t       length,
+    uint32_t       length,
     void          *arg)
 {
     uds_server_ctx_t *srv    = (uds_server_ctx_t *)arg;
@@ -803,16 +803,16 @@ static void on_isotp_rx_complete(
         return;
     }
 
-    if ((length == (uint16_t)0U) || (length > (uint16_t)UDS_MAX_PAYLOAD_LEN)) {
+    if ((length == (uint32_t)0U) || (length > (uint32_t)UDS_MAX_PAYLOAD_LEN)) {
         LOG_WRN("[BMS] on_isotp_rx_complete: invalid length %u — PDU dropped.",
                 (unsigned)length);
         return;
     }
 
-    for (i = (uint16_t)0U; i < length; i++) {
+    for (i = (uint16_t)0U; i < (uint16_t)length; i++) {
         s_req_buf.data[i] = data[i];
     }
-    s_req_buf.length  = length;
+    s_req_buf.length  = (uint16_t)length;
     s_resp_buf.length = (uint16_t)0U;
 
     LOG_DBG("[BMS] UDS RX: SID=0x%02X len=%u",

--- a/examples/robot_joint_controller_ecu/src/main.c
+++ b/examples/robot_joint_controller_ecu/src/main.c
@@ -134,7 +134,7 @@ static void security_init(void)
  * ISO-TP RX completion callback
  * ---------------------------------------------------------------------------*/
 
-static void on_isotp_rx_complete(const uint8_t *data, uint16_t length, void *arg)
+static void on_isotp_rx_complete(const uint8_t *data, uint32_t length, void *arg)
 {
     uds_server_ctx_t *srv = (uds_server_ctx_t *)arg;
     isotp_ctx_t      *tp  = uds_generated_get_isotp();
@@ -142,10 +142,10 @@ static void on_isotp_rx_complete(const uint8_t *data, uint16_t length, void *arg
     uint16_t          i;
 
     if ((data == NULL) || (srv == NULL) || (tp == NULL)) { return; }
-    if ((length == 0U) || (length > (uint16_t)UDS_MAX_PAYLOAD_LEN)) { return; }
+    if ((length == 0U) || (length > (uint32_t)UDS_MAX_PAYLOAD_LEN)) { return; }
 
-    for (i = 0U; i < length; i++) { s_req_buf.data[i] = data[i]; }
-    s_req_buf.length  = length;
+    for (i = 0U; i < (uint16_t)length; i++) { s_req_buf.data[i] = data[i]; }
+    s_req_buf.length  = (uint16_t)length;
     s_resp_buf.length = 0U;
 
     (void)diag_mutex_lock(&s_session_lock);

--- a/examples/safeboot_ecu/src/main.c
+++ b/examples/safeboot_ecu/src/main.c
@@ -265,7 +265,7 @@ static int diag_security_algo_init(void)
  * ============================================================================= */
 static void on_isotp_rx_complete(
     const uint8_t *data,
-    uint16_t       length,
+    uint32_t       length,
     void          *arg)
 {
     uds_server_ctx_t *srv = (uds_server_ctx_t *)arg;
@@ -278,17 +278,17 @@ static void on_isotp_rx_complete(
         return;
     }
 
-    if ((length == (uint16_t)0U) || (length > (uint16_t)UDS_MAX_PAYLOAD_LEN)) {
+    if ((length == (uint32_t)0U) || (length > (uint32_t)UDS_MAX_PAYLOAD_LEN)) {
         LOG_WRN("on_isotp_rx_complete: invalid length %u — PDU dropped.",
                 (unsigned)length);
         return;
     }
 
     /* Copy PDU into static request buffer. */
-    for (i = (uint16_t)0U; i < length; i++) {
+    for (i = (uint16_t)0U; i < (uint16_t)length; i++) {
         s_req_buf.data[i] = data[i];
     }
-    s_req_buf.length = length;
+    s_req_buf.length = (uint16_t)length;
     s_resp_buf.length = (uint16_t)0U;
 
     LOG_DBG("UDS RX: SID=0x%02X len=%u", (unsigned)data[0], (unsigned)length);

--- a/examples/sensor_ecu/src/main.c
+++ b/examples/sensor_ecu/src/main.c
@@ -130,7 +130,7 @@ static int diag_security_algo_init(void)
  * ISO-TP RX completion callback
  * ---------------------------------------------------------------------------*/
 
-static void on_isotp_rx_complete(const uint8_t *data, uint16_t length, void *arg)
+static void on_isotp_rx_complete(const uint8_t *data, uint32_t length, void *arg)
 {
     uds_server_ctx_t *srv = (uds_server_ctx_t *)arg;
     isotp_ctx_t      *tp  = uds_generated_get_isotp();
@@ -140,14 +140,14 @@ static void on_isotp_rx_complete(const uint8_t *data, uint16_t length, void *arg
     if ((data == NULL) || (srv == NULL) || (tp == NULL)) {
         return;
     }
-    if ((length == 0U) || (length > (uint16_t)UDS_MAX_PAYLOAD_LEN)) {
+    if ((length == 0U) || (length > (uint32_t)UDS_MAX_PAYLOAD_LEN)) {
         return;
     }
 
-    for (i = 0U; i < length; i++) {
+    for (i = 0U; i < (uint16_t)length; i++) {
         s_req_buf.data[i] = data[i];
     }
-    s_req_buf.length  = length;
+    s_req_buf.length  = (uint16_t)length;
     s_resp_buf.length = 0U;
 
     (void)diag_mutex_lock(&s_session_lock);

--- a/examples/sensor_ecu_freertos/src/main.c
+++ b/examples/sensor_ecu_freertos/src/main.c
@@ -100,7 +100,7 @@ static uds_msg_buf_t s_resp_buf;
 
 static void on_isotp_rx_complete(
     const uint8_t *data,
-    uint16_t       length,
+    uint32_t       length,
     void          *arg)
 {
     uds_server_ctx_t *srv = (uds_server_ctx_t *)arg;
@@ -109,12 +109,12 @@ static void on_isotp_rx_complete(
     uint16_t          i;
 
     if ((data == NULL) || (srv == NULL) || (tp == NULL)) { return; }
-    if ((length == (uint16_t)0U) || (length > (uint16_t)UDS_MAX_PAYLOAD_LEN)) { return; }
+    if ((length == (uint32_t)0U) || (length > (uint32_t)UDS_MAX_PAYLOAD_LEN)) { return; }
 
-    for (i = 0U; i < length; i++) {
+    for (i = 0U; i < (uint16_t)length; i++) {
         s_req_buf.data[i] = data[i];
     }
-    s_req_buf.length  = length;
+    s_req_buf.length  = (uint16_t)length;
     s_resp_buf.length = (uint16_t)0U;
 
     status = uds_server_process_request(srv, &s_req_buf, &s_resp_buf);

--- a/tests/unit_runnable/test_isotp.c
+++ b/tests/unit_runnable/test_isotp.c
@@ -87,16 +87,16 @@ static can_transport_t g_mock_can = {
 
 /* RX callback state */
 static uint8_t  g_rx_cb_data[UDS_MAX_PAYLOAD_LEN];
-static uint16_t g_rx_cb_len;
+static uint32_t g_rx_cb_len;
 static bool     g_rx_cb_called;
 
-static void rx_complete_cb(const uint8_t *data, uint16_t length, void *arg)
+static void rx_complete_cb(const uint8_t *data, uint32_t length, void *arg)
 {
     (void)arg;
     g_rx_cb_called = true;
     g_rx_cb_len    = length;
-    if (length <= UDS_MAX_PAYLOAD_LEN) {
-        memcpy(g_rx_cb_data, data, length);
+    if (length <= (uint32_t)UDS_MAX_PAYLOAD_LEN) {
+        memcpy(g_rx_cb_data, data, (size_t)length);
     }
 }
 
@@ -118,7 +118,7 @@ static void rx_cb_reset(void)
     g_rx_cb_called = false;
 }
 
-/** Build a Zephyr-side CAN frame (helper). */
+/** Build a Classic CAN frame (helper). */
 static uds_can_frame_t make_can_frame(uint32_t id, const uint8_t *data, uint8_t dlc)
 {
     uds_can_frame_t f;
@@ -131,7 +131,15 @@ static uds_can_frame_t make_can_frame(uint32_t id, const uint8_t *data, uint8_t 
     return f;
 }
 
-/** Initialise a fresh isotp_ctx_t with the mock CAN transport. */
+/** Build a CAN FD frame (helper). */
+static uds_can_frame_t make_fd_frame(uint32_t id, const uint8_t *data, uint8_t dlc)
+{
+    uds_can_frame_t f = make_can_frame(id, data, dlc);
+    f.is_fd = true;
+    return f;
+}
+
+/** Initialise a fresh isotp_ctx_t with the mock CAN transport (Classic CAN). */
 static uds_status_t init_isotp(isotp_ctx_t *ctx)
 {
     isotp_cfg_t cfg;
@@ -140,6 +148,21 @@ static uds_status_t init_isotp(isotp_ctx_t *ctx)
     cfg.tx_can_id   = 0x7E8U;
     cfg.block_size  = 0U;
     cfg.stmin_ms    = 0U;
+    cfg.use_fd      = false;
+    cfg.can         = &g_mock_can;
+    return isotp_init(ctx, &cfg);
+}
+
+/** Initialise a fresh isotp_ctx_t in CAN FD mode. */
+static uds_status_t init_isotp_fd(isotp_ctx_t *ctx)
+{
+    isotp_cfg_t cfg;
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.rx_can_id   = 0x7DFU;
+    cfg.tx_can_id   = 0x7E8U;
+    cfg.block_size  = 0U;
+    cfg.stmin_ms    = 0U;
+    cfg.use_fd      = true;
     cfg.can         = &g_mock_can;
     return isotp_init(ctx, &cfg);
 }
@@ -423,8 +446,11 @@ ZTEST(test_isotp_rx_multi, test_cf_without_ff)
 }
 
 /**
- * TC-ISTP-RX-MF-004: FF payload length exceeds UDS_MAX_PAYLOAD_LEN
- *                     → UDS_STATUS_ERR_TP_OVERFLOW.
+ * TC-ISTP-RX-MF-004: CAN FD FF escape sequence with FF_DL > ISOTP_RX_BUF_LEN
+ *                     → UDS_STATUS_ERR_TP_OVERFLOW + FC OVFLW transmitted.
+ *
+ * Sends an FD FF with 32-bit FF_DL = 5000 (> 4095 = ISOTP_RX_BUF_LEN).
+ * Bytes 0-1 = 0x10 0x00 (escape); bytes 2-5 = big-endian 5000 = 0x00001388.
  */
 ZTEST(test_isotp_rx_multi, test_ff_overflow)
 {
@@ -432,16 +458,243 @@ ZTEST(test_isotp_rx_multi, test_ff_overflow)
     rx_cb_reset();
     isotp_ctx_t ctx;
     memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp_fd(&ctx), UDS_STATUS_OK, "init failed");
+
+    uint8_t ff_payload[] = {
+        0x10U, 0x00U,               /* FF type, escape sequence trigger */
+        0x00U, 0x00U, 0x13U, 0x88U, /* FF_DL = 5000 (big-endian) */
+        0x01U, 0x02U, 0x03U, 0x04U, 0x05U, 0x06U  /* first data bytes */
+    };
+    uds_can_frame_t ff = make_fd_frame(0x7DFU, ff_payload, 12U);
+    uds_status_t rc = isotp_process_rx_frame(&ctx, &ff, rx_complete_cb, NULL);
+    zassert_equal(rc, UDS_STATUS_ERR_TP_OVERFLOW,
+                  "FD FF with FF_DL > ISOTP_RX_BUF_LEN must send OVFLW and fail");
+    /* FC OVFLW must have been transmitted */
+    zassert_true(g_mock_tx_count >= 1U, "FC OVFLW frame must be sent");
+    zassert_equal((g_mock_tx_frames[0].data[0] >> 4U), (uint8_t)ISOTP_FRAME_TYPE_FC,
+                  "Transmitted frame must be FC type");
+    zassert_equal((g_mock_tx_frames[0].data[0] & 0x0FU), (uint8_t)ISOTP_FC_STATUS_OVERFLOW,
+                  "FC status must be OVERFLOW");
+}
+
+/* =========================================================================
+ * Test suite: CAN FD SF and FF (ISO 15765-2 §9.8)
+ * ========================================================================= */
+
+ZTEST_SUITE(test_isotp_canfd, NULL, NULL, NULL, NULL, NULL);
+
+/**
+ * TC-ISTP-FD-001: CAN FD SF receive — 10-byte payload.
+ * FD SF encoding: byte 0 = 0x00, byte 1 = SF_DL (10), data at [2..11].
+ */
+ZTEST(test_isotp_canfd, test_fd_sf_rx_10_bytes)
+{
+    mock_can_reset();
+    rx_cb_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp_fd(&ctx), UDS_STATUS_OK, "init failed");
+
+    uint8_t payload[12] = {
+        0x00U, 0x0AU,                                       /* FD SF PCI: SF_DL = 10 */
+        0x01U, 0x02U, 0x03U, 0x04U, 0x05U,
+        0x06U, 0x07U, 0x08U, 0x09U, 0x0AU                  /* 10 data bytes */
+    };
+    uds_can_frame_t f = make_fd_frame(0x7DFU, payload, 12U);
+
+    uds_status_t rc = isotp_process_rx_frame(&ctx, &f, rx_complete_cb, NULL);
+    zassert_equal(rc, UDS_STATUS_OK, "FD SF RX must succeed");
+    zassert_true(g_rx_cb_called, "Callback must fire");
+    zassert_equal(g_rx_cb_len, 10U, "Length must be 10");
+    zassert_equal(g_rx_cb_data[0], 0x01U, "data[0] mismatch");
+    zassert_equal(g_rx_cb_data[9], 0x0AU, "data[9] mismatch");
+}
+
+/**
+ * TC-ISTP-FD-002: CAN FD SF receive — maximum 62-byte payload.
+ */
+ZTEST(test_isotp_canfd, test_fd_sf_rx_62_bytes)
+{
+    mock_can_reset();
+    rx_cb_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp_fd(&ctx), UDS_STATUS_OK, "init failed");
+
+    uint8_t payload[64];
+    memset(payload, 0, sizeof(payload));
+    payload[0] = 0x00U;  /* FD SF escape */
+    payload[1] = 0x3EU;  /* SF_DL = 62 */
+    memset(&payload[2], 0xAAU, 62U);
+
+    uds_can_frame_t f = make_fd_frame(0x7DFU, payload, 64U);
+    uds_status_t rc = isotp_process_rx_frame(&ctx, &f, rx_complete_cb, NULL);
+    zassert_equal(rc, UDS_STATUS_OK, "FD SF 62-byte RX must succeed");
+    zassert_true(g_rx_cb_called, "Callback must fire");
+    zassert_equal(g_rx_cb_len, 62U, "Length must be 62");
+    zassert_equal(g_rx_cb_data[0],  0xAAU, "data[0] mismatch");
+    zassert_equal(g_rx_cb_data[61], 0xAAU, "data[61] mismatch");
+}
+
+/**
+ * TC-ISTP-FD-003: CAN FD SF receive — SF_DL = 0 on FD frame → FRAME_INVALID.
+ * byte 0 = 0x00, byte 1 = 0x00 → SF_DL zero is invalid.
+ */
+ZTEST(test_isotp_canfd, test_fd_sf_rx_zero_dl)
+{
+    mock_can_reset();
+    rx_cb_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp_fd(&ctx), UDS_STATUS_OK, "init failed");
+
+    uint8_t payload[12] = { 0x00U, 0x00U };
+    uds_can_frame_t f = make_fd_frame(0x7DFU, payload, 12U);
+    uds_status_t rc = isotp_process_rx_frame(&ctx, &f, rx_complete_cb, NULL);
+    zassert_equal(rc, UDS_STATUS_ERR_TP_FRAME_INVALID,
+                  "FD SF with SF_DL=0 must be rejected");
+    zassert_false(g_rx_cb_called, "Callback must not fire");
+}
+
+/**
+ * TC-ISTP-FD-004: CAN FD SF transmit — 10-byte payload.
+ * Verifies FD SF encoding: byte 0 = 0x00, byte 1 = 10.
+ */
+ZTEST(test_isotp_canfd, test_fd_sf_tx_10_bytes)
+{
+    mock_can_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp_fd(&ctx), UDS_STATUS_OK, "init failed");
+
+    uint8_t data[10];
+    memset(data, 0xBBU, sizeof(data));
+
+    uds_status_t rc = isotp_transmit(&ctx, data, 10U);
+    zassert_equal(rc, UDS_STATUS_OK, "FD SF TX must succeed");
+    zassert_equal(g_mock_tx_count, 1U, "Exactly one CAN frame must be sent");
+    zassert_true(g_mock_tx_frames[0].is_fd, "Transmitted frame must be CAN FD");
+    zassert_equal(g_mock_tx_frames[0].data[0], 0x00U, "FD SF byte 0 must be 0x00");
+    zassert_equal(g_mock_tx_frames[0].data[1], 10U,   "FD SF byte 1 must be SF_DL=10");
+    zassert_equal(g_mock_tx_frames[0].data[2], 0xBBU, "First data byte mismatch");
+
+    isotp_state_t state;
+    isotp_get_state(&ctx, &state);
+    zassert_equal(state, ISOTP_STATE_IDLE, "State must return to IDLE after FD SF TX");
+}
+
+/**
+ * TC-ISTP-FD-005: CAN FD FF escape sequence receive — FF_DL = 5000 bytes
+ *                  within ISOTP_RX_BUF_LEN → not possible without expanding
+ *                  the buffer; test that FF_DL = 100 (fits) works.
+ *
+ * Sends an FD FF with escape sequence: bytes 0-1 = 0x10 0x00,
+ * bytes 2-5 = 0x00000064 (100 decimal), then 10 first data bytes.
+ */
+ZTEST(test_isotp_canfd, test_fd_ff_escape_rx_fits)
+{
+    mock_can_reset();
+    rx_cb_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp_fd(&ctx), UDS_STATUS_OK, "init failed");
+
+    uint8_t ff_payload[16] = {
+        0x10U, 0x00U,               /* FD FF escape */
+        0x00U, 0x00U, 0x00U, 0x64U, /* FF_DL = 100 */
+        0x01U, 0x02U, 0x03U, 0x04U, 0x05U, 0x06U, 0x07U, 0x08U, 0x09U, 0x0AU
+    };
+    uds_can_frame_t ff = make_fd_frame(0x7DFU, ff_payload, 16U);
+    uds_status_t rc = isotp_process_rx_frame(&ctx, &ff, rx_complete_cb, NULL);
+    zassert_equal(rc, UDS_STATUS_OK, "FD FF escape RX must be accepted");
+    zassert_false(g_rx_cb_called, "Callback must NOT fire after FF alone");
+
+    isotp_state_t state;
+    isotp_get_state(&ctx, &state);
+    zassert_equal(state, ISOTP_STATE_RX_WAIT_CF, "Must be in RX_WAIT_CF");
+    /* FC CTS must have been sent */
+    zassert_true(g_mock_tx_count >= 1U, "FC CTS must be transmitted");
+    zassert_equal((g_mock_tx_frames[0].data[0] >> 4U), (uint8_t)ISOTP_FRAME_TYPE_FC,
+                  "Transmitted frame must be FC type");
+    zassert_equal((g_mock_tx_frames[0].data[0] & 0x0FU),
+                  (uint8_t)ISOTP_FC_STATUS_CONTINUE_TO_SEND,
+                  "FC status must be CTS");
+}
+
+/**
+ * TC-ISTP-FD-006: CAN FD FF escape — FF_DL > ISOTP_RX_BUF_LEN → FC OVFLW.
+ * Duplicate of test_ff_overflow but via the FD-specific suite for clarity.
+ */
+ZTEST(test_isotp_canfd, test_fd_ff_escape_rx_overflow)
+{
+    mock_can_reset();
+    rx_cb_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp_fd(&ctx), UDS_STATUS_OK, "init failed");
+
+    uint8_t ff_payload[] = {
+        0x10U, 0x00U,
+        0x00U, 0x00U, 0x13U, 0x88U,  /* FF_DL = 5000 > 4095 */
+        0x01U, 0x02U
+    };
+    uds_can_frame_t ff = make_fd_frame(0x7DFU, ff_payload, 8U);
+    uds_status_t rc = isotp_process_rx_frame(&ctx, &ff, rx_complete_cb, NULL);
+    zassert_equal(rc, UDS_STATUS_ERR_TP_OVERFLOW, "Must overflow when FF_DL > buf");
+}
+
+/**
+ * TC-ISTP-FD-007: CAN FD FF escape on Classic CAN frame → FRAME_INVALID.
+ * FF_DL == 0 on a non-FD frame must be rejected.
+ */
+ZTEST(test_isotp_canfd, test_fd_ff_escape_classic_can_rejected)
+{
+    mock_can_reset();
+    rx_cb_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
     zassert_equal(init_isotp(&ctx), UDS_STATUS_OK, "init failed");
 
-    /* FF with total_len encoded as > 4095: use 0x1F, 0xFF = 4095+1 = impossible
-     * but > 4095 encoded as 0x10 hi, 0x00 is 4096 — use max+1 */
-    /* ISO-TP 12-bit length: max = 0xFFF = 4095. Set 0x1F 0xFF = 8191 */
-    uint8_t ff_payload[] = { 0x1FU, 0xFFU, 0x01U, 0x02U, 0x03U, 0x04U, 0x05U, 0x06U };
-    uds_can_frame_t ff = make_can_frame(0x7DFU, ff_payload, 8U);
-    uds_status_t rc = isotp_process_rx_frame(&ctx, &ff, rx_complete_cb, NULL);
-    zassert_equal(UDS_STATUS_ERR_TP_OVERFLOW, rc,
-                  "FF with len > UDS_MAX_PAYLOAD_LEN must be rejected");
+    /* Classic CAN frame with byte 0 = 0x10, byte 1 = 0x00 → escape not valid */
+    uint8_t payload[] = { 0x10U, 0x00U, 0x00U, 0x00U, 0x00U, 0x64U, 0x01U, 0x02U };
+    uds_can_frame_t f = make_can_frame(0x7DFU, payload, 8U);
+    uds_status_t rc = isotp_process_rx_frame(&ctx, &f, rx_complete_cb, NULL);
+    zassert_equal(rc, UDS_STATUS_ERR_TP_FRAME_INVALID,
+                  "FF_DL=0 on Classic CAN must be FRAME_INVALID");
+}
+
+/**
+ * TC-ISTP-FD-008: CAN FD FF escape TX — length > UDS_MAX_PAYLOAD_LEN (4095).
+ * Verifies escape encoding: byte 0 = 0x10, byte 1 = 0x00, bytes 2-5 = length.
+ */
+ZTEST(test_isotp_canfd, test_fd_ff_escape_tx)
+{
+    mock_can_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp_fd(&ctx), UDS_STATUS_OK, "init failed");
+
+    static uint8_t s_large_data[5000];
+    memset(s_large_data, 0xCCU, sizeof(s_large_data));
+
+    uds_status_t rc = isotp_transmit(&ctx, s_large_data, 5000U);
+    zassert_equal(rc, UDS_STATUS_OK, "FD FF escape TX must succeed");
+    zassert_true(g_mock_tx_count >= 1U, "FF must be transmitted");
+
+    /* Verify escape encoding */
+    zassert_true(g_mock_tx_frames[0].is_fd, "FF must be a CAN FD frame");
+    zassert_equal(g_mock_tx_frames[0].data[0], 0x10U, "FF byte 0 must be 0x10");
+    zassert_equal(g_mock_tx_frames[0].data[1], 0x00U, "FF byte 1 must be 0x00");
+    /* 5000 = 0x00001388 */
+    zassert_equal(g_mock_tx_frames[0].data[2], 0x00U, "FF_DL byte 2 mismatch");
+    zassert_equal(g_mock_tx_frames[0].data[3], 0x00U, "FF_DL byte 3 mismatch");
+    zassert_equal(g_mock_tx_frames[0].data[4], 0x13U, "FF_DL byte 4 mismatch");
+    zassert_equal(g_mock_tx_frames[0].data[5], 0x88U, "FF_DL byte 5 mismatch");
+
+    isotp_state_t state;
+    isotp_get_state(&ctx, &state);
+    zassert_equal(state, ISOTP_STATE_TX_WAIT_FC,
+                  "State must be TX_WAIT_FC after FD FF escape TX");
 }
 
 /* =========================================================================
@@ -488,7 +741,8 @@ ZTEST(test_isotp_transmit, test_zero_length)
 }
 
 /**
- * TC-ISTP-TX-004: Length > UDS_MAX_PAYLOAD_LEN → UDS_STATUS_ERR_BUFFER_OVERFLOW.
+ * TC-ISTP-TX-004: Classic CAN, length > UDS_MAX_PAYLOAD_LEN →
+ *                 UDS_STATUS_ERR_BUFFER_OVERFLOW.
  */
 ZTEST(test_isotp_transmit, test_overflow_length)
 {
@@ -497,8 +751,8 @@ ZTEST(test_isotp_transmit, test_overflow_length)
     memset(&ctx, 0, sizeof(ctx));
     zassert_equal(init_isotp(&ctx), UDS_STATUS_OK, "init failed");
     uint8_t data[8] = { 0 };
-    uds_status_t rc = isotp_transmit(&ctx, data, (uint16_t)(UDS_MAX_PAYLOAD_LEN + 1U));
-    zassert_equal(rc, UDS_STATUS_ERR_BUFFER_OVERFLOW, "Overflow length must fail");
+    uds_status_t rc = isotp_transmit(&ctx, data, (uint32_t)(UDS_MAX_PAYLOAD_LEN + 1U));
+    zassert_equal(rc, UDS_STATUS_ERR_BUFFER_OVERFLOW, "Classic CAN overflow must fail");
 }
 
 /**
@@ -741,6 +995,14 @@ extern void test_isotp_rx_multi__test_first_frame_triggers_fc(void);
 extern void test_isotp_rx_multi__test_ff_cf_complete(void);
 extern void test_isotp_rx_multi__test_cf_without_ff(void);
 extern void test_isotp_rx_multi__test_ff_overflow(void);
+extern void test_isotp_canfd__test_fd_sf_rx_10_bytes(void);
+extern void test_isotp_canfd__test_fd_sf_rx_62_bytes(void);
+extern void test_isotp_canfd__test_fd_sf_rx_zero_dl(void);
+extern void test_isotp_canfd__test_fd_sf_tx_10_bytes(void);
+extern void test_isotp_canfd__test_fd_ff_escape_rx_fits(void);
+extern void test_isotp_canfd__test_fd_ff_escape_rx_overflow(void);
+extern void test_isotp_canfd__test_fd_ff_escape_classic_can_rejected(void);
+extern void test_isotp_canfd__test_fd_ff_escape_tx(void);
 extern void test_isotp_transmit__test_null_ctx(void);
 extern void test_isotp_transmit__test_null_data(void);
 extern void test_isotp_transmit__test_zero_length(void);
@@ -772,6 +1034,14 @@ void run_all_tests(void)
     RUN_TEST(test_isotp_rx_multi__test_ff_cf_complete);
     RUN_TEST(test_isotp_rx_multi__test_cf_without_ff);
     RUN_TEST(test_isotp_rx_multi__test_ff_overflow);
+    RUN_TEST(test_isotp_canfd__test_fd_sf_rx_10_bytes);
+    RUN_TEST(test_isotp_canfd__test_fd_sf_rx_62_bytes);
+    RUN_TEST(test_isotp_canfd__test_fd_sf_rx_zero_dl);
+    RUN_TEST(test_isotp_canfd__test_fd_sf_tx_10_bytes);
+    RUN_TEST(test_isotp_canfd__test_fd_ff_escape_rx_fits);
+    RUN_TEST(test_isotp_canfd__test_fd_ff_escape_rx_overflow);
+    RUN_TEST(test_isotp_canfd__test_fd_ff_escape_classic_can_rejected);
+    RUN_TEST(test_isotp_canfd__test_fd_ff_escape_tx);
     RUN_TEST(test_isotp_transmit__test_null_ctx);
     RUN_TEST(test_isotp_transmit__test_null_data);
     RUN_TEST(test_isotp_transmit__test_zero_length);

--- a/tests/unit_runnable/test_isotp.c
+++ b/tests/unit_runnable/test_isotp.c
@@ -131,6 +131,7 @@ static uds_can_frame_t make_can_frame(uint32_t id, const uint8_t *data, uint8_t 
     return f;
 }
 
+#if ISOTP_ENABLE_CAN_FD
 /** Build a CAN FD frame (helper). */
 static uds_can_frame_t make_fd_frame(uint32_t id, const uint8_t *data, uint8_t dlc)
 {
@@ -138,6 +139,7 @@ static uds_can_frame_t make_fd_frame(uint32_t id, const uint8_t *data, uint8_t d
     f.is_fd = true;
     return f;
 }
+#endif /* ISOTP_ENABLE_CAN_FD */
 
 /** Initialise a fresh isotp_ctx_t with the mock CAN transport (Classic CAN). */
 static uds_status_t init_isotp(isotp_ctx_t *ctx)
@@ -148,11 +150,14 @@ static uds_status_t init_isotp(isotp_ctx_t *ctx)
     cfg.tx_can_id   = 0x7E8U;
     cfg.block_size  = 0U;
     cfg.stmin_ms    = 0U;
+#if ISOTP_ENABLE_CAN_FD
     cfg.use_fd      = false;
+#endif
     cfg.can         = &g_mock_can;
     return isotp_init(ctx, &cfg);
 }
 
+#if ISOTP_ENABLE_CAN_FD
 /** Initialise a fresh isotp_ctx_t in CAN FD mode. */
 static uds_status_t init_isotp_fd(isotp_ctx_t *ctx)
 {
@@ -166,6 +171,7 @@ static uds_status_t init_isotp_fd(isotp_ctx_t *ctx)
     cfg.can         = &g_mock_can;
     return isotp_init(ctx, &cfg);
 }
+#endif /* ISOTP_ENABLE_CAN_FD */
 
 /* =========================================================================
  * Test suite: isotp_init
@@ -445,6 +451,7 @@ ZTEST(test_isotp_rx_multi, test_cf_without_ff)
     zassert_false(g_rx_cb_called, "Callback must not fire for unexpected CF");
 }
 
+#if ISOTP_ENABLE_CAN_FD
 /**
  * TC-ISTP-RX-MF-004: CAN FD FF escape sequence with FF_DL > ISOTP_RX_BUF_LEN
  *                     → UDS_STATUS_ERR_TP_OVERFLOW + FC OVFLW transmitted.
@@ -476,10 +483,13 @@ ZTEST(test_isotp_rx_multi, test_ff_overflow)
     zassert_equal((g_mock_tx_frames[0].data[0] & 0x0FU), (uint8_t)ISOTP_FC_STATUS_OVERFLOW,
                   "FC status must be OVERFLOW");
 }
+#endif /* ISOTP_ENABLE_CAN_FD — test_ff_overflow */
 
 /* =========================================================================
  * Test suite: CAN FD SF and FF (ISO 15765-2 §9.8)
  * ========================================================================= */
+
+#if ISOTP_ENABLE_CAN_FD
 
 ZTEST_SUITE(test_isotp_canfd, NULL, NULL, NULL, NULL, NULL);
 
@@ -696,6 +706,7 @@ ZTEST(test_isotp_canfd, test_fd_ff_escape_tx)
     zassert_equal(state, ISOTP_STATE_TX_WAIT_FC,
                   "State must be TX_WAIT_FC after FD FF escape TX");
 }
+#endif /* ISOTP_ENABLE_CAN_FD — test_isotp_canfd suite */
 
 /* =========================================================================
  * Test suite: isotp_transmit
@@ -994,6 +1005,7 @@ extern void test_isotp_rx_single__test_sf_seven_bytes(void);
 extern void test_isotp_rx_multi__test_first_frame_triggers_fc(void);
 extern void test_isotp_rx_multi__test_ff_cf_complete(void);
 extern void test_isotp_rx_multi__test_cf_without_ff(void);
+#if ISOTP_ENABLE_CAN_FD
 extern void test_isotp_rx_multi__test_ff_overflow(void);
 extern void test_isotp_canfd__test_fd_sf_rx_10_bytes(void);
 extern void test_isotp_canfd__test_fd_sf_rx_62_bytes(void);
@@ -1003,6 +1015,7 @@ extern void test_isotp_canfd__test_fd_ff_escape_rx_fits(void);
 extern void test_isotp_canfd__test_fd_ff_escape_rx_overflow(void);
 extern void test_isotp_canfd__test_fd_ff_escape_classic_can_rejected(void);
 extern void test_isotp_canfd__test_fd_ff_escape_tx(void);
+#endif /* ISOTP_ENABLE_CAN_FD */
 extern void test_isotp_transmit__test_null_ctx(void);
 extern void test_isotp_transmit__test_null_data(void);
 extern void test_isotp_transmit__test_zero_length(void);
@@ -1033,6 +1046,7 @@ void run_all_tests(void)
     RUN_TEST(test_isotp_rx_multi__test_first_frame_triggers_fc);
     RUN_TEST(test_isotp_rx_multi__test_ff_cf_complete);
     RUN_TEST(test_isotp_rx_multi__test_cf_without_ff);
+#if ISOTP_ENABLE_CAN_FD
     RUN_TEST(test_isotp_rx_multi__test_ff_overflow);
     RUN_TEST(test_isotp_canfd__test_fd_sf_rx_10_bytes);
     RUN_TEST(test_isotp_canfd__test_fd_sf_rx_62_bytes);
@@ -1042,6 +1056,7 @@ void run_all_tests(void)
     RUN_TEST(test_isotp_canfd__test_fd_ff_escape_rx_overflow);
     RUN_TEST(test_isotp_canfd__test_fd_ff_escape_classic_can_rejected);
     RUN_TEST(test_isotp_canfd__test_fd_ff_escape_tx);
+#endif /* ISOTP_ENABLE_CAN_FD */
     RUN_TEST(test_isotp_transmit__test_null_ctx);
     RUN_TEST(test_isotp_transmit__test_null_data);
     RUN_TEST(test_isotp_transmit__test_zero_length);

--- a/tests/unit_runnable/test_isotp_concurrent.c
+++ b/tests/unit_runnable/test_isotp_concurrent.c
@@ -108,14 +108,14 @@ static can_transport_t g_mock_can = {
 #define MAX_CB_DATA (256U)
 
 static uint8_t  g_cb_data[MAX_CB_DATA];
-static uint16_t g_cb_len;
+static uint32_t g_cb_len;
 static uint8_t  g_cb_count;
 
-static void rx_complete_cb(const uint8_t *data, uint16_t length, void *arg)
+static void rx_complete_cb(const uint8_t *data, uint32_t length, void *arg)
 {
     (void)arg;
     g_cb_count++;
-    if (length <= (uint16_t)MAX_CB_DATA) {
+    if (length <= (uint32_t)MAX_CB_DATA) {
         (void)memcpy(g_cb_data, data, (size_t)length);
     }
     g_cb_len = length;

--- a/tests/unit_runnable/test_phase2_isotp_stmin.c
+++ b/tests/unit_runnable/test_phase2_isotp_stmin.c
@@ -80,7 +80,7 @@ static void mock_reset(void)
 }
 
 /* Null RX callback — used for TX-only tests */
-static void null_rx_cb(const uint8_t *d, uint16_t l, void *a)
+static void null_rx_cb(const uint8_t *d, uint32_t l, void *a)
 {
     (void)d; (void)l; (void)a;
 }

--- a/transport/isotp.c
+++ b/transport/isotp.c
@@ -14,8 +14,10 @@
  *   [P2-TP-04] FC reception and segmented TX state machine — fully implemented.
  *   [P2-TP-05] As/Bs/Cr timeout enforcement in isotp_tick_1ms.
  *   [P2-TP-06] STmin inter-frame delay for TX consecutive frames.
- *   [P2-TP-07] CAN FD escape sequence for PDU length > 4095 bytes noted
- *              as out of scope (UDS_MAX_PAYLOAD_LEN is 4095).
+ *   [P2-TP-07] CAN FD SF and FF encoding added (ISO 15765-2 §9.8):
+ *              SF RX/TX: byte 0 = 0x00, byte 1 = SF_DL (1-62) when frame->is_fd.
+ *              FF RX/TX: escape sequence (bytes 0-1 = 0x10 0x00, bytes 2-5 = 32-bit
+ *              FF_DL) when use_fd and length > UDS_MAX_PAYLOAD_LEN.
  *
  * MULTI-FRAME TX SEQUENCE:
  *   isotp_transmit()            — sends FF, transitions to TX_WAIT_FC
@@ -99,6 +101,7 @@ uds_status_t isotp_init(isotp_ctx_t *ctx, const isotp_cfg_t *cfg)
     ctx->tx_can_id        = cfg->tx_can_id;
     ctx->local_block_size = cfg->block_size;
     ctx->local_stmin_ms   = cfg->stmin_ms;
+    ctx->use_fd           = cfg->use_fd;
     ctx->can              = cfg->can;
     ctx->rx_state         = ISOTP_STATE_IDLE;
     ctx->tx_state         = ISOTP_STATE_IDLE;
@@ -133,9 +136,34 @@ uds_status_t isotp_process_rx_frame(
 
         /* ----------------------------------------------------------------
          * [P2-TP-01] Single Frame (SF) reception
+         * [P2-TP-07] CAN FD SF: byte 0 = 0x00, byte 1 = SF_DL (ISO 15765-2 §9.8.1)
          * ---------------------------------------------------------------- */
         case (uint8_t)ISOTP_FRAME_TYPE_SF: {
-            uint8_t sf_dl = (uint8_t)(frame->data[0] & (uint8_t)0x0FU);
+            uint8_t sf_dl;
+
+            /* CAN FD Single Frame: signalled by frame->is_fd and byte 0 == 0x00. */
+            if (frame->is_fd && (frame->data[0] == (uint8_t)0x00U)) {
+                sf_dl = frame->data[1];
+
+                if (sf_dl == (uint8_t)0U) {
+                    return UDS_STATUS_ERR_TP_FRAME_INVALID;
+                }
+                if (sf_dl > (uint8_t)ISOTP_FD_SF_MAX_PAYLOAD_LEN) {
+                    return UDS_STATUS_ERR_TP_OVERFLOW;
+                }
+                /* Need PCI (2 bytes) + sf_dl data bytes. */
+                if (frame->dlc < (uint8_t)((uint8_t)2U + sf_dl)) {
+                    return UDS_STATUS_ERR_TP_FRAME_INVALID;
+                }
+
+                ctx->rx_state = ISOTP_STATE_IDLE;
+                (void)memcpy(ctx->rx_buf, &frame->data[2], (size_t)sf_dl);
+                rx_cb(ctx->rx_buf, (uint32_t)sf_dl, rx_cb_arg);
+                return UDS_STATUS_OK;
+            }
+
+            /* Classic CAN Single Frame. */
+            sf_dl = (uint8_t)(frame->data[0] & (uint8_t)0x0FU);
 
             if (sf_dl == (uint8_t)0U) {
                 return UDS_STATUS_ERR_TP_FRAME_INVALID;
@@ -149,14 +177,10 @@ uds_status_t isotp_process_rx_frame(
              * [MISRA 14.3] Guard against rx_buf overflow using the named
              * protocol constant rather than sizeof().
              *
-             * sizeof(ctx->rx_buf) == UDS_MAX_PAYLOAD_LEN (4095) which, when
-             * cast to uint8_t, wraps to 0xFF — making "sf_dl > 0xFF" always
-             * false for a uint8_t operand.  The correct check uses the
-             * compile-time constant directly so the comparison is type-clean
-             * and the intent is explicit: a CAN SF carries at most 7 data
-             * bytes, and rx_buf is 4095 bytes, so any valid SF always fits.
-             * We verify against ISOTP_SF_MAX_PAYLOAD_LEN (7U) to catch a
-             * malformed PCI byte that overstates the data length.
+             * sizeof(ctx->rx_buf) == ISOTP_RX_BUF_LEN which, when cast to
+             * uint8_t for a >255-byte buffer, would wrap — the named constant
+             * keeps the comparison type-clean.  A Classic CAN SF carries at
+             * most 7 data bytes, so any valid SF always fits.
              */
             if (sf_dl > (uint8_t)ISOTP_SF_MAX_PAYLOAD_LEN) {
                 return UDS_STATUS_ERR_TP_OVERFLOW;
@@ -166,34 +190,54 @@ uds_status_t isotp_process_rx_frame(
             ctx->rx_state = ISOTP_STATE_IDLE;
 
             (void)memcpy(ctx->rx_buf, &frame->data[1], (size_t)sf_dl);
-            rx_cb(ctx->rx_buf, (uint16_t)sf_dl, rx_cb_arg);
+            rx_cb(ctx->rx_buf, (uint32_t)sf_dl, rx_cb_arg);
             return UDS_STATUS_OK;
         }
 
         /* ----------------------------------------------------------------
          * [P2-TP-02] First Frame (FF) reception
+         * [P2-TP-07] CAN FD FF escape sequence for FF_DL > 4095 bytes
+         *            (ISO 15765-2 §9.8.2): bytes 0-1 = 0x10 0x00,
+         *            bytes 2-5 = 32-bit big-endian FF_DL.
          * ---------------------------------------------------------------- */
         case (uint8_t)ISOTP_FRAME_TYPE_FF: {
-            uint16_t ff_dl;
+            uint32_t ff_dl;
             uint8_t  ff_data_bytes;
+            uint8_t  ff_data_offset;
 
-            /* FF_DL is 12 bits: (byte0 & 0x0F) << 8 | byte1. */
-            ff_dl = (uint16_t)(((uint16_t)(frame->data[0] & (uint8_t)0x0FU) << (uint16_t)8U)
-                               | (uint16_t)frame->data[1]);
+            /* FF_DL: 12 bits from (byte0 & 0x0F) << 8 | byte1. */
+            ff_dl = (uint32_t)(((uint32_t)(frame->data[0] & (uint8_t)0x0FU) << 8U)
+                               | (uint32_t)frame->data[1]);
 
-            if (ff_dl == (uint16_t)0U) {
-                return UDS_STATUS_ERR_TP_FRAME_INVALID;
+            if (ff_dl == (uint32_t)0U) {
+                /*
+                 * ISO 15765-2 §9.8.2: FF_DL == 0 signals the CAN FD escape
+                 * sequence.  Classic CAN never uses this encoding — reject it.
+                 */
+                if (!frame->is_fd) {
+                    return UDS_STATUS_ERR_TP_FRAME_INVALID;
+                }
+                /* Escape header requires at least 6 bytes: 2 PCI + 4 length. */
+                if (frame->dlc < (uint8_t)6U) {
+                    return UDS_STATUS_ERR_TP_FRAME_INVALID;
+                }
+                /* Extract 32-bit FF_DL from bytes 2-5 (big-endian). */
+                ff_dl = ((uint32_t)frame->data[2] << 24U)
+                      | ((uint32_t)frame->data[3] << 16U)
+                      | ((uint32_t)frame->data[4] <<  8U)
+                      |  (uint32_t)frame->data[5];
+
+                if (ff_dl == (uint32_t)0U) {
+                    return UDS_STATUS_ERR_TP_FRAME_INVALID;
+                }
+                ff_data_offset = (uint8_t)6U;
+            } else {
+                /* Standard 12-bit FF_DL (values 1-4095). */
+                ff_data_offset = (uint8_t)2U;
             }
 
-            /*
-             * ISO 15765-2 §9.8.2: FF_DL == 0 uses escape sequence (CAN FD only).
-             * For standard CAN, FF_DL must be 8..4095 (0x008..0xFFF).
-             * FF_DL > UDS_MAX_PAYLOAD_LEN is not reachable with 12-bit encoding
-             * (max = 0xFFF = 4095 = UDS_MAX_PAYLOAD_LEN), but we check for
-             * any value that would overflow our static RX buffer.
-             */
-            if (ff_dl >= (uint16_t)UDS_MAX_PAYLOAD_LEN) {
-                /* Send FC OVFLW and abort. */
+            /* Reject if assembled PDU exceeds the static RX buffer. */
+            if (ff_dl > (uint32_t)ISOTP_RX_BUF_LEN) {
                 (void)isotp_send_fc(ctx,
                                     (uint8_t)ISOTP_FC_STATUS_OVERFLOW,
                                     (uint8_t)0U,
@@ -201,20 +245,20 @@ uds_status_t isotp_process_rx_frame(
                 return UDS_STATUS_ERR_TP_OVERFLOW;
             }
 
-            /* Need at least FF PCI (2 bytes) + some data. */
-            if (frame->dlc < (uint8_t)3U) {
+            /* Need at least the PCI header + some data. */
+            if (frame->dlc <= ff_data_offset) {
                 return UDS_STATUS_ERR_TP_FRAME_INVALID;
             }
 
-            ff_data_bytes = (uint8_t)(frame->dlc - (uint8_t)2U);
-            if ((uint16_t)ff_data_bytes > ff_dl) {
+            ff_data_bytes = (uint8_t)(frame->dlc - ff_data_offset);
+            if ((uint32_t)ff_data_bytes > ff_dl) {
                 ff_data_bytes = (uint8_t)ff_dl;
             }
 
-            (void)memcpy(ctx->rx_buf, &frame->data[2], (size_t)ff_data_bytes);
+            (void)memcpy(ctx->rx_buf, &frame->data[ff_data_offset], (size_t)ff_data_bytes);
 
             ctx->rx_expected_len = ff_dl;
-            ctx->rx_received_len = (uint16_t)ff_data_bytes;
+            ctx->rx_received_len = (uint32_t)ff_data_bytes;
             ctx->rx_expected_sn  = (uint8_t)1U;
             ctx->rx_cr_timer_ms  = (uint32_t)ISOTP_TIMEOUT_CR_MS;
             ctx->rx_state        = ISOTP_STATE_RX_WAIT_CF;
@@ -233,9 +277,9 @@ uds_status_t isotp_process_rx_frame(
          * ---------------------------------------------------------------- */
         case (uint8_t)ISOTP_FRAME_TYPE_CF: {
             uint8_t  sn;
-            uint16_t remaining;
+            uint32_t remaining;
             uint8_t  cf_data;
-            uint16_t copy_len;
+            uint32_t copy_len;
 
             if (ctx->rx_state != ISOTP_STATE_RX_WAIT_CF) {
                 return UDS_STATUS_ERR_TP_UNEXPECTED_PDU;
@@ -256,9 +300,9 @@ uds_status_t isotp_process_rx_frame(
 
             remaining = ctx->rx_expected_len - ctx->rx_received_len;
             cf_data   = (uint8_t)(frame->dlc - (uint8_t)1U);
-            copy_len  = ((uint16_t)cf_data < remaining) ? (uint16_t)cf_data : remaining;
+            copy_len  = ((uint32_t)cf_data < remaining) ? (uint32_t)cf_data : remaining;
 
-            if ((ctx->rx_received_len + copy_len) > (uint16_t)sizeof(ctx->rx_buf)) {
+            if ((ctx->rx_received_len + copy_len) > (uint32_t)sizeof(ctx->rx_buf)) {
                 ctx->rx_state = ISOTP_STATE_ERROR;
                 return UDS_STATUS_ERR_TP_OVERFLOW;
             }
@@ -266,7 +310,7 @@ uds_status_t isotp_process_rx_frame(
             (void)memcpy(&ctx->rx_buf[ctx->rx_received_len],
                          &frame->data[1], (size_t)copy_len);
 
-            ctx->rx_received_len = (uint16_t)(ctx->rx_received_len + copy_len);
+            ctx->rx_received_len = ctx->rx_received_len + copy_len;
             ctx->rx_expected_sn  = (uint8_t)(ctx->rx_expected_sn + (uint8_t)1U);
 
             /* Reset Cr timer on each received CF. */
@@ -345,7 +389,7 @@ uds_status_t isotp_process_rx_frame(
 uds_status_t isotp_transmit(
     isotp_ctx_t    *ctx,
     const uint8_t  *data,
-    uint16_t        length)
+    uint32_t        length)
 {
     if ((ctx == NULL) || (data == NULL)) {
         return UDS_STATUS_ERR_NULL_PTR;
@@ -355,11 +399,12 @@ uds_status_t isotp_transmit(
         return UDS_STATUS_ERR_NOT_INITIALIZED;
     }
 
-    if (length == (uint16_t)0U) {
+    if (length == (uint32_t)0U) {
         return UDS_STATUS_ERR_INVALID_PARAM;
     }
 
-    if (length > (uint16_t)UDS_MAX_PAYLOAD_LEN) {
+    /* Classic CAN caps at UDS_MAX_PAYLOAD_LEN (4095); CAN FD allows larger. */
+    if (!ctx->use_fd && (length > (uint32_t)UDS_MAX_PAYLOAD_LEN)) {
         return UDS_STATUS_ERR_BUFFER_OVERFLOW;
     }
 
@@ -369,19 +414,19 @@ uds_status_t isotp_transmit(
 
     ctx->tx_data        = data;
     ctx->tx_total_len   = length;
-    ctx->tx_sent_len    = (uint16_t)0U;
+    ctx->tx_sent_len    = (uint32_t)0U;
     ctx->tx_sn          = (uint8_t)0U;
     ctx->tx_blocks_sent = (uint8_t)0U;
 
-    if (length <= (uint16_t)7U) {
-        /* ---- Single Frame path ---- */
+    if (length <= (uint32_t)7U) {
+        /* ---- Classic CAN Single Frame (payload 1-7 bytes) ---- */
         uds_can_frame_t sf;
         uds_status_t    tx_rc;
 
         (void)memset(&sf, 0, sizeof(sf));
         sf.id      = ctx->tx_can_id;
-        sf.dlc     = (uint8_t)(length + (uint16_t)1U);
-        sf.data[0] = (uint8_t)length;   /* PCI: SF, SF_DL in lower nibble */
+        sf.dlc     = (uint8_t)(length + (uint32_t)1U);
+        sf.data[0] = (uint8_t)length;   /* PCI: SF type (0x0), SF_DL in lower nibble */
         (void)memcpy(&sf.data[1], data, (size_t)length);
 
         tx_rc = can_transport_transmit(ctx->can, &sf);
@@ -394,8 +439,66 @@ uds_status_t isotp_transmit(
         return UDS_STATUS_OK;
     }
 
+    if (ctx->use_fd && (length <= (uint32_t)ISOTP_FD_SF_MAX_PAYLOAD_LEN)) {
+        /* ---- [P2-TP-07] CAN FD Single Frame (payload 8-62 bytes) ----
+         * ISO 15765-2 §9.8.1: byte 0 = 0x00, byte 1 = SF_DL, data at [2..].
+         */
+        uds_can_frame_t sf;
+        uds_status_t    tx_rc;
+
+        (void)memset(&sf, 0, sizeof(sf));
+        sf.id      = ctx->tx_can_id;
+        sf.dlc     = (uint8_t)(length + (uint32_t)2U);
+        sf.is_fd   = true;
+        sf.data[0] = (uint8_t)0x00U;            /* FD SF escape byte */
+        sf.data[1] = (uint8_t)length;            /* SF_DL */
+        (void)memcpy(&sf.data[2], data, (size_t)length);
+
+        tx_rc = can_transport_transmit(ctx->can, &sf);
+        if (tx_rc != UDS_STATUS_OK) {
+            return UDS_STATUS_ERR_TP_TX_FAILED;
+        }
+
+        ctx->tx_sent_len = length;
+        return UDS_STATUS_OK;
+    }
+
     /* ---- Multi-Frame: send First Frame ---- */
-    {
+    if (ctx->use_fd && (length > (uint32_t)UDS_MAX_PAYLOAD_LEN)) {
+        /* ---- [P2-TP-07] CAN FD FF escape sequence (payload > 4095 bytes) ----
+         * ISO 15765-2 §9.8.2: bytes 0-1 = 0x10 0x00, bytes 2-5 = 32-bit FF_DL.
+         * First data bytes start at offset 6; up to 58 bytes fit in a 64-byte frame.
+         */
+        uds_can_frame_t ff;
+        uds_status_t    tx_rc;
+        uint8_t         first_data;
+
+        first_data = (length > (uint32_t)58U) ? (uint8_t)58U : (uint8_t)length;
+
+        (void)memset(&ff, 0, sizeof(ff));
+        ff.id      = ctx->tx_can_id;
+        ff.dlc     = (uint8_t)(6U + (uint32_t)first_data);
+        ff.is_fd   = true;
+        ff.data[0] = (uint8_t)((uint8_t)ISOTP_FRAME_TYPE_FF << (uint8_t)4U); /* 0x10 */
+        ff.data[1] = (uint8_t)0x00U;                                          /* escape */
+        ff.data[2] = (uint8_t)((length >> 24U) & (uint8_t)0xFFU);
+        ff.data[3] = (uint8_t)((length >> 16U) & (uint8_t)0xFFU);
+        ff.data[4] = (uint8_t)((length >>  8U) & (uint8_t)0xFFU);
+        ff.data[5] = (uint8_t)(length           & (uint8_t)0xFFU);
+        (void)memcpy(&ff.data[6], data, (size_t)first_data);
+
+        tx_rc = can_transport_transmit(ctx->can, &ff);
+        if (tx_rc != UDS_STATUS_OK) {
+            return UDS_STATUS_ERR_TP_TX_FAILED;
+        }
+
+        ctx->tx_sent_len    = (uint32_t)first_data;
+        ctx->tx_sn          = (uint8_t)1U;
+        ctx->tx_bs_timer_ms = (uint32_t)ISOTP_TIMEOUT_BS_MS;
+        ctx->tx_as_timer_ms = (uint32_t)ISOTP_TIMEOUT_AS_MS;
+        ctx->tx_state       = ISOTP_STATE_TX_WAIT_FC;
+    } else {
+        /* ---- Classic CAN FF (12-bit FF_DL, payload 8-4095 bytes) ---- */
         uds_can_frame_t ff;
         uds_status_t    tx_rc;
 
@@ -403,7 +506,7 @@ uds_status_t isotp_transmit(
         ff.id      = ctx->tx_can_id;
         ff.dlc     = (uint8_t)8U;
         ff.data[0] = (uint8_t)((uint8_t)((uint8_t)ISOTP_FRAME_TYPE_FF << (uint8_t)4U)
-                               | (uint8_t)((length >> (uint8_t)8U) & (uint8_t)0x0FU));
+                               | (uint8_t)((length >> 8U) & (uint8_t)0x0FU));
         ff.data[1] = (uint8_t)(length & (uint8_t)0xFFU);
         (void)memcpy(&ff.data[2], data, (size_t)6U);
 
@@ -412,7 +515,7 @@ uds_status_t isotp_transmit(
             return UDS_STATUS_ERR_TP_TX_FAILED;
         }
 
-        ctx->tx_sent_len    = (uint16_t)6U;
+        ctx->tx_sent_len    = (uint32_t)6U;
         ctx->tx_sn          = (uint8_t)1U;
 
         /* [P2-TP-05] Arm Bs timer — must receive FC within ISOTP_TIMEOUT_BS_MS. */
@@ -504,13 +607,13 @@ uds_status_t isotp_reset(isotp_ctx_t *ctx)
 
     ctx->rx_state          = ISOTP_STATE_IDLE;
     ctx->tx_state          = ISOTP_STATE_IDLE;
-    ctx->rx_expected_len   = (uint16_t)0U;
-    ctx->rx_received_len   = (uint16_t)0U;
+    ctx->rx_expected_len   = (uint32_t)0U;
+    ctx->rx_received_len   = (uint32_t)0U;
     ctx->rx_expected_sn    = (uint8_t)0U;
     ctx->rx_cr_timer_ms    = 0U;
     ctx->tx_data           = NULL;
-    ctx->tx_total_len      = (uint16_t)0U;
-    ctx->tx_sent_len       = (uint16_t)0U;
+    ctx->tx_total_len      = (uint32_t)0U;
+    ctx->tx_sent_len       = (uint32_t)0U;
     ctx->tx_sn             = (uint8_t)0U;
     ctx->tx_block_size     = (uint8_t)0U;
     ctx->tx_stmin_ms       = (uint8_t)0U;
@@ -600,7 +703,7 @@ static uint8_t isotp_decode_stmin_ms(uint8_t stmin_raw)
 static void isotp_tx_pump(isotp_ctx_t *ctx)
 {
     uds_can_frame_t  cf;
-    uint16_t         remaining;
+    uint32_t         remaining;
     uint8_t          cf_data_len;
     uds_status_t     tx_rc;
 
@@ -614,7 +717,7 @@ static void isotp_tx_pump(isotp_ctx_t *ctx)
     }
 
     remaining = ctx->tx_total_len - ctx->tx_sent_len;
-    if (remaining == (uint16_t)0U) {
+    if (remaining == (uint32_t)0U) {
         /* All bytes sent — TX complete. */
         ctx->tx_state       = ISOTP_STATE_IDLE;
         ctx->tx_data        = NULL;
@@ -622,7 +725,7 @@ static void isotp_tx_pump(isotp_ctx_t *ctx)
         return;
     }
 
-    cf_data_len = (remaining > (uint16_t)7U) ? (uint8_t)7U : (uint8_t)remaining;
+    cf_data_len = (remaining > (uint32_t)7U) ? (uint8_t)7U : (uint8_t)remaining;
 
     (void)memset(&cf, 0, sizeof(cf));
     cf.id      = ctx->tx_can_id;
@@ -637,7 +740,7 @@ static void isotp_tx_pump(isotp_ctx_t *ctx)
         return;
     }
 
-    ctx->tx_sent_len    = (uint16_t)(ctx->tx_sent_len + (uint16_t)cf_data_len);
+    ctx->tx_sent_len    = ctx->tx_sent_len + (uint32_t)cf_data_len;
     ctx->tx_sn          = (uint8_t)(ctx->tx_sn + (uint8_t)1U);
     ctx->tx_blocks_sent = (uint8_t)(ctx->tx_blocks_sent + (uint8_t)1U);
 

--- a/transport/isotp.c
+++ b/transport/isotp.c
@@ -101,7 +101,9 @@ uds_status_t isotp_init(isotp_ctx_t *ctx, const isotp_cfg_t *cfg)
     ctx->tx_can_id        = cfg->tx_can_id;
     ctx->local_block_size = cfg->block_size;
     ctx->local_stmin_ms   = cfg->stmin_ms;
+#if ISOTP_ENABLE_CAN_FD
     ctx->use_fd           = cfg->use_fd;
+#endif
     ctx->can              = cfg->can;
     ctx->rx_state         = ISOTP_STATE_IDLE;
     ctx->tx_state         = ISOTP_STATE_IDLE;
@@ -141,6 +143,7 @@ uds_status_t isotp_process_rx_frame(
         case (uint8_t)ISOTP_FRAME_TYPE_SF: {
             uint8_t sf_dl;
 
+#if ISOTP_ENABLE_CAN_FD
             /* CAN FD Single Frame: signalled by frame->is_fd and byte 0 == 0x00. */
             if (frame->is_fd && (frame->data[0] == (uint8_t)0x00U)) {
                 sf_dl = frame->data[1];
@@ -161,6 +164,7 @@ uds_status_t isotp_process_rx_frame(
                 rx_cb(ctx->rx_buf, (uint32_t)sf_dl, rx_cb_arg);
                 return UDS_STATUS_OK;
             }
+#endif /* ISOTP_ENABLE_CAN_FD */
 
             /* Classic CAN Single Frame. */
             sf_dl = (uint8_t)(frame->data[0] & (uint8_t)0x0FU);
@@ -210,6 +214,7 @@ uds_status_t isotp_process_rx_frame(
                                | (uint32_t)frame->data[1]);
 
             if (ff_dl == (uint32_t)0U) {
+#if ISOTP_ENABLE_CAN_FD
                 /*
                  * ISO 15765-2 §9.8.2: FF_DL == 0 signals the CAN FD escape
                  * sequence.  Classic CAN never uses this encoding — reject it.
@@ -231,6 +236,10 @@ uds_status_t isotp_process_rx_frame(
                     return UDS_STATUS_ERR_TP_FRAME_INVALID;
                 }
                 ff_data_offset = (uint8_t)6U;
+#else
+                /* FF_DL == 0 is reserved on Classic CAN — always reject. */
+                return UDS_STATUS_ERR_TP_FRAME_INVALID;
+#endif /* ISOTP_ENABLE_CAN_FD */
             } else {
                 /* Standard 12-bit FF_DL (values 1-4095). */
                 ff_data_offset = (uint8_t)2U;
@@ -403,8 +412,12 @@ uds_status_t isotp_transmit(
         return UDS_STATUS_ERR_INVALID_PARAM;
     }
 
-    /* Classic CAN caps at UDS_MAX_PAYLOAD_LEN (4095); CAN FD allows larger. */
+#if ISOTP_ENABLE_CAN_FD
+    /* CAN FD allows payloads > 4095; Classic CAN is capped at UDS_MAX_PAYLOAD_LEN. */
     if (!ctx->use_fd && (length > (uint32_t)UDS_MAX_PAYLOAD_LEN)) {
+#else
+    if (length > (uint32_t)UDS_MAX_PAYLOAD_LEN) {
+#endif
         return UDS_STATUS_ERR_BUFFER_OVERFLOW;
     }
 
@@ -439,6 +452,7 @@ uds_status_t isotp_transmit(
         return UDS_STATUS_OK;
     }
 
+#if ISOTP_ENABLE_CAN_FD
     if (ctx->use_fd && (length <= (uint32_t)ISOTP_FD_SF_MAX_PAYLOAD_LEN)) {
         /* ---- [P2-TP-07] CAN FD Single Frame (payload 8-62 bytes) ----
          * ISO 15765-2 §9.8.1: byte 0 = 0x00, byte 1 = SF_DL, data at [2..].
@@ -462,8 +476,10 @@ uds_status_t isotp_transmit(
         ctx->tx_sent_len = length;
         return UDS_STATUS_OK;
     }
+#endif /* ISOTP_ENABLE_CAN_FD */
 
     /* ---- Multi-Frame: send First Frame ---- */
+#if ISOTP_ENABLE_CAN_FD
     if (ctx->use_fd && (length > (uint32_t)UDS_MAX_PAYLOAD_LEN)) {
         /* ---- [P2-TP-07] CAN FD FF escape sequence (payload > 4095 bytes) ----
          * ISO 15765-2 §9.8.2: bytes 0-1 = 0x10 0x00, bytes 2-5 = 32-bit FF_DL.
@@ -497,7 +513,9 @@ uds_status_t isotp_transmit(
         ctx->tx_bs_timer_ms = (uint32_t)ISOTP_TIMEOUT_BS_MS;
         ctx->tx_as_timer_ms = (uint32_t)ISOTP_TIMEOUT_AS_MS;
         ctx->tx_state       = ISOTP_STATE_TX_WAIT_FC;
-    } else {
+    } else
+#endif /* ISOTP_ENABLE_CAN_FD */
+    {
         /* ---- Classic CAN FF (12-bit FF_DL, payload 8-4095 bytes) ---- */
         uds_can_frame_t ff;
         uds_status_t    tx_rc;

--- a/transport/isotp.h
+++ b/transport/isotp.h
@@ -67,6 +67,25 @@ extern "C" {
 #define ISOTP_SF_MAX_PAYLOAD_LEN (7U)
 #endif
 
+/**
+ * Maximum payload bytes in a CAN FD Single Frame.
+ * ISO 15765-2:2016 §9.8.1: CAN FD frame = up to 64 bytes;
+ * 2 bytes consumed by the escape PCI (0x00 + SF_DL), leaving 62 bytes.
+ */
+#ifndef ISOTP_FD_SF_MAX_PAYLOAD_LEN
+#define ISOTP_FD_SF_MAX_PAYLOAD_LEN (62U)
+#endif
+
+/**
+ * Static RX reassembly buffer size in bytes.
+ * Defaults to UDS_MAX_PAYLOAD_LEN (4095).  Override at compile time
+ * (e.g. -DISOTOP_RX_BUF_LEN=131072) for large CAN FD OTA transfers.
+ * Must be at least 8 and no larger than UINT32_MAX.
+ */
+#ifndef ISOTP_RX_BUF_LEN
+#define ISOTP_RX_BUF_LEN (UDS_MAX_PAYLOAD_LEN)
+#endif
+
 /** Default block size (0 = no block size limit). */
 #ifndef ISOTP_DEFAULT_BLOCK_SIZE
 #define ISOTP_DEFAULT_BLOCK_SIZE (0U)
@@ -117,17 +136,17 @@ typedef struct isotp_ctx {
 
     /* RX state */
     isotp_state_t    rx_state;                          /**< Current RX state. */
-    uint8_t          rx_buf[UDS_MAX_PAYLOAD_LEN];       /**< Static RX reassembly buffer. */
-    uint16_t         rx_expected_len;                   /**< Total expected message length. */
-    uint16_t         rx_received_len;                   /**< Bytes received so far. */
+    uint8_t          rx_buf[ISOTP_RX_BUF_LEN];         /**< Static RX reassembly buffer. */
+    uint32_t         rx_expected_len;                   /**< Total expected message length. */
+    uint32_t         rx_received_len;                   /**< Bytes received so far. */
     uint8_t          rx_expected_sn;                    /**< Expected consecutive frame SN. */
     uint32_t         rx_cr_timer_ms;                    /**< Cr timeout countdown (ms). */
 
     /* TX state */
     isotp_state_t    tx_state;                          /**< Current TX state. */
     const uint8_t   *tx_data;                           /**< Pointer to TX data (not owned). */
-    uint16_t         tx_total_len;                      /**< Total bytes to transmit. */
-    uint16_t         tx_sent_len;                       /**< Bytes transmitted so far. */
+    uint32_t         tx_total_len;                      /**< Total bytes to transmit. */
+    uint32_t         tx_sent_len;                       /**< Bytes transmitted so far. */
     uint8_t          tx_sn;                             /**< TX consecutive frame sequence number. */
     uint8_t          tx_block_size;                     /**< Negotiated block size. */
     uint8_t          tx_stmin_ms;                       /**< Negotiated STmin in ms. */
@@ -141,6 +160,7 @@ typedef struct isotp_ctx {
     uint32_t         tx_can_id;                         /**< CAN ID to transmit on. */
     uint8_t          local_block_size;                  /**< Block size to advertise in FC. */
     uint8_t          local_stmin_ms;                    /**< STmin to advertise in FC (ms). */
+    bool             use_fd;                            /**< True: CAN FD mode (SF up to 62 B, FF escape for >4095 B). */
 
     /* Bound CAN transport interface. */
     can_transport_t *can;                               /**< Pointer to CAN transport interface. */
@@ -158,6 +178,7 @@ typedef struct isotp_cfg {
     uint32_t         tx_can_id;         /**< CAN ID to use for outgoing frames. */
     uint8_t          block_size;        /**< Block size to advertise to sender (0 = unlimited). */
     uint8_t          stmin_ms;          /**< Minimum separation time to advertise (ms). */
+    bool             use_fd;            /**< Set true to enable CAN FD SF/FF encoding. */
     can_transport_t *can;               /**< Pointer to initialized CAN transport interface. */
 } isotp_cfg_t;
 
@@ -177,7 +198,7 @@ typedef struct isotp_cfg {
  */
 typedef void (*isotp_rx_complete_cb)(
     const uint8_t *data,
-    uint16_t       length,
+    uint32_t       length,
     void          *arg
 );
 
@@ -240,14 +261,14 @@ uds_status_t isotp_process_rx_frame(
  * @return UDS_STATUS_ERR_NOT_INITIALIZED if ctx not initialized.
  * @return UDS_STATUS_ERR_BUSY if a TX is already in progress.
  * @return UDS_STATUS_ERR_INVALID_PARAM if length is zero.
- * @return UDS_STATUS_ERR_BUFFER_OVERFLOW if length exceeds UDS_MAX_PAYLOAD_LEN.
+ * @return UDS_STATUS_ERR_BUFFER_OVERFLOW if length exceeds UDS_MAX_PAYLOAD_LEN and use_fd is false.
  *
  * @note TIMING: Timing-critical — TX initiation must occur within P2server_max.
  */
 uds_status_t isotp_transmit(
     isotp_ctx_t    *ctx,
     const uint8_t  *data,
-    uint16_t        length
+    uint32_t        length
 );
 
 /**

--- a/transport/isotp.h
+++ b/transport/isotp.h
@@ -68,6 +68,22 @@ extern "C" {
 #endif
 
 /**
+ * Compile-time CAN FD opt-in.
+ * Set to 1 (e.g. -DISOTP_ENABLE_CAN_FD=1) to enable the ISO 15765-2 §9.8
+ * SF/FF escape paths.  Default 0 — Classic CAN only, FD code is compiled out
+ * entirely so the binary contains no FD logic.
+ *
+ * The runtime use_fd flag in isotp_cfg_t / isotp_ctx_t is only present when
+ * this macro is 1.  Both layers are required to enable CAN FD:
+ *   - compile time: -DISOTP_ENABLE_CAN_FD=1
+ *   - run time: isotp_cfg_t.use_fd = true
+ */
+#ifndef ISOTP_ENABLE_CAN_FD
+#define ISOTP_ENABLE_CAN_FD 0
+#endif
+
+#if ISOTP_ENABLE_CAN_FD
+/**
  * Maximum payload bytes in a CAN FD Single Frame.
  * ISO 15765-2:2016 §9.8.1: CAN FD frame = up to 64 bytes;
  * 2 bytes consumed by the escape PCI (0x00 + SF_DL), leaving 62 bytes.
@@ -75,6 +91,7 @@ extern "C" {
 #ifndef ISOTP_FD_SF_MAX_PAYLOAD_LEN
 #define ISOTP_FD_SF_MAX_PAYLOAD_LEN (62U)
 #endif
+#endif /* ISOTP_ENABLE_CAN_FD */
 
 /**
  * Static RX reassembly buffer size in bytes.
@@ -160,7 +177,9 @@ typedef struct isotp_ctx {
     uint32_t         tx_can_id;                         /**< CAN ID to transmit on. */
     uint8_t          local_block_size;                  /**< Block size to advertise in FC. */
     uint8_t          local_stmin_ms;                    /**< STmin to advertise in FC (ms). */
+#if ISOTP_ENABLE_CAN_FD
     bool             use_fd;                            /**< True: CAN FD mode (SF up to 62 B, FF escape for >4095 B). */
+#endif
 
     /* Bound CAN transport interface. */
     can_transport_t *can;                               /**< Pointer to CAN transport interface. */
@@ -178,7 +197,9 @@ typedef struct isotp_cfg {
     uint32_t         tx_can_id;         /**< CAN ID to use for outgoing frames. */
     uint8_t          block_size;        /**< Block size to advertise to sender (0 = unlimited). */
     uint8_t          stmin_ms;          /**< Minimum separation time to advertise (ms). */
+#if ISOTP_ENABLE_CAN_FD
     bool             use_fd;            /**< Set true to enable CAN FD SF/FF encoding. */
+#endif
     can_transport_t *can;               /**< Pointer to initialized CAN transport interface. */
 } isotp_cfg_t;
 
@@ -261,7 +282,8 @@ uds_status_t isotp_process_rx_frame(
  * @return UDS_STATUS_ERR_NOT_INITIALIZED if ctx not initialized.
  * @return UDS_STATUS_ERR_BUSY if a TX is already in progress.
  * @return UDS_STATUS_ERR_INVALID_PARAM if length is zero.
- * @return UDS_STATUS_ERR_BUFFER_OVERFLOW if length exceeds UDS_MAX_PAYLOAD_LEN and use_fd is false.
+ * @return UDS_STATUS_ERR_BUFFER_OVERFLOW if length exceeds UDS_MAX_PAYLOAD_LEN
+ *         (when ISOTP_ENABLE_CAN_FD=0, always; when =1, only if use_fd is false).
  *
  * @note TIMING: Timing-critical — TX initiation must occur within P2server_max.
  */


### PR DESCRIPTION
## Summary

Implements the four CAN FD gaps from ISO 15765-2 §9.8 reported in #14.

- **SF RX escape**: detects `frame->is_fd && data[0] == 0x00`, reads `data[1]` as SF_DL (1–62 bytes)
- **FF RX escape**: when `ff_dl == 0` on a FD frame, parses bytes 2–5 as 32-bit big-endian FF_DL (supports payloads > 4095 bytes)
- **SF TX escape**: when `use_fd && length ≤ 62`, emits `data[0]=0x00, data[1]=length, is_fd=true`
- **FF TX escape**: when `use_fd && length > 4095`, emits escape header `0x10 0x00` + 32-bit FF_DL in bytes 2–5

All paths are gated behind `isotp_cfg_t.use_fd = true`. Zero-initialised structs keep `use_fd = false`, so every existing Classic CAN caller compiles and behaves identically.

## API changes

- `isotp_rx_complete_cb` `length` param: `uint16_t` → `uint32_t`
- `isotp_transmit` `length` param: `uint16_t` → `uint32_t`
- Internal state fields (`rx_expected_len`, `rx_received_len`, `tx_total_len`, `tx_sent_len`): `uint16_t` → `uint32_t`
- New `bool use_fd` in `isotp_cfg_t` and `isotp_ctx_t`
- New constants: `ISOTP_FD_SF_MAX_PAYLOAD_LEN (62U)`, `ISOTP_RX_BUF_LEN` (overridable)

All 7 example `on_isotp_rx_complete` callbacks updated for the new signature.

## New tests (8)

`ZTEST_SUITE(test_isotp_canfd)` in `tests/unit_runnable/test_isotp.c`:
`test_fd_sf_rx_10_bytes`, `test_fd_sf_rx_62_bytes`, `test_fd_sf_rx_zero_dl`, `test_fd_sf_tx_10_bytes`, `test_fd_ff_escape_rx_fits`, `test_fd_ff_escape_rx_overflow`, `test_fd_ff_escape_classic_can_rejected`, `test_fd_ff_escape_tx`

## Known limitation

The Zephyr and FreeRTOS platform HAL bindings (`platform/zephyr/zephyr_can.c`, `platform/freertos/freertos_can.c`) still target Classic CAN only — DLC > 8 is rejected on TX and `is_fd = false` is hardcoded on RX. Users who enable `use_fd=true` need a CAN FD-capable platform binding. Tracked as a follow-up issue.

## Test plan

- [ ] `bash build_tests.sh` — all 37 modules pass, 0 failed
- [ ] CI unit-tests job green
- [ ] Verify existing Classic CAN behaviour unchanged (test_isotp suite still fully green)
- [ ] New test_isotp_canfd suite: all 8 tests pass

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)