### PR TITLE
feat(session): strict programming session gate — require EXTENDED before PROGRAMMING (closes #22, #23)

### DIFF
--- a/core/uds_session.c
+++ b/core/uds_session.c
@@ -113,6 +113,14 @@ uds_status_t uds_session_transition(
         return rc;
     }
 
+    /* OEM strict gate: when enabled, DEFAULT → PROGRAMMING requires an
+     * intermediate EXTENDED session (BMW/VAG toolchain convention). */
+    if (ctx->strict_programming &&
+        (ctx->active_session == UDS_SESSION_DEFAULT) &&
+        (new_session == UDS_SESSION_PROGRAMMING)) {
+        return UDS_STATUS_ERR_SESSION_TRANSITION;
+    }
+
     old_session         = ctx->active_session;
     ctx->active_session = new_session;
     ctx->session_change_count++;
@@ -227,6 +235,22 @@ bool uds_session_is_default(const uds_session_ctx_t *ctx)
     }
 
     return (ctx->active_session == UDS_SESSION_DEFAULT);
+}
+
+uds_status_t uds_session_set_strict_programming(
+    uds_session_ctx_t *ctx,
+    bool               strict)
+{
+    if (ctx == NULL) {
+        return UDS_STATUS_ERR_NULL_PTR;
+    }
+
+    if (!ctx->initialized) {
+        return UDS_STATUS_ERR_NOT_INITIALIZED;
+    }
+
+    ctx->strict_programming = strict;
+    return UDS_STATUS_OK;
 }
 
 /* --------------------------------------------------------------------------

--- a/core/uds_session.h
+++ b/core/uds_session.h
@@ -72,6 +72,9 @@ typedef struct uds_session_ctx {
     uint32_t                      s3_timeout_cfg_ms;     /**< Configured S3server timeout (ms). */
     uint32_t                      session_change_count;  /**< Number of session transitions. */
     uds_session_change_notify_fn  on_session_change;     /**< [P2-SESS-02] change notification callback. */
+    bool                          strict_programming;    /**< When true, DEFAULT→PROGRAMMING is blocked;
+                                                          *   EXTENDED session is required as an
+                                                          *   intermediate step (common OEM policy). */
 } uds_session_ctx_t;
 
 /* --------------------------------------------------------------------------
@@ -149,6 +152,28 @@ uds_status_t uds_session_tick_1ms(uds_session_ctx_t *ctx);
  * @brief Check if the active session is the default session.
  */
 bool uds_session_is_default(const uds_session_ctx_t *ctx);
+
+/**
+ * @brief Enable or disable strict programming session gate.
+ *
+ * When enabled, a direct DEFAULT → PROGRAMMING transition is rejected
+ * with UDS_STATUS_ERR_SESSION_TRANSITION. The tester must first enter
+ * EXTENDED session, then request PROGRAMMING. This matches the session
+ * transition policy used by BMW, VAG, and other OEM diagnostic toolchains.
+ *
+ * Default: false (ISO 14229-1 §7.4.2.3 permissive mode — direct transition
+ * is not normatively prohibited).
+ *
+ * @param[in] ctx     Initialized session context.
+ * @param[in] strict  True to require EXTENDED as intermediate step.
+ *
+ * @return UDS_STATUS_OK on success.
+ * @return UDS_STATUS_ERR_NULL_PTR if ctx is NULL.
+ * @return UDS_STATUS_ERR_NOT_INITIALIZED if ctx is not initialized.
+ */
+uds_status_t uds_session_set_strict_programming(
+    uds_session_ctx_t *ctx,
+    bool               strict);
 
 #ifdef __cplusplus
 }

--- a/tests/unit_runnable/test_uds_session.c
+++ b/tests/unit_runnable/test_uds_session.c
@@ -449,6 +449,78 @@ ZTEST(test_uds_session_is_default, test_programming_session_false)
 }
 
 /* =========================================================================
+ * Test suite: uds_session_set_strict_programming
+ * ========================================================================= */
+
+ZTEST_SUITE(test_uds_session_strict, NULL, NULL, NULL, NULL, NULL);
+
+/**
+ * TC-SESS-STRICT-001: NULL ctx → UDS_STATUS_ERR_NULL_PTR.
+ */
+ZTEST(test_uds_session_strict, test_null_ctx)
+{
+    uds_status_t rc = uds_session_set_strict_programming(NULL, true);
+    zassert_equal(rc, UDS_STATUS_ERR_NULL_PTR, "NULL ctx must return NULL_PTR");
+}
+
+/**
+ * TC-SESS-STRICT-002: strict=true blocks DEFAULT → PROGRAMMING directly.
+ */
+ZTEST(test_uds_session_strict, test_blocks_default_to_programming)
+{
+    uds_session_ctx_t ctx;
+    zassert_equal(default_init(&ctx), UDS_STATUS_OK, "init failed");
+    zassert_equal(uds_session_set_strict_programming(&ctx, true),
+                  UDS_STATUS_OK, "set_strict failed");
+
+    uds_status_t rc = uds_session_transition(&ctx, UDS_SESSION_PROGRAMMING);
+    zassert_equal(rc, UDS_STATUS_ERR_SESSION_TRANSITION,
+                  "strict mode must block DEFAULT→PROGRAMMING");
+
+    uds_session_type_t active;
+    uds_session_get_active(&ctx, &active);
+    zassert_equal(active, UDS_SESSION_DEFAULT, "Session must remain DEFAULT after rejection");
+}
+
+/**
+ * TC-SESS-STRICT-003: strict=true allows DEFAULT → EXTENDED → PROGRAMMING.
+ */
+ZTEST(test_uds_session_strict, test_allows_via_extended)
+{
+    uds_session_ctx_t ctx;
+    zassert_equal(default_init(&ctx), UDS_STATUS_OK, "init failed");
+    zassert_equal(uds_session_set_strict_programming(&ctx, true),
+                  UDS_STATUS_OK, "set_strict failed");
+
+    zassert_equal(uds_session_transition(&ctx, UDS_SESSION_EXTENDED),
+                  UDS_STATUS_OK, "DEFAULT→EXTENDED must succeed in strict mode");
+    zassert_equal(uds_session_transition(&ctx, UDS_SESSION_PROGRAMMING),
+                  UDS_STATUS_OK, "EXTENDED→PROGRAMMING must succeed in strict mode");
+
+    uds_session_type_t active;
+    uds_session_get_active(&ctx, &active);
+    zassert_equal(active, UDS_SESSION_PROGRAMMING, "Must end in PROGRAMMING");
+}
+
+/**
+ * TC-SESS-STRICT-004: strict=true does not affect other transitions.
+ */
+ZTEST(test_uds_session_strict, test_other_transitions_unaffected)
+{
+    uds_session_ctx_t ctx;
+    zassert_equal(default_init(&ctx), UDS_STATUS_OK, "init failed");
+    zassert_equal(uds_session_set_strict_programming(&ctx, true),
+                  UDS_STATUS_OK, "set_strict failed");
+
+    zassert_equal(uds_session_transition(&ctx, UDS_SESSION_EXTENDED),
+                  UDS_STATUS_OK, "DEFAULT→EXTENDED must work in strict mode");
+    zassert_equal(uds_session_transition(&ctx, UDS_SESSION_DEFAULT),
+                  UDS_STATUS_OK, "EXTENDED→DEFAULT must work in strict mode");
+    zassert_equal(uds_session_transition(&ctx, UDS_SESSION_SAFETY_SYSTEM),
+                  UDS_STATUS_OK, "DEFAULT→SAFETY_SYSTEM must work in strict mode");
+}
+
+/* =========================================================================
  * AUTO-GENERATED: run_all_tests — wires ZTEST functions into Unity runner
  * ========================================================================= */
 
@@ -477,6 +549,10 @@ extern void test_uds_session_is_default__test_null_returns_true(void);
 extern void test_uds_session_is_default__test_default_session_true(void);
 extern void test_uds_session_is_default__test_extended_session_false(void);
 extern void test_uds_session_is_default__test_programming_session_false(void);
+extern void test_uds_session_strict__test_null_ctx(void);
+extern void test_uds_session_strict__test_blocks_default_to_programming(void);
+extern void test_uds_session_strict__test_allows_via_extended(void);
+extern void test_uds_session_strict__test_other_transitions_unaffected(void);
 
 void run_all_tests(void)
 {
@@ -505,4 +581,8 @@ void run_all_tests(void)
     RUN_TEST(test_uds_session_is_default__test_default_session_true);
     RUN_TEST(test_uds_session_is_default__test_extended_session_false);
     RUN_TEST(test_uds_session_is_default__test_programming_session_false);
+    RUN_TEST(test_uds_session_strict__test_null_ctx);
+    RUN_TEST(test_uds_session_strict__test_blocks_default_to_programming);
+    RUN_TEST(test_uds_session_strict__test_allows_via_extended);
+    RUN_TEST(test_uds_session_strict__test_other_transitions_unaffected);
 }


### PR DESCRIPTION
Closes #22. Closes #23.

## Background

A reporter with a BMW background correctly identified that many OEM diagnostic toolchains (BMW, VAG) require the tester to enter **EXTENDED session before requesting PROGRAMMING** — a direct DEFAULT→PROGRAMMING jump is rejected. The issue response acknowledged this and promised a `diagnostics_config.yaml` option. This PR delivers the behaviour via a runtime API (no codegen changes needed).

ISO 14229-1 §7.4.2.3 does not normatively prohibit DEFAULT→PROGRAMMING, so the **default remains permissive** — zero behaviour change for existing integrations.

## What changed

**`core/uds_session.h`**
- New `bool strict_programming` field in `uds_session_ctx_t` (default `false` via `memset` in `uds_session_init`)
- New public API: `uds_session_set_strict_programming(ctx, strict)`

**`core/uds_session.c`**
- Implements the setter (NULL + initialized guards)
- In `uds_session_transition()`: after the ISO matrix check passes, applies the OEM gate — rejects DEFAULT→PROGRAMMING when `strict_programming == true`

**`tests/unit_runnable/test_uds_session.c`**
- 4 new tests in `ZTEST_SUITE(test_uds_session_strict)`:
  - `test_null_ctx` — setter NULL guard
  - `test_blocks_default_to_programming` — strict mode rejects direct jump, session stays DEFAULT
  - `test_allows_via_extended` — DEFAULT→EXTENDED→PROGRAMMING works correctly
  - `test_other_transitions_unaffected` — EXTENDED↔DEFAULT, DEFAULT→SAFETY_SYSTEM unaffected

## Usage

```c
/* After uds_generated_init() / uds_session_init(): */
uds_session_set_strict_programming(&session_ctx, true);
```

## Test plan
- [x] 37/37 unit tests pass locally
- [x] Existing `test_default_to_programming` still passes (default is permissive)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)