### PR TITLE
fix: handle pending_reset_type in all example on_isotp_rx_complete callbacks (closes #37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
+## [1.8.2] — Bug fix (closes #37)
+
+### Fixed
+- All 8 example `on_isotp_rx_complete()` callbacks now handle `pending_reset_type`
+  after dispatch: flush NVM, wait 50 ms for ISO-TP TX to reach the wire, then call
+  `zephyr_port_ecu_reset()` / `eds_platform_ecu_reset()`. Previously the ECU sent the
+  `0x11` positive response but never reset (closes #37).
+
+---
 ## [1.8.1] — Bug fixes (closes #34, #35)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Xaloqi Embedded Diagnostics Suite
 
 [![CI](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml/badge.svg)](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-v1.8.1-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.8.1)
+[![Version](https://img.shields.io/badge/version-v1.8.2-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.8.2)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](LICENSE)
 [![Zephyr](https://img.shields.io/badge/Zephyr-v3.7%2B-brightgreen)](https://zephyrproject.org)
 
@@ -122,7 +122,7 @@ manifest:
   projects:
     - name: EDS
       remote: xaloqi
-      revision: v1.8.1
+      revision: v1.8.2
       path: modules/eds
 ```
 
@@ -146,7 +146,7 @@ The `ZEPHYR_EDS_MODULE_DIR` variable is set automatically by west when the modul
 
 ```bash
 pip install west
-west init -m https://github.com/Xaloqi/EDS --mr v1.8.1 eds-workspace
+west init -m https://github.com/Xaloqi/EDS --mr v1.8.2 eds-workspace
 cd eds-workspace && west update
 pip install -r tools/requirements.txt
 ```

--- a/boards/native_sim/native_sim.conf
+++ b/boards/native_sim/native_sim.conf
@@ -61,6 +61,9 @@ CONFIG_LOG_BACKEND_NATIVE_POSIX=y
 # --- FIX W5: NEWLIB_LIBC choice conflict (force newlib over picolibc default) ---
 CONFIG_NEWLIB_LIBC=y
 
+# --- Reboot subsystem (required for zephyr_port_ecu_reset / sys_reboot) ---
+CONFIG_REBOOT=y
+
 # --- Platform adjustments ---
 CONFIG_LOG_DEFAULT_LEVEL=2
 CONFIG_WATCHDOG=n

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -13,7 +13,7 @@ ISO 15765-2 (ISO-TP) diagnostics stack for embedded RTOS targets. It is YAML-dri
 describe your DIDs, DTCs, and routines in YAML, run the code generator, and receive
 ASIL-B safety-wrapped C code ready to compile into your ECU firmware.
 
-**Version:** v1.8.1
+**Version:** v1.8.2
 **Target RTOS:** Zephyr v3.7+ · FreeRTOS (any version with static allocation support)
 **Target boards:** native_sim (CI/dev) · STM32 Nucleo-H743ZI2 (hardware) · QEMU ARM Cortex-M4 (FreeRTOS CI)
 **Transport:** ISO-TP over CAN (default) · DoIP over Ethernet/TCP (v1.6.0+)
@@ -1004,5 +1004,5 @@ tool-level assertions. Requires `pyyaml` only.
 
 ---
 
-*EDS v1.8.1 — Developer €690/yr · Professional €1,990/yr — xaloqi.com*
+*EDS v1.8.2 — Developer €690/yr · Professional €1,990/yr — xaloqi.com*
 *Runtime: GPL v2 · Examples: Apache 2.0 · Tools + IDE + GUI: Commercial*

--- a/docs/COMMERCIAL_ONBOARDING.md
+++ b/docs/COMMERCIAL_ONBOARDING.md
@@ -15,7 +15,7 @@ After purchase you will have received a download link containing a ZIP file.
 ### Developer license ZIP contents
 
 ```
-xaloqi-eds-developer-v1.8.1.zip
+xaloqi-eds-developer-v1.8.2.zip
 ├── tools/
 │   ├── _license.py          ← License validation module (required for codegen)
 │   └── templates/           ← Jinja2 templates for all generated C/H files
@@ -37,7 +37,7 @@ xaloqi-eds-developer-v1.8.1.zip
 Everything in Developer, plus:
 
 ```
-xaloqi-eds-professional-v1.8.1.zip
+xaloqi-eds-professional-v1.8.2.zip
 ├── tools/
 │   ├── _license.py
 │   └── templates/           ← Same Jinja2 templates

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -61,7 +61,7 @@ west --version   # must print 1.2 or newer
 mkdir eds-workspace && cd eds-workspace
 
 # Initialise the workspace from the EDS repository
-west init -m https://github.com/Xaloqi/EDS --mr v1.8.1 .
+west init -m https://github.com/Xaloqi/EDS --mr v1.8.2 .
 
 # Pull Zephyr and all dependencies (this downloads ~500 MB, takes 2-4 min)
 west update

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -1,10 +1,10 @@
 # Integration Guide
 
-## Xaloqi EDS — Zephyr RTOS, FreeRTOS, DoIP, and SOVD (v1.8.1)
+## Xaloqi EDS — Zephyr RTOS, FreeRTOS, DoIP, and SOVD (v1.8.2)
 
 | Field | Value |
 |---|---|
-| Stack version | 1.8.1 |
+| Stack version | 1.8.2 |
 | Zephyr version | v3.7.0 (pinned in `west.yml`) |
 | FreeRTOS version | FreeRTOS-Kernel (any recent release; tested with HEAD) |
 | ISO standard | ISO 14229-1:2020 (UDS), ISO 15765-2:2016 (ISO-TP), ISO 13400-2 (DoIP) |
@@ -178,7 +178,7 @@ manifest:
 
     - name: embedded-diagnostics-suite
       url: https://github.com/your-org/embedded-diagnostics-suite
-      revision: v1.8.1            # pin to a release tag
+      revision: v1.8.2            # pin to a release tag
       path: eds
 ```
 
@@ -1116,7 +1116,7 @@ The flag is opt-in — omitting it leaves all existing behaviour unchanged.
 ```json
 {
   "sovdVersion": "1.0.0",
-  "generatedBy": "Xaloqi EDS codegen v1.8.1",
+  "generatedBy": "Xaloqi EDS codegen v1.8.2",
   "generatedAt": "2026-05-20T10:00:00Z",
   "ecuIdentification": {
     "name": "BasicECU",

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 # Xaloqi Embedded Diagnostics Suite
 
 [![CI](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml/badge.svg)](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-v1.8.1-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.8.1)
+[![Version](https://img.shields.io/badge/version-v1.8.2-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.8.2)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](LICENSE)
 [![Zephyr](https://img.shields.io/badge/Zephyr-v3.7%2B-brightgreen)](https://zephyrproject.org)
 

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -1,6 +1,6 @@
 # Testing Strategy — Xaloqi EDS
 
-**Version:** v1.8.1  
+**Version:** v1.8.2  
 **Status:** 37/37 unit test modules passing. 68/68 harness tests passing. 8/8 CI jobs green. FreeRTOS, SafeBoot (Zephyr + FreeRTOS), DoIP, and sensor examples all covered.
 
 ---
@@ -10,7 +10,7 @@
 EDS uses a four-layer testing strategy: unit tests, harness tests, integration tests, and system
 tests. All four layers run automatically in CI on every push and pull request.
 
-**Current test counts (v1.8.1):**
+**Current test counts (v1.8.2):**
 
 | Layer | Count | Framework | Status |
 |---|---|---|---|

--- a/examples/ardep_ecu/src/main.c
+++ b/examples/ardep_ecu/src/main.c
@@ -674,6 +674,16 @@ static void on_isotp_rx_complete(
             LOG_ERR("ISO-TP TX error 0x%02X", (unsigned)status);
         }
     }
+
+    /* [P2-0x11-01] Deferred reset: response is on the wire, now reset. */
+    if (srv->pending_reset_type != (uint8_t)0U) {
+        uint8_t reset_type = srv->pending_reset_type;
+        srv->pending_reset_type = (uint8_t)0U;
+        (void)zephyr_port_nvm_flush();
+        k_msleep(50);  /* Allow ISO-TP TX to reach the wire before reset (As timer). */
+        (void)zephyr_port_ecu_reset(reset_type);
+        /* Does not return. */
+    }
 }
 
 /* =============================================================================

--- a/examples/basic_ecu/src/main.c
+++ b/examples/basic_ecu/src/main.c
@@ -141,6 +141,16 @@ static void on_isotp_rx_complete(
     }
 
     (void)diag_mutex_unlock(&s_session_lock);
+
+    /* [P2-0x11-01] Deferred reset: response is on the wire, now reset. */
+    if (srv->pending_reset_type != (uint8_t)0U) {
+        uint8_t reset_type = srv->pending_reset_type;
+        srv->pending_reset_type = (uint8_t)0U;
+        (void)zephyr_port_nvm_flush();
+        k_msleep(50);  /* Allow ISO-TP TX to reach the wire before reset (As timer). */
+        (void)zephyr_port_ecu_reset(reset_type);
+        /* Does not return. */
+    }
 }
 
 /* =============================================================================

--- a/examples/bms_ecu/src/main.c
+++ b/examples/bms_ecu/src/main.c
@@ -838,6 +838,16 @@ static void on_isotp_rx_complete(
             LOG_ERR("[BMS] ISO-TP TX error 0x%02X", (unsigned)status);
         }
     }
+
+    /* [P2-0x11-01] Deferred reset: response is on the wire, now reset. */
+    if (srv->pending_reset_type != (uint8_t)0U) {
+        uint8_t reset_type = srv->pending_reset_type;
+        srv->pending_reset_type = (uint8_t)0U;
+        (void)zephyr_port_nvm_flush();
+        k_msleep(50);  /* Allow ISO-TP TX to reach the wire before reset (As timer). */
+        (void)zephyr_port_ecu_reset(reset_type);
+        /* Does not return. */
+    }
 }
 
 /* ── 1 ms tick callback ────────────────────────────────────────────────────── */

--- a/examples/robot_joint_controller_ecu/src/main.c
+++ b/examples/robot_joint_controller_ecu/src/main.c
@@ -159,6 +159,16 @@ static void on_isotp_rx_complete(const uint8_t *data, uint32_t length, void *arg
     } else if (rc != UDS_STATUS_OK) {
         LOG_ERR("UDS error 0x%02X, no response.", (unsigned)rc);
     }
+
+    /* [P2-0x11-01] Deferred reset: response is on the wire, now reset. */
+    if (srv->pending_reset_type != (uint8_t)0U) {
+        uint8_t reset_type = srv->pending_reset_type;
+        srv->pending_reset_type = (uint8_t)0U;
+        (void)zephyr_port_nvm_flush();
+        k_msleep(50);  /* Allow ISO-TP TX to reach the wire before reset (As timer). */
+        (void)zephyr_port_ecu_reset(reset_type);
+        /* Does not return. */
+    }
 }
 
 /* ---------------------------------------------------------------------------

--- a/examples/safeboot_ecu/src/main.c
+++ b/examples/safeboot_ecu/src/main.c
@@ -318,6 +318,16 @@ static void on_isotp_rx_complete(
             LOG_ERR("ISO-TP TX error 0x%02X", (unsigned)status);
         }
     }
+
+    /* [P2-0x11-01] Deferred reset: response is on the wire, now reset. */
+    if (srv->pending_reset_type != (uint8_t)0U) {
+        uint8_t reset_type = srv->pending_reset_type;
+        srv->pending_reset_type = (uint8_t)0U;
+        (void)zephyr_port_nvm_flush();
+        k_msleep(50);  /* Allow ISO-TP TX to reach the wire before reset (As timer). */
+        (void)zephyr_port_ecu_reset(reset_type);
+        /* Does not return. */
+    }
 }
 
 /* =============================================================================

--- a/examples/safeboot_freertos_ecu/src/main.c
+++ b/examples/safeboot_freertos_ecu/src/main.c
@@ -152,6 +152,16 @@ static void on_isotp_rx_complete(
     if (s_resp_buf.length > (uint16_t)0U) {
         (void)isotp_transmit(tp, s_resp_buf.data, s_resp_buf.length);
     }
+
+    /* [P2-0x11-01] Deferred reset: response is on the wire, now reset. */
+    if (srv->pending_reset_type != (uint8_t)0U) {
+        uint8_t reset_type = srv->pending_reset_type;
+        srv->pending_reset_type = (uint8_t)0U;
+        (void)eds_platform_nvm_flush();
+        vTaskDelay(pdMS_TO_TICKS(50));  /* Allow ISO-TP TX to reach the wire before reset (As timer). */
+        (void)eds_platform_ecu_reset(reset_type);
+        /* Does not return. */
+    }
 }
 
 /* =============================================================================

--- a/examples/sensor_ecu/src/main.c
+++ b/examples/sensor_ecu/src/main.c
@@ -161,6 +161,16 @@ static void on_isotp_rx_complete(const uint8_t *data, uint32_t length, void *arg
     } else if (status != UDS_STATUS_OK) {
         LOG_ERR("UDS error 0x%02X, no response.", (unsigned)status);
     }
+
+    /* [P2-0x11-01] Deferred reset: response is on the wire, now reset. */
+    if (srv->pending_reset_type != (uint8_t)0U) {
+        uint8_t reset_type = srv->pending_reset_type;
+        srv->pending_reset_type = (uint8_t)0U;
+        (void)zephyr_port_nvm_flush();
+        k_msleep(50);  /* Allow ISO-TP TX to reach the wire before reset (As timer). */
+        (void)zephyr_port_ecu_reset(reset_type);
+        /* Does not return. */
+    }
 }
 
 /* ---------------------------------------------------------------------------

--- a/examples/sensor_ecu_freertos/src/main.c
+++ b/examples/sensor_ecu_freertos/src/main.c
@@ -124,6 +124,16 @@ static void on_isotp_rx_complete(
     if (s_resp_buf.length > (uint16_t)0U) {
         (void)isotp_transmit(tp, s_resp_buf.data, s_resp_buf.length);
     }
+
+    /* [P2-0x11-01] Deferred reset: response is on the wire, now reset. */
+    if (srv->pending_reset_type != (uint8_t)0U) {
+        uint8_t reset_type = srv->pending_reset_type;
+        srv->pending_reset_type = (uint8_t)0U;
+        (void)eds_platform_nvm_flush();
+        vTaskDelay(pdMS_TO_TICKS(50));  /* Allow ISO-TP TX to reach the wire before reset (As timer). */
+        (void)eds_platform_ecu_reset(reset_type);
+        /* Does not return. */
+    }
 }
 
 /* =============================================================================


### PR DESCRIPTION
## Root cause

All 8 example `on_isotp_rx_complete()` callbacks called `uds_server_process_request()` and `isotp_transmit()` but never checked `ctx->pending_reset_type` afterward. The `0x11` handler correctly sets this field and returns — it is the integration layer's responsibility to act on it. None of the examples did.

Result: the ECU sent the positive response for `0x11 01` but never reset. Tester tools (CANalyzer, CANoe) that wait for the ECU to go offline after `0x11` would time out, leaving subsequent services in a failed state.

## Fix

After `isotp_transmit()` in each `on_isotp_rx_complete()`:

```c
if (srv->pending_reset_type != (uint8_t)0U) {
    uint8_t reset_type = srv->pending_reset_type;
    srv->pending_reset_type = (uint8_t)0U;
    (void)zephyr_port_nvm_flush();
    k_msleep(50);  /* Allow ISO-TP TX to reach the wire (As timer) */
    (void)zephyr_port_ecu_reset(reset_type);
    /* Does not return. */
}
```

FreeRTOS examples use `eds_platform_nvm_flush()` / `eds_platform_ecu_reset()` / `vTaskDelay(pdMS_TO_TICKS(50))`.

The 50 ms delay gives the CAN frame time to reach the wire before `sys_reboot()` / `portNVIC_SystemReset()` is called (ISO 14229-1 As timer requirement).

## Files changed

| Example | RTOS |
|---|---|
| `examples/basic_ecu/src/main.c` | Zephyr |
| `examples/sensor_ecu/src/main.c` | Zephyr |
| `examples/bms_ecu/src/main.c` | Zephyr |
| `examples/ardep_ecu/src/main.c` | Zephyr |
| `examples/safeboot_ecu/src/main.c` | Zephyr |
| `examples/robot_joint_controller_ecu/src/main.c` | Zephyr |
| `examples/sensor_ecu_freertos/src/main.c` | FreeRTOS |
| `examples/safeboot_freertos_ecu/src/main.c` | FreeRTOS |

Closes #37.