### PR TITLE
refactor(isotp): replace else/#endif idiom with early return in FF TX (closes #18)

### DIFF
--- a/transport/isotp.c
+++ b/transport/isotp.c
@@ -513,10 +513,12 @@ uds_status_t isotp_transmit(
         ctx->tx_bs_timer_ms = (uint32_t)ISOTP_TIMEOUT_BS_MS;
         ctx->tx_as_timer_ms = (uint32_t)ISOTP_TIMEOUT_AS_MS;
         ctx->tx_state       = ISOTP_STATE_TX_WAIT_FC;
-    } else
+        return UDS_STATUS_OK;
+    }
 #endif /* ISOTP_ENABLE_CAN_FD */
+
+    /* ---- Classic CAN FF (12-bit FF_DL, payload 8-4095 bytes) ---- */
     {
-        /* ---- Classic CAN FF (12-bit FF_DL, payload 8-4095 bytes) ---- */
         uds_can_frame_t ff;
         uds_status_t    tx_rc;
 


### PR DESCRIPTION
Fixes #18.

## What changed

The FD First Frame escape block in `isotp_transmit` used a `} else\n#endif\n{` idiom to fall through to the Classic CAN FF path when CAN FD is disabled at compile time. This is valid C — the `else` clause body is the compound statement `{...}` that follows `#endif` — but it's visually confusing because the `}` before `#endif` looks like an unmatched brace.

The fix adds an early `return UDS_STATUS_OK;` at the end of the FD branch and removes the `else`, leaving the Classic CAN path as an unconditional block below `#endif`:

```c
/* Before */
    } else
#endif /* ISOTP_ENABLE_CAN_FD */
    {
        /* Classic CAN FF */
    }
    return UDS_STATUS_OK;

/* After */
        return UDS_STATUS_OK;
    }
#endif /* ISOTP_ENABLE_CAN_FD */

    /* Classic CAN FF */
    {
    }
    return UDS_STATUS_OK;
```

No logic change. Both paths still set `tx_state = ISOTP_STATE_TX_WAIT_FC` and return `UDS_STATUS_OK`. ISO 15765-2 §9.8.2 behaviour is identical.

## Test plan
- [x] `bash build_tests.sh` — 37/37 passed locally
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)