### PR TITLE
feat(platform): CAN FD HAL support for Zephyr and FreeRTOS (closes #16)

### DIFF
--- a/platform/freertos/freertos_can.c
+++ b/platform/freertos/freertos_can.c
@@ -50,6 +50,7 @@
 #include "platform_api.h"
 #include "can_transport.h"
 #include "uds_types.h"
+#include "isotp.h"         /* ISOTP_ENABLE_CAN_FD compile-time gate. */
 
 #include "FreeRTOS.h"
 #include "queue.h"
@@ -121,21 +122,24 @@ static uds_status_t freertos_can_transmit(
     }
     taskEXIT_CRITICAL();
 
+#if ISOTP_ENABLE_CAN_FD
+    if (frame->dlc > (uint8_t)64U) {
+        return UDS_STATUS_ERR_INVALID_PARAM;
+    }
+#else
     if (frame->dlc > (uint8_t)8U) {
         return UDS_STATUS_ERR_INVALID_PARAM;
     }
+#endif
 
-    /*
-     * Convert uds_can_frame_t → eds_can_frame_t.
-     *
-     * uds_can_frame_t has an is_fd field (CAN FD flag) and a larger
-     * data buffer (64 bytes). eds_can_frame_t is classic CAN only (8 bytes).
-     * DLC is already validated <= 8 above, so the copy is safe.
-     */
+    /* Convert uds_can_frame_t → eds_can_frame_t for the customer send callback. */
     (void)memset(&ef, 0, sizeof(ef));
     ef.id          = frame->id;
     ef.dlc         = frame->dlc;
     ef.is_extended = frame->is_extended_id;
+#if ISOTP_ENABLE_CAN_FD
+    ef.is_fd       = frame->is_fd;
+#endif
     (void)memcpy(ef.data, frame->data, (size_t)frame->dlc);
 
     return s_can_send_fn(&ef);
@@ -179,7 +183,11 @@ static uds_status_t freertos_can_receive(
     out_frame->id              = ef.id;
     out_frame->dlc             = ef.dlc;
     out_frame->is_extended_id  = ef.is_extended;
-    out_frame->is_fd           = false;   /* FreeRTOS shim: classic CAN only */
+#if ISOTP_ENABLE_CAN_FD
+    out_frame->is_fd = ef.is_fd;
+#else
+    out_frame->is_fd = false;
+#endif
     (void)memcpy(out_frame->data, ef.data, (size_t)ef.dlc);
 
     *out_ready = true;

--- a/platform/platform_api.h
+++ b/platform/platform_api.h
@@ -58,11 +58,25 @@ extern "C" {
  * Zephyr transport converts between this and struct can_frame internally.
  * ========================================================================== */
 
+/**
+ * Maximum payload bytes in eds_can_frame_t.
+ * 8 for Classic CAN builds; 64 when ISOTP_ENABLE_CAN_FD=1.
+ * Must agree with UDS_CAN_FRAME_MAX_LEN in uds_types.h (both = 64 for FD).
+ */
+#if ISOTP_ENABLE_CAN_FD
+#define EDS_CAN_FRAME_MAX_DLEN  (64U)
+#else
+#define EDS_CAN_FRAME_MAX_DLEN  (8U)
+#endif
+
 typedef struct {
-    uint32_t id;           /**< CAN frame ID (11-bit or 29-bit). */
-    uint8_t  data[8];      /**< CAN data bytes (classic CAN, max 8). */
-    uint8_t  dlc;          /**< Data length code (0–8). */
-    bool     is_extended;  /**< True if 29-bit extended ID. */
+    uint32_t id;                            /**< CAN frame ID (11-bit or 29-bit). */
+    uint8_t  data[EDS_CAN_FRAME_MAX_DLEN]; /**< Frame payload bytes. */
+    uint8_t  dlc;                           /**< Byte count (0–8 Classic; 0–64 FD). */
+    bool     is_extended;                   /**< True if 29-bit extended ID. */
+#if ISOTP_ENABLE_CAN_FD
+    bool     is_fd;                         /**< True if CAN FD frame. */
+#endif
 } eds_can_frame_t;
 
 /* ============================================================================

--- a/platform/zephyr/zephyr_can.c
+++ b/platform/zephyr/zephyr_can.c
@@ -58,6 +58,7 @@
 #include "zephyr_port.h"   /* Platform types: zephyr_port_cfg_t, timestamps, etc. */
 #include "can_transport.h"
 #include "uds_types.h"
+#include "isotp.h"         /* ISOTP_ENABLE_CAN_FD compile-time gate. */
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/can.h>
@@ -151,14 +152,32 @@ static uds_status_t zephyr_can_transmit(
         return UDS_STATUS_ERR_CAN_BUS_OFF;
     }
 
+#if ISOTP_ENABLE_CAN_FD
+    if (frame->is_fd) {
+        if (frame->dlc > (uint8_t)64U) {
+            return UDS_STATUS_ERR_INVALID_PARAM;
+        }
+    } else {
+        if (frame->dlc > (uint8_t)CAN_MAX_DLC) {
+            return UDS_STATUS_ERR_INVALID_PARAM;
+        }
+    }
+#else
     if (frame->dlc > (uint8_t)CAN_MAX_DLC) {
         return UDS_STATUS_ERR_INVALID_PARAM;
     }
+#endif
 
     (void)memset(&zf, 0, sizeof(zf));
-    zf.id    = frame->id;
+    zf.id = frame->id;
+#if ISOTP_ENABLE_CAN_FD
+    /* CAN FD: set FDF flag; encode DLC as CAN FD DLC value (0–15). */
+    zf.flags = frame->is_fd ? (uint8_t)CAN_FRAME_FDF : (uint8_t)0U;
+    zf.dlc   = frame->is_fd ? can_bytes_to_dlc(frame->dlc) : frame->dlc;
+#else
+    zf.flags = (uint8_t)0U;  /* can_frame_flags_t removed in Zephyr 3.x */
     zf.dlc   = frame->dlc;
-    zf.flags = (uint8_t)0U;  /* can_frame_flags_t removed in Zephyr 3.x; flags is uint8_t */
+#endif
     (void)memcpy(zf.data, frame->data, (size_t)frame->dlc);
 
     /* Timeout = 25 ms = ISO 15765-2 N_As. */
@@ -209,8 +228,15 @@ static uds_status_t zephyr_can_receive(
     }
 
     (void)memset(out_frame, 0, sizeof(*out_frame));
-    out_frame->id  = zf.id;
+    out_frame->id = zf.id;
+#if ISOTP_ENABLE_CAN_FD
+    /* Propagate FD flag; convert CAN FD DLC (0–15) to actual byte count. */
+    out_frame->is_fd = ((zf.flags & (uint8_t)CAN_FRAME_FDF) != (uint8_t)0U);
+    out_frame->dlc   = out_frame->is_fd ? can_dlc_to_bytes(zf.dlc)
+                                        : (uint8_t)MIN(zf.dlc, (uint8_t)CAN_MAX_DLC);
+#else
     out_frame->dlc = (uint8_t)MIN(zf.dlc, (uint8_t)CAN_MAX_DLC);
+#endif
     (void)memcpy(out_frame->data, zf.data, (size_t)out_frame->dlc);
 
     *out_ready = true;
@@ -296,12 +322,20 @@ uds_status_t zephyr_can_platform_init(
         return UDS_STATUS_ERR_CAN_NOT_READY;
     }
 
-    /* Set to normal (non-loopback) operating mode. */
+    /* Set operating mode. CAN FD mode requires CONFIG_CAN_FD_MODE=y in Kconfig. */
+#if ISOTP_ENABLE_CAN_FD
+    rc = can_set_mode(can_dev, CAN_MODE_FD);
+    if (rc != 0) {
+        LOG_ERR("CAN: can_set_mode(FD) failed: %d — ensure CONFIG_CAN_FD_MODE=y.", rc);
+        return UDS_STATUS_ERR_PLATFORM;
+    }
+#else
     rc = can_set_mode(can_dev, CAN_MODE_NORMAL);
     if (rc != 0) {
         LOG_ERR("CAN: can_set_mode(NORMAL) failed: %d", rc);
         return UDS_STATUS_ERR_PLATFORM;
     }
+#endif
 
     /* Start the CAN controller. */
     rc = can_start(can_dev);


### PR DESCRIPTION
Closes #16.

## What changed

The ISO-TP layer has supported CAN FD frames since v1.7.1, but the Zephyr and FreeRTOS platform HALs were silently dropping them. This PR wires both HALs so FD frames flow through correctly on real hardware.

All changes are behind `#if ISOTP_ENABLE_CAN_FD` — **Classic CAN builds (the default) are byte-for-byte unchanged**: `eds_can_frame_t` stays 8 bytes, no new code compiles in, `zephyr_can_transmit` still rejects `dlc > CAN_MAX_DLC`.

### `platform/platform_api.h`
- Add `EDS_CAN_FRAME_MAX_DLEN` (8 when `ISOTP_ENABLE_CAN_FD=0`; 64 when `=1`)
- `eds_can_frame_t.data[]` uses `EDS_CAN_FRAME_MAX_DLEN`
- `eds_can_frame_t.is_fd` field added under `#if ISOTP_ENABLE_CAN_FD`

### `platform/zephyr/zephyr_can.c`
- **TX**: sets `CAN_FRAME_FDF` and calls `can_bytes_to_dlc()` for FD frames; Classic CAN path unchanged
- **RX**: propagates `CAN_FRAME_FDF → out_frame->is_fd`; calls `can_dlc_to_bytes()` to recover actual byte count from CAN FD DLC (0–15 encoding)
- **Init**: selects `CAN_MODE_FD` when `ISOTP_ENABLE_CAN_FD=1`, logs a clear message if `CONFIG_CAN_FD_MODE=y` is missing from Kconfig

### `platform/freertos/freertos_can.c`
- **TX**: raises DLC limit to 64 for FD builds; passes `is_fd` through to customer send callback
- **RX**: propagates `ef.is_fd → out_frame->is_fd` instead of hardcoding `false`

## Integration note (Zephyr)

Enable CAN FD in your project Kconfig:
```
CONFIG_CAN_FD_MODE=y
```
And compile EDS with:
```
-DISOTP_ENABLE_CAN_FD=1
```

## Test plan
- [x] `bash build_tests.sh` — 37/37 passed (FD path compiled via `-DISOTP_ENABLE_CAN_FD=1`)
- [x] `_Static_assert` verified `eds_can_frame_t` layout in both Classic and FD modes
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)