### PR TITLE
feat: SID 0x35 RequestUpload — ECU-to-tester data transfer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 # Community tier CI pipeline — 8 jobs covering the public GPL runtime stack.
 #
 # Jobs:
-#   1. unit-tests           — 37 host-side C unit tests (Unity framework)
+#   1. unit-tests           — 38 host-side C unit tests (Unity framework)
 #   2. integration-tests    — pytest suite against basic_ecu generated output (simulator mode)
 #   3. static-analysis      — GCC -fanalyzer + MISRA C:2012 cppcheck (zero open violations)
 #   4. zephyr-native        — west build -b native_sim (basic_ecu, Zephyr v3.7)
@@ -245,7 +245,7 @@ jobs:
 
   # ── Job 1: Host unit tests ─────────────────────────────────────────────────
   unit-tests:
-    name: "Unit Tests (37 modules)"
+    name: "Unit Tests (38 modules)"
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -274,8 +274,8 @@ jobs:
         run: |
           result=$(bash build_tests.sh 2>&1 | tail -3)
           echo "$result"
-          echo "$result" | grep -q "37 passed, 0 failed" || \
-            (echo "ERROR: Expected '37 passed, 0 failed'" && exit 1)
+          echo "$result" | grep -q "38 passed, 0 failed" || \
+            (echo "ERROR: Expected '38 passed, 0 failed'" && exit 1)
 
       - name: Verify pre-committed test files present
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **SID 0x35 RequestUpload** — ECU-to-tester data readback over the existing 0x36/0x37 transfer state machine. Symmetric counterpart to 0x34 RequestDownload. Supports calibration data readback, NVM log extraction, and flash image verification readout. Requires Programming session + Level 1 security unlock. `read_cb = NULL` is backward-compatible and returns NRC 0x22. Closes #46.
+
 - `extras/wireshark/eds.lua`: Wireshark Lua dissector — UDS service decode (all 14 SIDs), full NRC table, ISO-TP PCI frame types, DoIP payload types (0x0005–0x0008, 0x8001–0x8003) — closes #44
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Bug reports, documentation improvements, and issue comments never require a CLA.
 - Changes that remove or weaken any step of the 5-step ASIL-B safety wrapper chain
 - Dynamic memory allocation (`malloc`, `free`) anywhere in the stack
 - Recursion in any safety-critical module
-- Changes that break the `native_sim` CI build or cause any of the 37 unit tests to fail
+- Changes that break the `native_sim` CI build or cause any of the 38 unit tests to fail
 - Hand-written changes to files under `generated/` — these are codegen output;
   fix the template in `tools/templates/` instead
 - External runtime dependencies not already present in the stack
@@ -126,7 +126,7 @@ python3 tools/codegen.py \
   --out generated/ \
   --safety-wrappers --asil-level B --test-gen
 
-# All 37 unit tests must pass
+# All 38 unit tests must pass
 bash build_tests.sh
 
 # All 68 harness tests must pass
@@ -148,7 +148,7 @@ any CI job is red.
 - [ ] SPDX header on every new file
 - [ ] Unit test added or updated for the changed module
 - [ ] `generated/` files regenerated and committed if YAML or templates changed
-- [ ] All 37 unit tests pass locally (`bash build_tests.sh`)
+- [ ] All 38 unit tests pass locally (`bash build_tests.sh`)
 - [ ] PR title follows format: `[fix|feat|docs|test|chore]: short description`
 
 ---

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The generator produces: DID handler stubs, ASIL-B safety wrappers, DTC registrat
 
 | Capability | Detail |
 |---|---|
-| **UDS stack** | 14 services: 0x10 0x11 0x14 0x19 0x22 0x27 0x28 0x2E 0x31 0x34 0x36 0x37 0x3E 0x85 · SID 0x19 sub-functions: 0x01 0x02 0x03 0x04 0x06 0x0A 0x0B 0x19 |
+| **UDS stack** | 15 services: 0x10 0x11 0x14 0x19 0x22 0x27 0x28 0x2E 0x31 0x34 0x35 0x36 0x37 0x3E 0x85 · SID 0x19 sub-functions: 0x01 0x02 0x03 0x04 0x06 0x0A 0x0B 0x19 |
 | **ISO-TP transport** | SF / FF / CF / FC · N_As / N_Bs / N_Cr timing · STmin sub-ms range |
 | **DoIP transport** | ISO 13400-2 server — Routing Activation · DiagnosticMessage dispatch · Positive/Negative Ack · Alive Check · Zephyr (zsock_*) and FreeRTOS+LwIP bindings · same UDS core, no code changes |
 | **ASIL-B safety chain** | 5-step DID validation enforced at codegen time — cannot be bypassed at runtime |
@@ -103,7 +103,7 @@ The generator produces: DID handler stubs, ASIL-B safety wrappers, DTC registrat
 | **Code generation** | YAML → 17 Jinja2 templates · CLI · reproducible deterministic output |
 | **Test generation** | YAML → pytest suite per DID and DTC · simulator mode (no hardware) · firmware harness mode |
 | **CANoe CAPL** | YAML → `.can` scripts for CANoe import · per-DID, per-DTC, core services |
-| **SOVD CDA** | `--sovd` flag: YAML → OpenSOVD 1.0 `sovd_cda.json` — DIDs, DTCs, routines, transport, all 14 services · DoIP ECUs include `logicalAddress` and `port` · Eclipse SDV / OEM SOVD clients |
+| **SOVD CDA** | `--sovd` flag: YAML → OpenSOVD 1.0 `sovd_cda.json` — DIDs, DTCs, routines, transport, all 15 services · DoIP ECUs include `logicalAddress` and `port` · Eclipse SDV / OEM SOVD clients |
 | **VS Code extension** | Inline YAML validation · hover docs · one-click codegen · auto-run on save · status bar indicator |
 | **MCP server** | `tools/mcp_server.py` — exposes `generate_did_config`, `run_codegen`, `validate_asil_b`, `explain_uds_error` to Claude, Cursor, and any MCP host. Included with Developer and Professional licenses. |
 | **ECU examples** | basic · basic\_doip · basic\_freertos · basic\_doip\_freertos · BMS · motor controller · ARDEP · sensor · safeboot · robot joint — 5–35 DIDs each, Zephyr and FreeRTOS |

--- a/build_tests.sh
+++ b/build_tests.sh
@@ -174,6 +174,7 @@ STACK_SRCS=(
     #   undefined reference to `uds_service_0x34_handler'
     # [FIX-DFU-SRCS] — root cause of "all tests BUILD_FAIL" regression.
     "${ROOT}/core/uds_services/service_0x34.c"   # RequestDownload
+    "${ROOT}/core/uds_services/service_0x35.c"   # RequestUpload
     "${ROOT}/core/uds_services/service_0x36.c"   # TransferData
     "${ROOT}/core/uds_services/service_0x37.c"   # RequestTransferExit
     "${ROOT}/core/uds_transfer_ctx.c"             # DFU transfer state machine
@@ -228,6 +229,7 @@ TESTS=(
     test_service_0x28
     test_service_0x31
     test_service_0x34
+    test_service_0x35
     test_service_0x36
     test_service_0x37
     test_service_0x3E

--- a/core/uds_access_table.c
+++ b/core/uds_access_table.c
@@ -180,6 +180,19 @@ static const uds_access_entry_t k_default_table[UDS_ACCESS_TABLE_DEFAULT_COUNT] 
         .require_unlocked   = true,
     },
 
+    /* [10b] 0x35 RequestUpload — Programming session + Level 1 security.
+     *
+     *  Upload exposes raw ECU memory content. Treating it as equivalent to
+     *  RequestDownload: requires programming session and security unlock to
+     *  prevent unauthorised memory readout.
+     */
+    {
+        .service_id         = UDS_SID_REQUEST_UPLOAD,
+        .session_mask       = UDS_ACL_SESSION_PROGRAMMING,
+        .required_sec_level = (uint8_t)1U,
+        .require_unlocked   = true,
+    },
+
     /* [11] 0x36 TransferData — Programming session + Level 1 security.
      *
      *  Same access constraints as RequestDownload.  An active transfer

--- a/core/uds_access_table.h
+++ b/core/uds_access_table.h
@@ -173,7 +173,7 @@ typedef struct uds_access_entry {
 /**
  * @brief Number of entries in the built-in default access rights table.
  */
-#define UDS_ACCESS_TABLE_DEFAULT_COUNT  (13U)
+#define UDS_ACCESS_TABLE_DEFAULT_COUNT  (14U)
 
 /* --------------------------------------------------------------------------
  * Public API

--- a/core/uds_services/service_0x35.c
+++ b/core/uds_services/service_0x35.c
@@ -1,58 +1,59 @@
 /*
  * =============================================================================
  * Xaloqi EDS
- * FILE: core/uds_services/service_0x34.c
+ * FILE: core/uds_services/service_0x35.c
  *
- * PURPOSE: SID 0x34 — RequestDownload service handler.
+ * PURPOSE: SID 0x35 — RequestUpload service handler.
  *
- * ISO 14229-1 §14.2: RequestDownload initiates a data transfer from the
- * external test tool (tester) to the ECU.  It is the mandatory first step
- * in a firmware update (DFU) sequence:
+ * ISO 14229-1 §14.5: RequestUpload initiates a data transfer from the ECU
+ * to the external test tool (tester).  It is the symmetric counterpart to
+ * RequestDownload (0x34).  Primary use cases: calibration data readback,
+ * NVM log extraction, flash image verification readout.
  *
- *   1. Erase flash  — SID 0x31 routine 0xFF10 (EraseApplicationFlash)
- *   2. Open session — SID 0x34 RequestDownload         ← THIS FILE
- *   3. Send data    — SID 0x36 TransferData (repeated)
- *   4. Commit       — SID 0x37 RequestTransferExit
- *   5. Verify       — SID 0x31 routine 0xFF11 (VerifyApplicationImage)
- *
- * REQUEST FORMAT (ISO 14229-1 §14.2.2):
- *   [0x34, dataFormatIdentifier, addressAndLengthFormatIdentifier,
+ * REQUEST FORMAT (ISO 14229-1 §14.5.2 — identical field layout to 0x34):
+ *   [0x35, dataFormatIdentifier, addressAndLengthFormatIdentifier,
  *    memoryAddress[0..M], memorySize[0..N]]
  *
  *   dataFormatIdentifier (1 byte):
- *     Bits [7:4] = compressionMethod  (0x0 = uncompressed)
- *     Bits [3:0] = encryptingMethod   (0x0 = unencrypted)
- *     This implementation only accepts 0x00.
+ *     Only 0x00 accepted (uncompressed / unencrypted).
  *
  *   addressAndLengthFormatIdentifier (1 byte):
- *     Bits [7:4] = memorySizeLength  (number of bytes encoding memorySize)
- *     Bits [3:0] = memoryAddressLength (number of bytes encoding memoryAddress)
- *     Both fields must be 1–4.
+ *     Bits [7:4] = memorySizeLength   (1–4)
+ *     Bits [3:0] = memoryAddressLength (1–4)
  *
  *   memoryAddress[0..M]:  big-endian, M = memoryAddressLength bytes.
  *   memorySize[0..N]:     big-endian, N = memorySizeLength bytes.
  *
- * POSITIVE RESPONSE (ISO 14229-1 §14.2.3):
- *   [0x74, lengthFormatIdentifier, maxNumberOfBlockLength[0..K]]
+ * POSITIVE RESPONSE (ISO 14229-1 §14.5.3 — same structure as 0x74):
+ *   [0x75, lengthFormatIdentifier, maxNumberOfBlockLength_Hi, maxNumberOfBlockLength_Lo]
  *
  *   lengthFormatIdentifier:
- *     Bits [7:4] = number of bytes encoding maxNumberOfBlockLength (always 2)
- *     Bits [3:0] = reserved (0x0)
- *   maxNumberOfBlockLength: 16-bit value including the 1-byte block counter.
+ *     Bits [7:4] = 2  (number of bytes encoding maxNumberOfBlockLength)
+ *     Bits [3:0] = 0  (reserved)
+ *   maxNumberOfBlockLength: uint16_t, includes the 1-byte blockSequenceCounter.
+ *
+ * TRANSFER EXCHANGE:
+ *   Tester                           ECU
+ *     0x35 [addr, size]             →
+ *                                   ← 0x75 [LFI=0x20, maxBlock=0x0101]
+ *     0x36 [blockSeq=0x01]          →
+ *                                   ← 0x76 [blockSeq=0x01, data[0..255]]
+ *     0x37                          →
+ *                                   ← 0x77
  *
  * NRC BEHAVIOUR:
  *   NRC 0x13 (incorrectMessageLengthOrInvalidFormat) — request too short
- *   NRC 0x22 (conditionsNotCorrect)                  — no flash ops registered
- *   NRC 0x31 (requestOutOfRange)                     — address/size invalid
- *   NRC 0x70 (uploadDownloadNotAccepted)              — flash erase failed
- *   NRC 0x7F (serviceNotSupportedInActiveSession)     — wrong session
+ *   NRC 0x22 (conditionsNotCorrect)                  — read_cb not registered
+ *   NRC 0x31 (requestOutOfRange)                     — invalid address/size
+ *   NRC 0x7F (serviceNotSupportedInActiveSession)    — wrong session
  *
  * SESSION REQUIREMENT:
  *   Programming session (UDS_SESSION_PROGRAMMING) required.
- *   The default ACL table enforces this.
+ *   Security Level 1 unlock required.  ACL table enforces both.
+ *   Upload exposes raw ECU memory — equivalent access risk to download.
  *
  * SAFETY:
- *   REQ-DL-001: Block counter initialised to 0x01 on successful 0x34.
+ *   REQ-DL-001: Block counter initialised to 0x01 on successful 0x35.
  *   REQ-DL-002: bytes_remaining set to total_size_bytes from request.
  *   REQ-FLASH-002: address + size validated against flash memory map.
  *
@@ -60,6 +61,9 @@
  * SPDX-License-Identifier: GPL-2.0-only
  * =============================================================================
  */
+
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2026 Xaloqi
 
 #include "services.h"
 #include "service_transfer_common.h"
@@ -73,57 +77,52 @@
 #include <string.h>
 
 /* --------------------------------------------------------------------------
- * Constants
+ * Constants — mirror exactly from service_0x34.c with SVC_0x35_ prefix.
  * -------------------------------------------------------------------------- */
 
-/** Minimum request length: [SID, dataFmt, addrLenFmt] = 3 bytes.
- *  Actual minimum depends on addrLenFmt fields — validated dynamically. */
-#define SVC_0x34_MIN_REQ_LEN          (3U)
+/** Minimum request length: [SID, dataFmt, addrLenFmt] = 3 bytes. */
+#define SVC_0x35_MIN_REQ_LEN          (3U)
 
 /** Offset of dataFormatIdentifier in the request PDU. */
-#define SVC_0x34_DATA_FMT_OFFSET      (1U)
+#define SVC_0x35_DATA_FMT_OFFSET      (1U)
 
 /** Offset of addressAndLengthFormatIdentifier in the request PDU. */
-#define SVC_0x34_ALFID_OFFSET         (2U)
+#define SVC_0x35_ALFID_OFFSET         (2U)
 
 /** Offset of the first memoryAddress byte in the request PDU. */
-#define SVC_0x34_MEM_ADDR_OFFSET      (3U)
+#define SVC_0x35_MEM_ADDR_OFFSET      (3U)
 
 /** Only uncompressed / unencrypted data is accepted. */
-#define SVC_0x34_ACCEPTED_DATA_FMT    (0x00U)
+#define SVC_0x35_ACCEPTED_DATA_FMT    (0x00U)
 
 /** Mask for addressLength nibble (bits [3:0]). */
-#define SVC_0x34_ADDR_LEN_MASK        (0x0FU)
+#define SVC_0x35_ADDR_LEN_MASK        (0x0FU)
 
 /** Mask for sizeLength nibble (bits [7:4]) — shift right by 4 after masking. */
-#define SVC_0x34_SIZE_LEN_MASK        (0xF0U)
-#define SVC_0x34_SIZE_LEN_SHIFT       (4U)
+#define SVC_0x35_SIZE_LEN_MASK        (0xF0U)
+#define SVC_0x35_SIZE_LEN_SHIFT       (4U)
 
 /** Maximum allowed value for addressLength and sizeLength fields. */
-#define SVC_0x34_MAX_FIELD_BYTES      (4U)
+#define SVC_0x35_MAX_FIELD_BYTES      (4U)
 
 /** Minimum allowed value (0 means "not present" — rejected). */
-#define SVC_0x34_MIN_FIELD_BYTES      (1U)
+#define SVC_0x35_MIN_FIELD_BYTES      (1U)
 
-/** Number of bytes used to encode maxNumberOfBlockLength in the response
- *  (always 2 bytes: one uint16_t). Stored in bits [7:4] of
- *  lengthFormatIdentifier. */
-#define SVC_0x34_MXBL_BYTE_COUNT      (2U)
-
-/* s_parse_big_endian() and s_validate_memory_range() are shared with
- * service_0x35.c via service_transfer_common.h (static inline). */
+/** Number of bytes used to encode maxNumberOfBlockLength in the response. */
+#define SVC_0x35_MXBL_BYTE_COUNT      (2U)
 
 /* --------------------------------------------------------------------------
- * SID 0x34 handler
+ * SID 0x35 handler
  * -------------------------------------------------------------------------- */
 
 /**
- * @brief SID 0x34 — RequestDownload handler.
+ * @brief SID 0x35 — RequestUpload handler.
  *
- * Validates the request, erases the target flash region, initialises the
- * transfer state machine, and returns maxNumberOfBlockLength.
+ * Validates the request, checks that read_cb is registered, initialises the
+ * transfer state machine in upload direction, and returns maxNumberOfBlockLength.
+ * Does NOT call erase_cb — upload is read-only.
  */
-uds_status_t uds_service_0x34_handler(
+uds_status_t uds_service_0x35_handler(
     uds_server_ctx_t    *ctx,
     const uds_msg_buf_t *req,
     uds_msg_buf_t       *resp)
@@ -144,42 +143,47 @@ uds_status_t uds_service_0x34_handler(
     }
 
     /* Minimum length: [SID, dataFmt, addrLenFmt]. */
-    status = uds_service_validate_length(req, (uint16_t)SVC_0x34_MIN_REQ_LEN);
+    status = uds_service_validate_length(req, (uint16_t)SVC_0x35_MIN_REQ_LEN);
     if (status != UDS_STATUS_OK) {
         return status;
     }
 
-    /* REQ-FLASH-001: Flash ops must be registered. */
+    /* Flash ops must be registered. */
     ops = uds_flash_ops_get();
     if (ops == NULL) {
         /* NRC 0x22 — conditions not correct (flash ops not registered). */
         return UDS_STATUS_ERR_CONDITIONS_NOT_MET;
     }
 
+    /* read_cb must be registered — upload requires flash read capability. */
+    if (ops->read_cb == NULL) {
+        /* NRC 0x22 — conditions not correct (read_cb not populated). */
+        return UDS_STATUS_ERR_CONDITIONS_NOT_MET;
+    }
+
     /* --- Parse dataFormatIdentifier --- */
-    data_fmt = req->data[SVC_0x34_DATA_FMT_OFFSET];
-    if (data_fmt != (uint8_t)SVC_0x34_ACCEPTED_DATA_FMT) {
+    data_fmt = req->data[SVC_0x35_DATA_FMT_OFFSET];
+    if (data_fmt != (uint8_t)SVC_0x35_ACCEPTED_DATA_FMT) {
         /* Compression or encryption requested — not supported. */
         return UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE;
     }
 
     /* --- Parse addressAndLengthFormatIdentifier --- */
-    alfid    = req->data[SVC_0x34_ALFID_OFFSET];
-    addr_len = (uint8_t)( alfid & (uint8_t)SVC_0x34_ADDR_LEN_MASK);
-    size_len = (uint8_t)((alfid & (uint8_t)SVC_0x34_SIZE_LEN_MASK) >>
-                          (uint8_t)SVC_0x34_SIZE_LEN_SHIFT);
+    alfid    = req->data[SVC_0x35_ALFID_OFFSET];
+    addr_len = (uint8_t)( alfid & (uint8_t)SVC_0x35_ADDR_LEN_MASK);
+    size_len = (uint8_t)((alfid & (uint8_t)SVC_0x35_SIZE_LEN_MASK) >>
+                          (uint8_t)SVC_0x35_SIZE_LEN_SHIFT);
 
     /* Both fields must be 1–4 bytes. */
-    if ((addr_len < (uint8_t)SVC_0x34_MIN_FIELD_BYTES) ||
-        (addr_len > (uint8_t)SVC_0x34_MAX_FIELD_BYTES) ||
-        (size_len < (uint8_t)SVC_0x34_MIN_FIELD_BYTES) ||
-        (size_len > (uint8_t)SVC_0x34_MAX_FIELD_BYTES)) {
+    if ((addr_len < (uint8_t)SVC_0x35_MIN_FIELD_BYTES) ||
+        (addr_len > (uint8_t)SVC_0x35_MAX_FIELD_BYTES) ||
+        (size_len < (uint8_t)SVC_0x35_MIN_FIELD_BYTES) ||
+        (size_len > (uint8_t)SVC_0x35_MAX_FIELD_BYTES)) {
         return UDS_STATUS_ERR_INVALID_PARAM;
     }
 
-    /* Check the request is long enough to hold address + size fields.
-     * fields_end = SVC_0x34_MEM_ADDR_OFFSET + addr_len + size_len. */
-    fields_end = (uint16_t)((uint16_t)SVC_0x34_MEM_ADDR_OFFSET +
+    /* Check the request is long enough to hold address + size fields. */
+    fields_end = (uint16_t)((uint16_t)SVC_0x35_MEM_ADDR_OFFSET +
                              (uint16_t)addr_len +
                              (uint16_t)size_len);
 
@@ -189,7 +193,7 @@ uds_status_t uds_service_0x34_handler(
 
     /* --- Parse memoryAddress (big-endian, addr_len bytes) --- */
     status = uds_transfer_parse_be(
-        &req->data[SVC_0x34_MEM_ADDR_OFFSET],
+        &req->data[SVC_0x35_MEM_ADDR_OFFSET],
         addr_len,
         &mem_address);
     if (status != UDS_STATUS_OK) {
@@ -198,7 +202,7 @@ uds_status_t uds_service_0x34_handler(
 
     /* --- Parse memorySize (big-endian, size_len bytes) --- */
     status = uds_transfer_parse_be(
-        &req->data[(uint16_t)SVC_0x34_MEM_ADDR_OFFSET + (uint16_t)addr_len],
+        &req->data[(uint16_t)SVC_0x35_MEM_ADDR_OFFSET + (uint16_t)addr_len],
         size_len,
         &mem_size);
     if (status != UDS_STATUS_OK) {
@@ -211,19 +215,14 @@ uds_status_t uds_service_0x34_handler(
         return UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE;
     }
 
-    /* --- Erase the target flash region --- */
-    status = ops->erase_cb(mem_address, mem_size);
-    if (status != UDS_STATUS_OK) {
-        /* NRC 0x70 — uploadDownloadNotAccepted (erase failure). */
-        return UDS_STATUS_ERR_PLATFORM;
-    }
+    /* Upload does NOT erase flash — read-only access. */
 
-    /* --- Initialise transfer state machine --- */
+    /* --- Initialise transfer state machine (upload direction) --- */
     tctx = uds_transfer_ctx_get();
     uds_transfer_ctx_reset(tctx);   /* abort any in-progress transfer */
 
     tctx->state                   = UDS_TRANSFER_ACTIVE;
-    tctx->direction               = UDS_TRANSFER_DIR_DOWNLOAD;
+    tctx->direction               = UDS_TRANSFER_DIR_UPLOAD;
     tctx->target_address          = mem_address;
     tctx->total_size_bytes        = mem_size;
     tctx->bytes_remaining         = mem_size;
@@ -243,15 +242,14 @@ uds_status_t uds_service_0x34_handler(
     }
 
     /* --- Build positive response --- */
-    /* [0x74, lengthFormatIdentifier, maxNumberOfBlockLength_Hi, maxNumberOfBlockLength_Lo] */
-    status = uds_service_write_pos_sid((uint8_t)UDS_SID_REQUEST_DOWNLOAD, resp);
+    /* [0x75, lengthFormatIdentifier, maxNumberOfBlockLength_Hi, maxNumberOfBlockLength_Lo] */
+    status = uds_service_write_pos_sid((uint8_t)UDS_SID_REQUEST_UPLOAD, resp);
     if (status != UDS_STATUS_OK) {
         return status;
     }
 
-    /* lengthFormatIdentifier: bits [7:4] = number of maxBlockLen bytes = 2,
-     * bits [3:0] = 0 (reserved). */
-    resp->data[1U] = (uint8_t)((uint8_t)SVC_0x34_MXBL_BYTE_COUNT << (uint8_t)4U);
+    /* lengthFormatIdentifier: bits [7:4] = 2 (2 bytes for maxBlockLen), [3:0] = 0. */
+    resp->data[1U] = (uint8_t)((uint8_t)SVC_0x35_MXBL_BYTE_COUNT << (uint8_t)4U);
 
     /* maxNumberOfBlockLength includes the 1-byte block counter field. */
     {

--- a/core/uds_services/service_0x36.c
+++ b/core/uds_services/service_0x36.c
@@ -73,8 +73,11 @@
  * Constants
  * -------------------------------------------------------------------------- */
 
-/** Minimum request: [SID, blockSeqCounter, ≥1 data byte] = 3 bytes. */
+/** Minimum request: [SID, blockSeqCounter, ≥1 data byte] = 3 bytes (download direction). */
 #define SVC_0x36_MIN_REQ_LEN          (3U)
+
+/** Minimum upload request: [SID, blockSeqCounter] = 2 bytes (no payload from tester). */
+#define SVC_0x36_UL_MIN_REQ_LEN       (2U)
 
 /** Offset of blockSequenceCounter in the request PDU. */
 #define SVC_0x36_BLOCK_SEQ_OFFSET     (1U)
@@ -90,6 +93,15 @@
 
 /** Value to which the counter wraps after reaching MAX (REQ-DL-001). */
 #define SVC_0x36_WRAP_BLOCK_SEQ       (0x01U)
+
+/* --------------------------------------------------------------------------
+ * Forward declaration
+ * -------------------------------------------------------------------------- */
+
+static uds_status_t s_handle_upload_block(
+    uds_server_ctx_t    *ctx,
+    const uds_msg_buf_t *req,
+    uds_msg_buf_t       *resp);
 
 /* --------------------------------------------------------------------------
  * Static helpers
@@ -155,28 +167,43 @@ uds_status_t uds_service_0x36_handler(
     uint16_t               src_offset;
     uint16_t               space_in_buf;
     uint16_t               chunk;
+    uint16_t               min_len;
 
     if (ctx == NULL) {
         return UDS_STATUS_ERR_NULL_PTR;
     }
 
-    /* Minimum length: [SID, blockSeq, ≥1 payload byte]. */
-    status = uds_service_validate_length(req, (uint16_t)SVC_0x36_MIN_REQ_LEN);
+    tctx = uds_transfer_ctx_get();
+
+    /* Upload requests carry no payload from the tester — minimum is 2 bytes.
+     * Download requests require at least 1 payload byte — minimum is 3 bytes. */
+    if ((tctx->state == UDS_TRANSFER_ACTIVE) &&
+        (tctx->direction == UDS_TRANSFER_DIR_UPLOAD)) {
+        min_len = (uint16_t)SVC_0x36_UL_MIN_REQ_LEN;
+    } else {
+        min_len = (uint16_t)SVC_0x36_MIN_REQ_LEN;
+    }
+
+    status = uds_service_validate_length(req, min_len);
     if (status != UDS_STATUS_OK) {
         return status;
     }
 
     /* REQ-DL-SEQ: A transfer must be active. */
-    tctx = uds_transfer_ctx_get();
     if (tctx->state != UDS_TRANSFER_ACTIVE) {
-        /* NRC 0x24 requestSequenceError — no active download session. */
+        /* NRC 0x24 requestSequenceError — no active transfer session. */
         return UDS_STATUS_ERR_SERVICE_NOT_SUPPORTED_IN_SESSION;
     }
 
     ops = uds_flash_ops_get();
     if (ops == NULL) {
-        /* Flash ops de-registered after 0x34 was accepted — should not happen. */
+        /* Flash ops de-registered after 0x34/0x35 was accepted — should not happen. */
         return UDS_STATUS_ERR_CONDITIONS_NOT_MET;
+    }
+
+    /* Dispatch to upload path if an upload session is active. */
+    if (tctx->direction == UDS_TRANSFER_DIR_UPLOAD) {
+        return s_handle_upload_block(ctx, req, resp);
     }
 
     /* --- Validate block sequence counter --- */
@@ -253,6 +280,93 @@ uds_status_t uds_service_0x36_handler(
 
     resp->data[1U] = block_seq;
     resp->length   = (uint16_t)2U;
+
+    return UDS_STATUS_OK;
+}
+
+/* --------------------------------------------------------------------------
+ * Upload block handler (SID 0x35 direction)
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @brief Handle one TransferData block in upload direction.
+ *
+ * The tester sends [0x36, blockSeqCounter] with no payload data; the ECU
+ * reads the next chunk from flash via read_cb and returns it in the response.
+ *
+ * write_buf is reused as the read buffer — the field name is misleading in
+ * the upload direction but renaming it would break 0x34/0x36 tests.
+ *
+ * @param[in]  ctx   Server context (validated by caller).
+ * @param[in]  req   Upload request buffer.
+ * @param[out] resp  Response buffer to populate.
+ *
+ * @return UDS_STATUS_OK on success.
+ * @return UDS_STATUS_ERR_TP_UNEXPECTED_PDU on block sequence counter error.
+ * @return UDS_STATUS_ERR_PLATFORM on read_cb failure.
+ */
+static uds_status_t s_handle_upload_block(
+    uds_server_ctx_t    *ctx,
+    const uds_msg_buf_t *req,
+    uds_msg_buf_t       *resp)
+{
+    uds_status_t           status;
+    uint8_t                block_seq;
+    uint32_t               bytes_to_read;
+    const uds_flash_ops_t *ops;
+    uds_transfer_ctx_t    *tctx;
+
+    (void)ctx; /* validated by caller — not needed in upload path */
+
+    tctx = uds_transfer_ctx_get();
+    ops  = uds_flash_ops_get();
+
+    /* --- Validate block sequence counter (same logic as download) --- */
+    block_seq = req->data[SVC_0x36_BLOCK_SEQ_OFFSET];
+
+    if (block_seq == (uint8_t)SVC_0x36_INVALID_BLOCK_SEQ) {
+        return UDS_STATUS_ERR_TP_UNEXPECTED_PDU; /* mapped → NRC 0x73 */
+    }
+
+    if (block_seq != tctx->next_expected_block_seq) {
+        return UDS_STATUS_ERR_TP_UNEXPECTED_PDU; /* mapped → NRC 0x73 */
+    }
+
+    /* --- Determine how many bytes to read this block --- */
+    bytes_to_read = (uint32_t)tctx->write_buf_capacity;
+    if (bytes_to_read > tctx->bytes_remaining) {
+        bytes_to_read = tctx->bytes_remaining;
+    }
+
+    /* --- Read from flash into write_buf (doubles as read buffer for upload) --- */
+    status = ops->read_cb(tctx->next_write_address,
+                          tctx->write_buf,
+                          bytes_to_read);
+    if (status != UDS_STATUS_OK) {
+        uds_transfer_ctx_reset(tctx); /* abort on failure */
+        return UDS_STATUS_ERR_PLATFORM;
+    }
+
+    /* Advance read address and decrement remaining. */
+    tctx->next_write_address += bytes_to_read;
+    tctx->bytes_remaining    -= bytes_to_read;
+
+    /* --- Advance block counter with wrap (REQ-DL-001 applies to upload too) --- */
+    if (tctx->next_expected_block_seq == (uint8_t)SVC_0x36_MAX_BLOCK_SEQ) {
+        tctx->next_expected_block_seq = (uint8_t)SVC_0x36_WRAP_BLOCK_SEQ;
+    } else {
+        tctx->next_expected_block_seq++;
+    }
+
+    /* --- Build positive response: [0x76, blockSeqCounter, data...] --- */
+    status = uds_service_write_pos_sid((uint8_t)UDS_SID_TRANSFER_DATA, resp);
+    if (status != UDS_STATUS_OK) {
+        return status;
+    }
+
+    resp->data[1U] = block_seq;
+    (void)memcpy(&resp->data[2U], tctx->write_buf, (size_t)bytes_to_read);
+    resp->length = (uint16_t)(2U + (uint16_t)bytes_to_read);
 
     return UDS_STATUS_OK;
 }

--- a/core/uds_services/service_registration.c
+++ b/core/uds_services/service_registration.c
@@ -273,6 +273,25 @@ const uds_service_entry_t g_uds_service_table[UDS_SERVICE_TABLE_COUNT] = {
         .suppress_pos_response_supported = false,
     },
     {
+        /* SID 0x35 — RequestUpload
+         *
+         * Opens an upload session for ECU-to-tester data readback.
+         * Validates target memory range, checks read_cb is registered, and
+         * initialises the transfer state machine in upload direction.
+         * Does NOT erase flash — upload is read-only.
+         *
+         * SESSION:  Programming session required.
+         * SECURITY: Level 1 security unlock required.
+         *
+         * SAFETY: Upload exposes raw ECU memory content. Same access gates
+         *         as RequestDownload.  suppressPosRspMsgIndicationBit not
+         *         applicable — no sub-function byte.
+         */
+        .service_id                      = UDS_SID_REQUEST_UPLOAD,
+        .handler                         = uds_service_0x35_handler,
+        .suppress_pos_response_supported = false,
+    },
+    {
         /* SID 0x36 — TransferData
          *
          * Carries firmware image blocks from the tester to ECU flash.

--- a/core/uds_services/service_transfer_common.h
+++ b/core/uds_services/service_transfer_common.h
@@ -1,0 +1,121 @@
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: core/uds_services/service_transfer_common.h
+ *
+ * PURPOSE: Shared static-inline helpers for SID 0x34 and 0x35 request parsing.
+ *
+ * Included by service_0x34.c (RequestDownload) and service_0x35.c
+ * (RequestUpload).  Both services parse identical PDU layouts for
+ * addressAndLengthFormatIdentifier, memoryAddress, and memorySize fields.
+ *
+ * Declaring the helpers as static inline avoids a separate translation unit
+ * and keeps the functions close to their callers without duplication.
+ *
+ * STANDARD: MISRA C:2012 alignment intended.
+ * SPDX-License-Identifier: GPL-2.0-only
+ * =============================================================================
+ */
+
+#ifndef UDS_SERVICE_TRANSFER_COMMON_H
+#define UDS_SERVICE_TRANSFER_COMMON_H
+
+#include "uds_types.h"
+#include "uds_flash_ops.h"
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Maximum number of bytes in a memoryAddress or memorySize field (ISO 14229-1). */
+#define UDS_TRANSFER_MAX_FIELD_BYTES  (4U)
+
+/**
+ * @brief Parse a big-endian unsigned integer of 1–4 bytes from a buffer.
+ *
+ * @param[in]  buf   Pointer to the first byte.
+ * @param[in]  n     Number of bytes (1–4).
+ * @param[out] out   Parsed value.
+ *
+ * @return UDS_STATUS_OK on success.
+ * @return UDS_STATUS_ERR_INVALID_PARAM if n > 4.
+ */
+static inline uds_status_t uds_transfer_parse_be(
+    const uint8_t *buf,
+    uint8_t        n,
+    uint32_t      *out)
+{
+    uint32_t val = (uint32_t)0U;
+    uint8_t  i;
+
+    if (n > (uint8_t)UDS_TRANSFER_MAX_FIELD_BYTES) {
+        return UDS_STATUS_ERR_INVALID_PARAM;
+    }
+
+    for (i = (uint8_t)0U; i < n; i++) {
+        val = (val << (uint32_t)8U) | (uint32_t)buf[i];
+    }
+
+    *out = val;
+    return UDS_STATUS_OK;
+}
+
+/**
+ * @brief Validate address + size against the registered flash memory map.
+ *
+ * REQ-FLASH-002.
+ *
+ * @param[in] ops      Registered flash ops table (not NULL).
+ * @param[in] address  Start address of the requested region.
+ * @param[in] size     Size in bytes of the requested region.
+ *
+ * @return UDS_STATUS_OK if the range lies within a writable region.
+ * @return UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE otherwise.
+ */
+static inline uds_status_t uds_transfer_validate_memory_range(
+    const uds_flash_ops_t *ops,
+    uint32_t               address,
+    uint32_t               size)
+{
+    uint8_t  i;
+    uint32_t req_end;
+    uint32_t region_end;
+
+    if (size == (uint32_t)0U) {
+        return UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE;
+    }
+
+    if (address > ((uint32_t)0xFFFFFFFFUL - size)) {
+        return UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE;
+    }
+
+    req_end = address + size;
+
+    for (i = (uint8_t)0U; i < ops->region_count; i++) {
+        const uds_flash_region_t *r = &ops->memory_map[i];
+
+        if (!r->writable) {
+            continue;
+        }
+
+        if (r->base_address > ((uint32_t)0xFFFFFFFFUL - r->size_bytes)) {
+            continue;
+        }
+
+        region_end = r->base_address + r->size_bytes;
+
+        if ((address >= r->base_address) && (req_end <= region_end)) {
+            return UDS_STATUS_OK;
+        }
+    }
+
+    return UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UDS_SERVICE_TRANSFER_COMMON_H */

--- a/core/uds_services/services.h
+++ b/core/uds_services/services.h
@@ -204,6 +204,25 @@ uds_status_t uds_service_0x34_handler(
 );
 
 /**
+ * @brief Handler for SID 0x35 — RequestUpload.
+ *
+ * Opens an upload transfer session for ECU-to-tester data readback.
+ * Validates dataFormatIdentifier, parses addressAndLengthFormatIdentifier,
+ * validates the target memory range, checks that read_cb is registered, and
+ * initialises the transfer state machine in upload direction.
+ * Does NOT call erase_cb — upload is read-only.
+ *
+ * SESSION:  Programming session required.
+ * SECURITY: Level 1 unlock required (enforced by ACL table).
+ *           Upload exposes raw ECU memory — same access risk as download.
+ */
+uds_status_t uds_service_0x35_handler(
+    uds_server_ctx_t    *ctx,
+    const uds_msg_buf_t *req,
+    uds_msg_buf_t       *resp
+);
+
+/**
  * @brief Handler for SID 0x36 — TransferData.
  *
  * Receives firmware image blocks from the tester.  Validates the block
@@ -249,7 +268,7 @@ uds_status_t uds_service_0x37_handler(
 /**
  * @brief Number of services registered in g_uds_service_table[].
  */
-#define UDS_SERVICE_TABLE_COUNT (14U)
+#define UDS_SERVICE_TABLE_COUNT (15U)
 
 /**
  * @brief Canonical UDS service registration table.

--- a/core/uds_transfer_ctx.c
+++ b/core/uds_transfer_ctx.c
@@ -114,7 +114,8 @@ void uds_transfer_ctx_reset(uds_transfer_ctx_t *ctx)
         return;
     }
     (void)memset(ctx, 0, sizeof(uds_transfer_ctx_t));
-    ctx->state = UDS_TRANSFER_IDLE;
+    ctx->state     = UDS_TRANSFER_IDLE;
+    ctx->direction = UDS_TRANSFER_DIR_DOWNLOAD; /* safe default — set by 0x34 or 0x35 */
     /* CRC accumulator initialised to 0xFFFFFFFF on each new transfer,
      * not at reset — see service_0x34.c. */
 }

--- a/core/uds_transfer_ctx.h
+++ b/core/uds_transfer_ctx.h
@@ -65,6 +65,22 @@ typedef enum uds_transfer_state {
 } uds_transfer_state_t;
 
 /* --------------------------------------------------------------------------
+ * Transfer direction enumeration
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @brief Direction of the active transfer session.
+ *
+ * Set by service_0x34 (download) or service_0x35 (upload) when the transfer
+ * context is initialised.  Read by service_0x36 to select the correct data
+ * path (write to flash vs. read from flash).
+ */
+typedef enum uds_transfer_direction {
+    UDS_TRANSFER_DIR_DOWNLOAD = 0x00U, /**< 0x34 → 0x36 → 0x37: tester writes to ECU. */
+    UDS_TRANSFER_DIR_UPLOAD   = 0x01U  /**< 0x35 → 0x36 → 0x37: ECU reads to tester.  */
+} uds_transfer_direction_t;
+
+/* --------------------------------------------------------------------------
  * Transfer context
  * -------------------------------------------------------------------------- */
 
@@ -75,7 +91,8 @@ typedef enum uds_transfer_state {
  * Access via uds_transfer_ctx_get() only.
  */
 typedef struct uds_transfer_ctx {
-    uds_transfer_state_t state;             /**< Current state machine state.   */
+    uds_transfer_state_t     state;         /**< Current state machine state.   */
+    uds_transfer_direction_t direction;     /**< Transfer direction, set by 0x34 or 0x35. */
 
     uint32_t  target_address;               /**< Base address for this download. */
     uint32_t  total_size_bytes;             /**< Total image size from 0x34.     */

--- a/core/uds_types.h
+++ b/core/uds_types.h
@@ -221,6 +221,7 @@ typedef enum uds_nrc {
 #define UDS_SID_COMMUNICATION_CONTROL         (0x28U)
 #define UDS_SID_ROUTINE_CONTROL               (0x31U)
 #define UDS_SID_REQUEST_DOWNLOAD              (0x34U)
+#define UDS_SID_REQUEST_UPLOAD                (0x35U)
 #define UDS_SID_TRANSFER_DATA                 (0x36U)
 #define UDS_SID_REQUEST_TRANSFER_EXIT         (0x37U)
 #define UDS_SID_TESTER_PRESENT                (0x3EU)

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -721,7 +721,8 @@ safeboot:
 
 After codegen, `uds_init.c` automatically includes and calls the platform flash ops init
 (`zephyr_flash_ops_init()` for Zephyr, `freertos_flash_ops_init()` for FreeRTOS).
-Services 0x34/0x36/0x37 become functional in the programming session with security level 1.
+Services 0x34/0x35/0x36/0x37 become functional in the programming session with security level 1.
+0x35 RequestUpload additionally requires `read_cb` to be registered in `uds_flash_ops_t`; if NULL, returns NRC 0x22.
 
 ---
 
@@ -783,7 +784,8 @@ UDS tester to unlock level 2: send `27 03` → receive seed → compute AES-128-
 | WriteDataByIdentifier | 0x2E | ✅ | Full ASIL-B wrapper chain |
 | RoutineControl | 0x31 | ✅ | Start / Stop / RequestResult |
 | RequestDownload | 0x34 | ✅ | Programming session + security level 1 required |
-| TransferData | 0x36 | ✅ | Block transfer; CRC-32 verified at exit |
+| RequestUpload | 0x35 | ✅ | ECU-to-tester readback; read_cb required; same session/security gates as 0x34 |
+| TransferData | 0x36 | ✅ | Block transfer (download or upload); CRC-32 verified at exit |
 | RequestTransferExit | 0x37 | ✅ | Verifies CRC, accepts MCUboot image |
 | TesterPresent | 0x3E | ✅ | Keep-alive; responseRequired sub-fn only |
 | ControlDTCSetting | 0x85 | ✅ | DTCSettingOn / DTCSettingOff |
@@ -844,7 +846,7 @@ pytest test_robustness_A_codegen.py \
 | Phase | Tests | What it covers |
 |---|---|---|
 | A | 22 | Generated file presence, C safety markers, GCC syntax |
-| B | 42 | Session transitions, TesterPresent, ECUReset, all 14 service NRCs |
+| B | 42 | Session transitions, TesterPresent, ECUReset, all 15 service NRCs |
 | C | 21 | CMAC SecurityAccess unlock/lockout/replay |
 | D | 30 | Customer workflow (fresh YAML → codegen → pytest), all 11 ECU examples |
 | E | 35 | DID read/write integrity, DTC lifecycle, session isolation |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -121,6 +121,8 @@ embedded-diagnostics-suite/
 │       ├── service_0x2e.c      # WriteDataByIdentifier
 │       ├── service_0x31.c      # RoutineControl
 │       ├── service_0x34.c      # RequestDownload
+│       ├── service_0x35.c      # RequestUpload
+│       ├── service_transfer_common.h  # Shared parse/validate helpers (0x34+0x35)
 │       ├── service_0x36.c      # TransferData
 │       ├── service_0x37.c      # RequestTransferExit
 │       ├── service_0x3e.c      # TesterPresent
@@ -241,6 +243,7 @@ looks up the SID in the dispatch table, and calls the corresponding service hand
 | 0x2E | WriteDataByIdentifier |
 | 0x31 | RoutineControl |
 | 0x34 | RequestDownload |
+| 0x35 | RequestUpload |
 | 0x36 | TransferData |
 | 0x37 | RequestTransferExit |
 | 0x3E | TesterPresent |

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -46,7 +46,8 @@ The following table covers every service defined in ISO 14229-1:2020. "Implement
 | 0x31 | RoutineControl | **Implemented** | Sub-fn 0x01 startRoutine, 0x02 stopRoutine (optional per routine descriptor), 0x03 requestRoutineResults (optional). Session and security level enforced per-routine via `routine_entry_t.min_session` and `.security_level`. Routine option record forwarded to callback. Status record (0–64 bytes) appended to positive response. suppressPosRspMsgIndicationBit (bit 7) honoured (v1.7.0). |
 | 0x34 | RequestDownload | **Implemented** | Programming session + Level 1 security required (enforced by ACL table). Validates `dataFormatIdentifier` (0x00 only — no compression/encryption), parses `addressAndLengthFormatIdentifier` (1–4 byte address and size fields), validates target address range against the registered flash memory map (`uds_flash_ops_t`), erases flash, and initialises the block-transfer state machine. Returns `maxNumberOfBlockLength`. **Requires** `uds_flash_ops_register()` before the first 0x34 request (see Step 5 integration note). |
 | 0x36 | TransferData | **Implemented** | Programming session required. Validates block sequence counter (starts at 0x01, wraps 0xFF → 0x01 per REQ-DL-001 — counter 0x00 always rejected with NRC 0x73). Accumulates payload bytes in a write buffer, flushes full chunks to flash via `flash_write_cb`, and maintains a running CRC-32 accumulator. |
-| 0x37 | RequestTransferExit | **Implemented** | Programming session required. Flushes any remaining write-buffer bytes, optionally validates an optional 4-byte CRC-32 `transferRequestParameterRecord` (NRC 0x72 on mismatch), invokes `flash_verify_cb`, and resets the transfer state machine to IDLE. Enforces `bytes_remaining == 0` before accepting exit (NRC 0x31 if incomplete). |
+| 0x35 | RequestUpload | **Implemented** | Programming session + Level 1 security required (same gates as 0x34). ECU-to-tester data readback. Validates address range, requires `read_cb` registered in `uds_flash_ops_t` (NRC 0x22 if NULL — backward-compatible). Initialises the transfer state machine in upload direction. No flash erase. Block data returned in 0x36 responses. |
+| 0x36 | TransferData | **Implemented** | Programming session required. Direction-aware: in download mode accumulates payload into flash via `flash_write_cb`; in upload mode reads memory via `read_cb` and returns data in the response. Validates block sequence counter (starts at 0x01, wraps 0xFF → 0x01 per REQ-DL-001). Maintains a running CRC-32 accumulator (download only). |
 | 0x38 | RequestFileTransfer | **Out of scope** | — |
 | 0x3D | WriteMemoryByAddress | **Out of scope** | — |
 | 0x3E | TesterPresent | **Implemented** | Sub-fn 0x00 only (bits 6:0 must be 0x00). suppressPosRspMsgIndicationBit (bit 7) honoured. Resets S3Server session timeout. |
@@ -298,6 +299,7 @@ target_sources(app PRIVATE
     ${EDS_ROOT}/core/uds_services/service_0x2E.c
     ${EDS_ROOT}/core/uds_services/service_0x31.c
     ${EDS_ROOT}/core/uds_services/service_0x34.c
+    ${EDS_ROOT}/core/uds_services/service_0x35.c
     ${EDS_ROOT}/core/uds_services/service_0x36.c
     ${EDS_ROOT}/core/uds_services/service_0x37.c
     ${EDS_ROOT}/core/uds_services/service_0x3E.c

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -130,7 +130,8 @@ bash scripts/build_tests.sh
 | `test_service_0x2e.c` | Valid DID write, write without security → NRC 0x33, wrong length → NRC 0x13 |
 | `test_service_0x31.c` | Routine start, stop, request result, unknown routine ID |
 | `test_service_0x34.c` | Download request in programming session, rejected in default |
-| `test_service_0x36.c` | Valid block transfer, wrong block sequence counter → NRC 0x73 |
+| `test_service_0x35.c` | Upload request: valid readback, read_cb=NULL → NRC 0x22, address range, direction set |
+| `test_service_0x36.c` | Valid block transfer (download + upload), wrong block sequence counter → NRC 0x73 |
 | `test_service_0x37.c` | Transfer exit, exit without prior download |
 | `test_service_0x3d.c` | File transfer request, unsupported mode |
 | `test_service_0x3e.c` | Tester present with/without response, suppress positive response bit |
@@ -477,7 +478,7 @@ across unit, harness, and integration layers:
 - Buffer overflow attempts (request length > static buffer size)
 - Invalid session transitions (programming → default without reset)
 - Security bypass attempts (send key without prior seed request)
-- DID access in wrong session (all 14 services × 3 sessions)
+- DID access in wrong session (all 15 services × 3 sessions)
 - Rapid repeated SecurityAccess failures (verify lockout delay enforced)
 - DoIP DiagnosticMessage before Routing Activation (→ NACK 0x02)
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -14,7 +14,7 @@ scripts ready to use immediately. Transport — CAN/ISO-TP or Ethernet/DoIP — 
 YAML choice. The same UDS core, safety chain, and codegen pipeline serve both transports.
 
 EDS implements:
-- ISO 14229 (UDS): 14 service handlers (0x10 0x11 0x14 0x19 0x22 0x27 0x28 0x2E 0x31 0x34 0x36 0x37 0x3E 0x85)
+- ISO 14229 (UDS): 15 service handlers (0x10 0x11 0x14 0x19 0x22 0x27 0x28 0x2E 0x31 0x34 0x35 0x36 0x37 0x3E 0x85)
 - ISO 15765-2 (ISO-TP): SF/FF/CF/FC, N_As/N_Bs/N_Cr timers, STmin, Flow Control
 - ISO 13400-2 (DoIP): ECU server — Routing Activation, DiagnosticMessage dispatch, Positive/Negative Ack, Alive Check; Zephyr (zsock_*) and FreeRTOS+LwIP bindings (v1.6.0)
 - ASIL-B safety wrapper chain: 5-step mandatory validation on every DID access
@@ -158,7 +158,8 @@ Every DID access passes 5 mandatory steps (generated, cannot be bypassed at runt
 0x2E WriteDataByIdentifier     — ASIL-B safety chain enforced
 0x31 RoutineControl            — Start / Stop / RequestResults
 0x34 RequestDownload           — programming session + SecurityAccess required
-0x36 TransferData              — CRC-32 accumulator
+0x35 RequestUpload             — ECU-to-tester data readback; read_cb required; programming session + SecurityAccess
+0x36 TransferData              — CRC-32 accumulator; direction-aware (download or upload)
 0x37 RequestTransferExit       — optional CRC-32 validation
 0x3E TesterPresent             — S3Server timeout reset
 0x85 ControlDTCSetting         — DTCSettingOn / DTCSettingOff
@@ -194,7 +195,7 @@ pytest tests/test_doip_integration.py -v --timeout=60
 
 ## Repository Structure
 
-core/               UDS server, session FSM, security, safety chain, 14 service handlers
+core/               UDS server, session FSM, security, safety chain, 15 service handlers
 transport/          ISO-TP state machine, CAN transport abstraction
   doip/             DoIP ECU server (ISO 13400-2) — Zephyr and FreeRTOS+LwIP bindings (v1.6.0)
 config/             DID database, DTC database, NVM DTC mirror

--- a/examples/ardep_ecu/CMakeLists.txt
+++ b/examples/ardep_ecu/CMakeLists.txt
@@ -163,6 +163,7 @@ target_sources(app PRIVATE
     # service_registration.c references all three in g_uds_service_table[];
     # omitting these causes link failure: undefined reference to uds_service_0x34_handler.
     ${DIAG_ROOT}/core/uds_services/service_0x34.c   # RequestDownload
+    ${DIAG_ROOT}/core/uds_services/service_0x35.c   # RequestUpload
     ${DIAG_ROOT}/core/uds_services/service_0x36.c   # TransferData
     ${DIAG_ROOT}/core/uds_services/service_0x37.c   # RequestTransferExit
     ${DIAG_ROOT}/core/uds_transfer_ctx.c             # DFU transfer state machine

--- a/examples/basic_ecu/CMakeLists.txt
+++ b/examples/basic_ecu/CMakeLists.txt
@@ -285,6 +285,7 @@ target_sources(app PRIVATE
     #   undefined reference to `uds_flash_ops_register'
     ${DIAG_ROOT}/core/uds_aes_cmac.c                    # AES-128-CMAC primitive (security + DFU)
     ${DIAG_ROOT}/core/uds_services/service_0x34.c       # RequestDownload
+    ${DIAG_ROOT}/core/uds_services/service_0x35.c       # RequestUpload
     ${DIAG_ROOT}/core/uds_services/service_0x36.c       # TransferData
     ${DIAG_ROOT}/core/uds_services/service_0x37.c       # RequestTransferExit
     ${DIAG_ROOT}/core/uds_transfer_ctx.c                # DFU transfer state machine + CRC-32

--- a/examples/basic_ecu_doip/CMakeLists.txt
+++ b/examples/basic_ecu_doip/CMakeLists.txt
@@ -119,6 +119,7 @@ target_sources(app PRIVATE
     ${DIAG_ROOT}/core/uds_services/service_0x3E.c
     ${DIAG_ROOT}/core/uds_services/service_0x85.c
     ${DIAG_ROOT}/core/uds_services/service_0x34.c
+    ${DIAG_ROOT}/core/uds_services/service_0x35.c
     ${DIAG_ROOT}/core/uds_services/service_0x36.c
     ${DIAG_ROOT}/core/uds_services/service_0x37.c
     ${DIAG_ROOT}/core/uds_transfer_ctx.c

--- a/examples/basic_ecu_doip_freertos/CMakeLists.txt
+++ b/examples/basic_ecu_doip_freertos/CMakeLists.txt
@@ -121,6 +121,7 @@ add_executable(eds_freertos_doip
     ${DIAG_ROOT}/core/uds_services/service_0x3E.c
     ${DIAG_ROOT}/core/uds_services/service_0x85.c
     ${DIAG_ROOT}/core/uds_services/service_0x34.c
+    ${DIAG_ROOT}/core/uds_services/service_0x35.c
     ${DIAG_ROOT}/core/uds_services/service_0x36.c
     ${DIAG_ROOT}/core/uds_services/service_0x37.c
     ${DIAG_ROOT}/core/uds_transfer_ctx.c

--- a/examples/basic_ecu_freertos/CMakeLists.txt
+++ b/examples/basic_ecu_freertos/CMakeLists.txt
@@ -178,6 +178,7 @@ add_executable(eds_freertos
     ${DIAG_ROOT}/core/uds_services/service_0x2E.c
     ${DIAG_ROOT}/core/uds_services/service_0x31.c
     ${DIAG_ROOT}/core/uds_services/service_0x34.c
+    ${DIAG_ROOT}/core/uds_services/service_0x35.c
     ${DIAG_ROOT}/core/uds_services/service_0x36.c
     ${DIAG_ROOT}/core/uds_services/service_0x37.c
     ${DIAG_ROOT}/core/uds_services/service_0x3E.c

--- a/examples/bms_ecu/CMakeLists.txt
+++ b/examples/bms_ecu/CMakeLists.txt
@@ -176,6 +176,7 @@ target_sources(app PRIVATE
     # service_registration.c references all three in g_uds_service_table[];
     # omitting these causes link failure: undefined reference to uds_service_0x34_handler.
     ${DIAG_ROOT}/core/uds_services/service_0x34.c   # RequestDownload
+    ${DIAG_ROOT}/core/uds_services/service_0x35.c   # RequestUpload
     ${DIAG_ROOT}/core/uds_services/service_0x36.c   # TransferData
     ${DIAG_ROOT}/core/uds_services/service_0x37.c   # RequestTransferExit
     ${DIAG_ROOT}/core/uds_transfer_ctx.c             # DFU transfer state machine

--- a/examples/motor_controller_ecu/CMakeLists.txt
+++ b/examples/motor_controller_ecu/CMakeLists.txt
@@ -176,6 +176,7 @@ target_sources(app PRIVATE
     # service_registration.c references all three in g_uds_service_table[];
     # omitting these causes link failure: undefined reference to uds_service_0x34_handler.
     ${DIAG_ROOT}/core/uds_services/service_0x34.c   # RequestDownload
+    ${DIAG_ROOT}/core/uds_services/service_0x35.c   # RequestUpload
     ${DIAG_ROOT}/core/uds_services/service_0x36.c   # TransferData
     ${DIAG_ROOT}/core/uds_services/service_0x37.c   # RequestTransferExit
     ${DIAG_ROOT}/core/uds_transfer_ctx.c             # DFU transfer state machine

--- a/examples/robot_joint_controller_ecu/CMakeLists.txt
+++ b/examples/robot_joint_controller_ecu/CMakeLists.txt
@@ -84,6 +84,7 @@ target_sources(app PRIVATE
     ${DIAG_ROOT}/core/uds_services/service_0x2E.c
     ${DIAG_ROOT}/core/uds_services/service_0x31.c
     ${DIAG_ROOT}/core/uds_services/service_0x34.c
+    ${DIAG_ROOT}/core/uds_services/service_0x35.c
     ${DIAG_ROOT}/core/uds_services/service_0x36.c
     ${DIAG_ROOT}/core/uds_services/service_0x37.c
     ${DIAG_ROOT}/core/uds_services/service_0x3E.c

--- a/examples/safeboot_ecu/CMakeLists.txt
+++ b/examples/safeboot_ecu/CMakeLists.txt
@@ -111,6 +111,7 @@ target_sources(app PRIVATE
     ${DIAG_ROOT}/core/uds_services/service_0x2E.c
     ${DIAG_ROOT}/core/uds_services/service_0x31.c
     ${DIAG_ROOT}/core/uds_services/service_0x34.c   # RequestDownload
+    ${DIAG_ROOT}/core/uds_services/service_0x35.c   # RequestUpload
     ${DIAG_ROOT}/core/uds_services/service_0x36.c   # TransferData
     ${DIAG_ROOT}/core/uds_services/service_0x37.c   # RequestTransferExit
     ${DIAG_ROOT}/core/uds_services/service_0x3E.c

--- a/examples/safeboot_freertos_ecu/CMakeLists.txt
+++ b/examples/safeboot_freertos_ecu/CMakeLists.txt
@@ -170,6 +170,7 @@ add_executable(eds_safeboot_freertos
     ${DIAG_ROOT}/core/uds_services/service_0x2E.c
     ${DIAG_ROOT}/core/uds_services/service_0x31.c
     ${DIAG_ROOT}/core/uds_services/service_0x34.c
+    ${DIAG_ROOT}/core/uds_services/service_0x35.c
     ${DIAG_ROOT}/core/uds_services/service_0x36.c
     ${DIAG_ROOT}/core/uds_services/service_0x37.c
     ${DIAG_ROOT}/core/uds_services/service_0x3E.c

--- a/examples/sensor_ecu/CMakeLists.txt
+++ b/examples/sensor_ecu/CMakeLists.txt
@@ -118,6 +118,7 @@ target_sources(app PRIVATE
     ${DIAG_ROOT}/core/uds_services/service_0x2E.c
     ${DIAG_ROOT}/core/uds_services/service_0x31.c
     ${DIAG_ROOT}/core/uds_services/service_0x34.c
+    ${DIAG_ROOT}/core/uds_services/service_0x35.c
     ${DIAG_ROOT}/core/uds_services/service_0x36.c
     ${DIAG_ROOT}/core/uds_services/service_0x37.c
     ${DIAG_ROOT}/core/uds_services/service_0x3E.c

--- a/examples/sensor_ecu_freertos/CMakeLists.txt
+++ b/examples/sensor_ecu_freertos/CMakeLists.txt
@@ -176,6 +176,7 @@ add_executable(eds_sensor_freertos
     ${DIAG_ROOT}/core/uds_services/service_0x2E.c
     ${DIAG_ROOT}/core/uds_services/service_0x31.c
     ${DIAG_ROOT}/core/uds_services/service_0x34.c
+    ${DIAG_ROOT}/core/uds_services/service_0x35.c
     ${DIAG_ROOT}/core/uds_services/service_0x36.c
     ${DIAG_ROOT}/core/uds_services/service_0x37.c
     ${DIAG_ROOT}/core/uds_services/service_0x3E.c

--- a/misra_analysis.py
+++ b/misra_analysis.py
@@ -313,6 +313,8 @@ MISRA_DEVIATIONS: List[Dict[str, Any]] = [
             # Phase 7 DFU + RoutineControl service handlers (new)
             "core/uds_services/service_0x31.c",
             "core/uds_services/service_0x34.c",
+            "core/uds_services/service_0x35.c",
+            "core/uds_services/service_transfer_common.h",
             "core/uds_services/service_0x36.c",
             "core/uds_services/service_0x37.c",
             "core/uds_services/service_registration.c",
@@ -663,6 +665,8 @@ MISRA_DEVIATIONS: List[Dict[str, Any]] = [
             "core/uds_services/service_0x2E.c",
             "core/uds_services/service_0x31.c",
             "core/uds_services/service_0x34.c",
+            "core/uds_services/service_0x35.c",
+            "core/uds_services/service_transfer_common.h",
             "core/uds_services/service_0x36.c",
             "core/uds_services/service_0x37.c",
             "core/uds_services/service_0x3E.c",
@@ -931,7 +935,9 @@ MISRA_DEVIATIONS: List[Dict[str, Any]] = [
             "core/uds_safety.c", "core/uds_access_table.c", "core/uds_security_algo.c",
             "core/uds_aes_cmac.c", "core/uds_transfer_ctx.c",
             "core/uds_services/service_0x19.c", "core/uds_services/service_0x27.c",
-            "core/uds_services/service_0x34.c", "core/uds_services/service_0x36.c",
+            "core/uds_services/service_0x34.c", "core/uds_services/service_0x35.c",
+            "core/uds_services/service_transfer_common.h",
+            "core/uds_services/service_0x36.c",
             "transport/isotp.c", "config/dtc_database.c",
             "generated/did_handlers.c", "generated/uds_init.c",
         

--- a/platform/uds_flash_ops.h
+++ b/platform/uds_flash_ops.h
@@ -128,10 +128,29 @@ typedef uds_status_t (*uds_flash_verify_cb_fn)(uint32_t address,
                                                 uint32_t expected_crc);
 
 /**
+ * @brief Callback: read a block of data from flash (required for 0x35 RequestUpload).
+ *
+ * Called by service_0x36 (TransferData) in upload direction to read each block
+ * from flash and return it to the tester.
+ *
+ * @param[in]  address   Source address in flash.
+ * @param[out] data      Buffer to receive the read data.
+ * @param[in]  length    Number of bytes to read.
+ *
+ * @return UDS_STATUS_OK on success.
+ * @return UDS_STATUS_ERR_PLATFORM on driver failure.
+ */
+typedef uds_status_t (*uds_flash_read_cb_fn)(uint32_t  address,
+                                              uint8_t  *data,
+                                              uint32_t  length);
+
+/**
  * @brief Flash operations table — registered at stack init.
  *
- * All three callbacks must be non-NULL when the table is registered.
- * The memory map pointer must reference at least one valid region.
+ * erase_cb, write_cb, and verify_cb must be non-NULL when the table is
+ * registered for download (0x34) support.  read_cb may be NULL for
+ * download-only configurations — service_0x35 checks at request time and
+ * returns NRC 0x22 if read_cb is NULL.
  *
  * REQ-FLASH-001: Register before any 0x34 request is accepted.
  */
@@ -139,6 +158,8 @@ typedef struct uds_flash_ops {
     uds_flash_erase_cb_fn   erase_cb;        /**< Erase callback.  */
     uds_flash_write_cb_fn   write_cb;        /**< Write callback.  */
     uds_flash_verify_cb_fn  verify_cb;       /**< Verify callback. */
+    uds_flash_read_cb_fn    read_cb;         /**< Read callback — required for 0x35 RequestUpload.
+                                               *  May be NULL for download-only configurations. */
 
     const uds_flash_region_t *memory_map;    /**< Array of permitted regions. */
     uint8_t                   region_count;  /**< Number of entries in memory_map[]. */
@@ -174,7 +195,8 @@ typedef struct uds_flash_ops {
  *
  * @return UDS_STATUS_OK on success.
  * @return UDS_STATUS_ERR_INVALID_PARAM if ops->erase_cb, write_cb, or
- *         verify_cb is NULL (when ops itself is non-NULL).
+ *         verify_cb is NULL (when ops itself is non-NULL).  read_cb may
+ *         be NULL — download-only configurations do not populate it.
  */
 uds_status_t uds_flash_ops_register(const uds_flash_ops_t *ops);
 

--- a/tests/unit_runnable/test_phase5_access_table.c
+++ b/tests/unit_runnable/test_phase5_access_table.c
@@ -87,13 +87,13 @@ ZTEST(test_phase5_access_table, tc001_get_default_not_null)
 /**
  * TC-ACL-002: Default table has UDS_ACCESS_TABLE_DEFAULT_COUNT entries.
  * We verify by counting lookups for each SID in the default table.
- * Count updated from 10 → 13 when DFU services 0x34/0x36/0x37 were added
- * to the default ACL table. [FIX-ACL-COUNT]
+ * Count updated from 10 → 13 when DFU services 0x34/0x36/0x37 were added,
+ * then 13 → 14 when 0x35 RequestUpload was added. [FIX-ACL-COUNT]
  */
 ZTEST(test_phase5_access_table, tc002_default_table_count)
 {
-    zassert_equal((uint8_t)UDS_ACCESS_TABLE_DEFAULT_COUNT, (uint8_t)13U,
-        "default table must have exactly 13 entries");
+    zassert_equal((uint8_t)UDS_ACCESS_TABLE_DEFAULT_COUNT, (uint8_t)14U,
+        "default table must have exactly 14 entries");
 }
 
 /**

--- a/tests/unit_runnable/test_service_0x35.c
+++ b/tests/unit_runnable/test_service_0x35.c
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2026 Xaloqi
+/*
+ * =============================================================================
+ * Xaloqi EDS — Unit Tests
+ * FILE: tests/unit_runnable/test_service_0x35.c
+ *
+ * MODULE UNDER TEST: core/uds_services/service_0x35.c
+ *                    SID 0x35 — RequestUpload
+ *
+ * Coverage:
+ *   TC-0x35-001  NULL ctx                              → ERR_NULL_PTR
+ *   TC-0x35-002  Request too short (< 3 bytes)         → ERR_INVALID_PARAM (NRC 0x13)
+ *   TC-0x35-003  read_cb not registered (NULL)         → ERR_CONDITIONS_NOT_MET (NRC 0x22)
+ *   TC-0x35-004  dataFormatIdentifier != 0x00          → ERR_REQUEST_OUT_OF_RANGE (NRC 0x31)
+ *   TC-0x35-005  addressLength == 0                    → ERR_INVALID_PARAM
+ *   TC-0x35-006  sizeLength == 0                       → ERR_INVALID_PARAM
+ *   TC-0x35-007  addressLength > 4                     → ERR_INVALID_PARAM
+ *   TC-0x35-008  sizeLength > 4                        → ERR_INVALID_PARAM
+ *   TC-0x35-009  Request too short for declared fields  → ERR_INVALID_PARAM
+ *   TC-0x35-010  Address outside registered region     → ERR_REQUEST_OUT_OF_RANGE
+ *   TC-0x35-011  Size == 0                             → ERR_REQUEST_OUT_OF_RANGE
+ *   TC-0x35-012  Valid 4+4 request                     → UDS_STATUS_OK, response [0x75, 0x20, Hi, Lo]
+ *   TC-0x35-013  Transfer direction set to UPLOAD      → tctx->direction == UDS_TRANSFER_DIR_UPLOAD
+ *   TC-0x35-014  Transfer state set to ACTIVE
+ *   TC-0x35-015  erase_cb NOT called (upload → read only)
+ *   TC-0x35-016  New 0x35 while upload active resets context then opens fresh transfer
+ *
+ * FRAMEWORK: Zephyr Ztest (via ztest_shim.h for host compilation)
+ * =============================================================================
+ */
+
+#include <zephyr/ztest.h>
+#include <string.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#include "services.h"
+#include "uds_types.h"
+#include "uds_server.h"
+#include "uds_session.h"
+#include "uds_security.h"
+#include "uds_safety.h"
+#include "uds_transfer_ctx.h"
+#include "uds_flash_ops.h"
+
+/* ==========================================================================
+ * Mock flash constants
+ * ========================================================================== */
+
+#define MOCK_FLASH_BASE   (0x08020000UL)
+#define MOCK_FLASH_SIZE   (0x2000UL)
+#define MOCK_BLOCK_LEN    (256U)
+
+/* ==========================================================================
+ * Mock flash state
+ * ========================================================================== */
+
+static bool     s_erase_called = false;
+static uint32_t s_read_call_count = 0U;
+
+/* ==========================================================================
+ * Mock flash callbacks
+ * ========================================================================== */
+
+static uds_status_t mock_erase(uint32_t address, uint32_t size_bytes)
+{
+    (void)address; (void)size_bytes;
+    s_erase_called = true;
+    return UDS_STATUS_OK;
+}
+
+static uds_status_t mock_write(uint32_t address,
+                                const uint8_t *data,
+                                uint32_t length)
+{
+    (void)address; (void)data; (void)length;
+    return UDS_STATUS_OK;
+}
+
+static uds_status_t mock_verify(uint32_t address,
+                                 uint32_t size_bytes,
+                                 uint32_t expected_crc)
+{
+    (void)address; (void)size_bytes; (void)expected_crc;
+    return UDS_STATUS_OK;
+}
+
+static uds_status_t mock_read(uint32_t address,
+                               uint8_t *data,
+                               uint32_t length)
+{
+    uint32_t i;
+    (void)address;
+    s_read_call_count++;
+    for (i = (uint32_t)0U; i < length; i++) {
+        data[i] = (uint8_t)(i & (uint32_t)0xFFU);
+    }
+    return UDS_STATUS_OK;
+}
+
+static const uds_flash_region_t k_mock_region[1U] = {
+    {
+        .base_address = MOCK_FLASH_BASE,
+        .size_bytes   = (uint32_t)MOCK_FLASH_SIZE,
+        .writable     = true,
+    }
+};
+
+/* ops table with read_cb populated */
+static const uds_flash_ops_t k_mock_ops_with_read = {
+    .erase_cb         = mock_erase,
+    .write_cb         = mock_write,
+    .verify_cb        = mock_verify,
+    .read_cb          = mock_read,
+    .memory_map       = k_mock_region,
+    .region_count     = (uint8_t)1U,
+    .max_block_length = (uint16_t)MOCK_BLOCK_LEN,
+};
+
+/* ops table without read_cb (download-only) */
+static const uds_flash_ops_t k_mock_ops_no_read = {
+    .erase_cb         = mock_erase,
+    .write_cb         = mock_write,
+    .verify_cb        = mock_verify,
+    .read_cb          = NULL,
+    .memory_map       = k_mock_region,
+    .region_count     = (uint8_t)1U,
+    .max_block_length = (uint16_t)MOCK_BLOCK_LEN,
+};
+
+/* ==========================================================================
+ * Test state
+ * ========================================================================== */
+
+static uds_session_ctx_t  s_sess;
+static uds_security_ctx_t s_sec;
+static uds_server_ctx_t   s_srv;
+static uds_msg_buf_t      s_req;
+static uds_msg_buf_t      s_resp;
+
+/* ==========================================================================
+ * setUp / tearDown
+ * ========================================================================== */
+
+void setUp(void)
+{
+    memset(&s_sess, 0, sizeof(s_sess));
+    memset(&s_sec,  0, sizeof(s_sec));
+    memset(&s_srv,  0, sizeof(s_srv));
+    memset(&s_req,  0, sizeof(s_req));
+    memset(&s_resp, 0, sizeof(s_resp));
+
+    s_erase_called    = false;
+    s_read_call_count = 0U;
+
+    (void)uds_safety_init();
+
+    s_sess.initialized    = true;
+    s_sess.active_session = UDS_SESSION_PROGRAMMING;
+    s_sec.initialized     = true;
+    s_sec.active_level    = 1U;
+
+    s_srv.cfg.session_ctx  = &s_sess;
+    s_srv.cfg.security_ctx = &s_sec;
+
+    uds_transfer_ctx_reset(uds_transfer_ctx_get());
+    (void)uds_flash_ops_register(NULL);
+}
+
+void tearDown(void) {}
+
+/* ==========================================================================
+ * Helper: build a well-formed 0x35 request
+ * ========================================================================== */
+
+static void build_valid_req(uint32_t mem_address, uint32_t mem_size)
+{
+    s_req.data[0] = 0x35U;
+    s_req.data[1] = 0x00U;  /* dataFormatIdentifier */
+    s_req.data[2] = 0x44U;  /* ALFID: 4 addr bytes, 4 size bytes */
+
+    s_req.data[3] = (uint8_t)((mem_address >> 24U) & 0xFFU);
+    s_req.data[4] = (uint8_t)((mem_address >> 16U) & 0xFFU);
+    s_req.data[5] = (uint8_t)((mem_address >>  8U) & 0xFFU);
+    s_req.data[6] = (uint8_t)( mem_address         & 0xFFU);
+
+    s_req.data[7]  = (uint8_t)((mem_size >> 24U) & 0xFFU);
+    s_req.data[8]  = (uint8_t)((mem_size >> 16U) & 0xFFU);
+    s_req.data[9]  = (uint8_t)((mem_size >>  8U) & 0xFFU);
+    s_req.data[10] = (uint8_t)( mem_size         & 0xFFU);
+
+    s_req.length = 11U;
+}
+
+/* ==========================================================================
+ * Test suite
+ * ========================================================================== */
+
+ZTEST_SUITE(svc_0x35, NULL, NULL, NULL, NULL, NULL);
+
+/* TC-0x35-001 */
+ZTEST(svc_0x35, test_null_ctx)
+{
+    build_valid_req(MOCK_FLASH_BASE, 0x100U);
+    (void)uds_flash_ops_register(&k_mock_ops_with_read);
+    zassert_equal(UDS_STATUS_ERR_NULL_PTR,
+                  uds_service_0x35_handler(NULL, &s_req, &s_resp), "");
+}
+
+/* TC-0x35-002 */
+ZTEST(svc_0x35, test_request_too_short)
+{
+    (void)uds_flash_ops_register(&k_mock_ops_with_read);
+    s_req.data[0] = 0x35U;
+    s_req.data[1] = 0x00U;
+    s_req.length  = 2U;   /* < 3 */
+    zassert_equal(UDS_STATUS_ERR_INVALID_PARAM,
+                  uds_service_0x35_handler(&s_srv, &s_req, &s_resp), "");
+}
+
+/* TC-0x35-003  read_cb not registered → NRC 0x22 */
+ZTEST(svc_0x35, test_read_cb_null)
+{
+    (void)uds_flash_ops_register(&k_mock_ops_no_read);
+    build_valid_req(MOCK_FLASH_BASE, 0x100U);
+    zassert_equal(UDS_STATUS_ERR_CONDITIONS_NOT_MET,
+                  uds_service_0x35_handler(&s_srv, &s_req, &s_resp), "");
+}
+
+/* TC-0x35-004  dataFormatIdentifier != 0x00 → NRC 0x31 */
+ZTEST(svc_0x35, test_nonzero_data_format_identifier)
+{
+    (void)uds_flash_ops_register(&k_mock_ops_with_read);
+    build_valid_req(MOCK_FLASH_BASE, 0x100U);
+    s_req.data[1] = 0x10U;
+    zassert_equal(UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE,
+                  uds_service_0x35_handler(&s_srv, &s_req, &s_resp), "");
+}
+
+/* TC-0x35-005  addressLength == 0 → NRC 0x13 */
+ZTEST(svc_0x35, test_address_length_zero)
+{
+    (void)uds_flash_ops_register(&k_mock_ops_with_read);
+    s_req.data[0] = 0x35U;
+    s_req.data[1] = 0x00U;
+    s_req.data[2] = 0x10U;  /* sizeLen=1, addrLen=0 */
+    s_req.data[3] = 0x01U;
+    s_req.length  = 4U;
+    zassert_equal(UDS_STATUS_ERR_INVALID_PARAM,
+                  uds_service_0x35_handler(&s_srv, &s_req, &s_resp), "");
+}
+
+/* TC-0x35-006  sizeLength == 0 → NRC 0x13 */
+ZTEST(svc_0x35, test_size_length_zero)
+{
+    (void)uds_flash_ops_register(&k_mock_ops_with_read);
+    s_req.data[0] = 0x35U;
+    s_req.data[1] = 0x00U;
+    s_req.data[2] = 0x01U;  /* sizeLen=0, addrLen=1 */
+    s_req.data[3] = 0x00U;
+    s_req.length  = 4U;
+    zassert_equal(UDS_STATUS_ERR_INVALID_PARAM,
+                  uds_service_0x35_handler(&s_srv, &s_req, &s_resp), "");
+}
+
+/* TC-0x35-007  addressLength > 4 → NRC 0x13 */
+ZTEST(svc_0x35, test_address_length_too_large)
+{
+    (void)uds_flash_ops_register(&k_mock_ops_with_read);
+    s_req.data[0] = 0x35U;
+    s_req.data[1] = 0x00U;
+    s_req.data[2] = 0x15U;  /* sizeLen=1, addrLen=5 */
+    s_req.length  = 3U;
+    zassert_equal(UDS_STATUS_ERR_INVALID_PARAM,
+                  uds_service_0x35_handler(&s_srv, &s_req, &s_resp), "");
+}
+
+/* TC-0x35-008  sizeLength > 4 → NRC 0x13 */
+ZTEST(svc_0x35, test_size_length_too_large)
+{
+    (void)uds_flash_ops_register(&k_mock_ops_with_read);
+    s_req.data[0] = 0x35U;
+    s_req.data[1] = 0x00U;
+    s_req.data[2] = 0x51U;  /* sizeLen=5, addrLen=1 */
+    s_req.length  = 3U;
+    zassert_equal(UDS_STATUS_ERR_INVALID_PARAM,
+                  uds_service_0x35_handler(&s_srv, &s_req, &s_resp), "");
+}
+
+/* TC-0x35-009  Request too short for declared fields → NRC 0x13 */
+ZTEST(svc_0x35, test_request_too_short_for_fields)
+{
+    (void)uds_flash_ops_register(&k_mock_ops_with_read);
+    s_req.data[0] = 0x35U;
+    s_req.data[1] = 0x00U;
+    s_req.data[2] = 0x44U;  /* claims 4 addr + 4 size bytes */
+    s_req.data[3] = 0x08U;
+    s_req.data[4] = 0x02U;
+    s_req.length  = 5U;     /* 5 < 3 + 4 + 4 = 11 */
+    zassert_equal(UDS_STATUS_ERR_INVALID_PARAM,
+                  uds_service_0x35_handler(&s_srv, &s_req, &s_resp), "");
+}
+
+/* TC-0x35-010  Address outside registered region → NRC 0x31 */
+ZTEST(svc_0x35, test_address_outside_region)
+{
+    (void)uds_flash_ops_register(&k_mock_ops_with_read);
+    build_valid_req(0x20000000UL, 0x100U);
+    zassert_equal(UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE,
+                  uds_service_0x35_handler(&s_srv, &s_req, &s_resp), "");
+}
+
+/* TC-0x35-011  Size == 0 → NRC 0x31 */
+ZTEST(svc_0x35, test_size_zero_rejected)
+{
+    (void)uds_flash_ops_register(&k_mock_ops_with_read);
+    build_valid_req(MOCK_FLASH_BASE, 0x0U);
+    zassert_equal(UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE,
+                  uds_service_0x35_handler(&s_srv, &s_req, &s_resp), "");
+}
+
+/* TC-0x35-012  Valid 4+4 request → UDS_STATUS_OK, response [0x75, 0x20, Hi, Lo] */
+ZTEST(svc_0x35, test_valid_request_4byte_fields)
+{
+    (void)uds_flash_ops_register(&k_mock_ops_with_read);
+    build_valid_req(MOCK_FLASH_BASE, 0x100U);
+    zassert_equal(UDS_STATUS_OK,
+                  uds_service_0x35_handler(&s_srv, &s_req, &s_resp), "");
+
+    zassert_equal(4U,    s_resp.length,  "response must be 4 bytes");
+    zassert_equal(0x75U, s_resp.data[0], "RSID must be 0x75");
+    zassert_equal(0x20U, s_resp.data[1], "LFI must be 0x20");
+}
+
+/* TC-0x35-013  Transfer direction set to UPLOAD */
+ZTEST(svc_0x35, test_transfer_direction_upload)
+{
+    (void)uds_flash_ops_register(&k_mock_ops_with_read);
+    build_valid_req(MOCK_FLASH_BASE, 0x100U);
+    zassert_equal(UDS_STATUS_OK,
+                  uds_service_0x35_handler(&s_srv, &s_req, &s_resp), "");
+    zassert_equal(UDS_TRANSFER_DIR_UPLOAD,
+                  uds_transfer_ctx_get()->direction,
+                  "direction must be UPLOAD after 0x35");
+}
+
+/* TC-0x35-014  Transfer state set to ACTIVE */
+ZTEST(svc_0x35, test_transfer_state_active)
+{
+    (void)uds_flash_ops_register(&k_mock_ops_with_read);
+    build_valid_req(MOCK_FLASH_BASE, 0x100U);
+    zassert_equal(UDS_STATUS_OK,
+                  uds_service_0x35_handler(&s_srv, &s_req, &s_resp), "");
+    zassert_equal(UDS_TRANSFER_ACTIVE,
+                  uds_transfer_ctx_get()->state,
+                  "transfer must be ACTIVE after 0x35");
+}
+
+/* TC-0x35-015  erase_cb NOT called (upload is read-only) */
+ZTEST(svc_0x35, test_erase_not_called)
+{
+    (void)uds_flash_ops_register(&k_mock_ops_with_read);
+    build_valid_req(MOCK_FLASH_BASE, 0x100U);
+    zassert_equal(UDS_STATUS_OK,
+                  uds_service_0x35_handler(&s_srv, &s_req, &s_resp), "");
+    zassert_false(s_erase_called, "erase_cb must NOT be called for upload");
+}
+
+/* TC-0x35-016  New 0x35 while upload active resets context then opens fresh transfer */
+ZTEST(svc_0x35, test_new_upload_aborts_active_transfer)
+{
+    (void)uds_flash_ops_register(&k_mock_ops_with_read);
+
+    /* First 0x35 — start an upload. */
+    build_valid_req(MOCK_FLASH_BASE, 0x100U);
+    zassert_equal(UDS_STATUS_OK,
+                  uds_service_0x35_handler(&s_srv, &s_req, &s_resp), "");
+    zassert_equal(UDS_TRANSFER_ACTIVE, uds_transfer_ctx_get()->state, "");
+
+    /* Second 0x35 — must reset and open a fresh upload. */
+    memset(&s_resp, 0, sizeof(s_resp));
+    build_valid_req(MOCK_FLASH_BASE, 0x200U);
+    zassert_equal(UDS_STATUS_OK,
+                  uds_service_0x35_handler(&s_srv, &s_req, &s_resp), "");
+    zassert_equal(UDS_TRANSFER_ACTIVE, uds_transfer_ctx_get()->state, "");
+    zassert_equal((uint32_t)0x200U,
+                  uds_transfer_ctx_get()->bytes_remaining,
+                  "bytes_remaining must reflect new upload size");
+    zassert_equal(UDS_TRANSFER_DIR_UPLOAD,
+                  uds_transfer_ctx_get()->direction,
+                  "direction must remain UPLOAD after restart");
+}
+
+/* ==========================================================================
+ * run_all_tests
+ * ========================================================================== */
+
+void run_all_tests(void)
+{
+    RUN_TEST(svc_0x35__test_null_ctx);
+    RUN_TEST(svc_0x35__test_request_too_short);
+    RUN_TEST(svc_0x35__test_read_cb_null);
+    RUN_TEST(svc_0x35__test_nonzero_data_format_identifier);
+    RUN_TEST(svc_0x35__test_address_length_zero);
+    RUN_TEST(svc_0x35__test_size_length_zero);
+    RUN_TEST(svc_0x35__test_address_length_too_large);
+    RUN_TEST(svc_0x35__test_size_length_too_large);
+    RUN_TEST(svc_0x35__test_request_too_short_for_fields);
+    RUN_TEST(svc_0x35__test_address_outside_region);
+    RUN_TEST(svc_0x35__test_size_zero_rejected);
+    RUN_TEST(svc_0x35__test_valid_request_4byte_fields);
+    RUN_TEST(svc_0x35__test_transfer_direction_upload);
+    RUN_TEST(svc_0x35__test_transfer_state_active);
+    RUN_TEST(svc_0x35__test_erase_not_called);
+    RUN_TEST(svc_0x35__test_new_upload_aborts_active_transfer);
+}

--- a/tests/unit_runnable/test_service_0x36.c
+++ b/tests/unit_runnable/test_service_0x36.c
@@ -8,7 +8,7 @@
  * MODULE UNDER TEST: core/uds_services/service_0x36.c
  *                    SID 0x36 — TransferData
  *
- * Coverage:
+ * Coverage (download direction):
  *   TC-0x36-001  NULL ctx                            → ERR_NULL_PTR
  *   TC-0x36-002  Request too short (< 3 bytes)       → ERR_INVALID_PARAM
  *   TC-0x36-003  No active transfer (IDLE state)     → ERR_SERVICE_NOT_SUPPORTED_IN_SESSION (NRC 0x24)
@@ -26,6 +26,12 @@
  *   TC-0x36-015  No flash ops after 0x34 → ERR_CONDITIONS_NOT_MET
  *   TC-0x36-016  Payload capped at bytes_remaining (oversized last block)
  *   TC-0x36-017  Second block accepted with correct incremented counter
+ *
+ * Coverage (upload direction — SID 0x35 active):
+ *   TC-0x36-UL-001  Upload: [0x36, 0x01] → response [0x76, 0x01, data[0..N]]
+ *   TC-0x36-UL-002  Upload: read_cb failure → ERR_PLATFORM (NRC 0x72)
+ *   TC-0x36-UL-003  Upload: bytes_remaining decremented after each block
+ *   TC-0x36-UL-004  Upload: block counter wraps 0xFF → 0x01 (REQ-DL-001 applies to upload)
  *
  * FRAMEWORK: Zephyr Ztest (via ztest_shim.h for host compilation)
  * =============================================================================
@@ -62,6 +68,9 @@ static uint32_t s_write_call_count = 0U;
 static uint32_t s_last_write_addr  = 0U;
 static uint32_t s_last_write_len   = 0U;
 
+static bool     s_read_fail        = false;
+static uint32_t s_read_call_count  = 0U;
+
 /* ==========================================================================
  * Mock flash callbacks
  * ========================================================================== */
@@ -94,6 +103,22 @@ static uds_status_t mock_verify(uint32_t address,
     return UDS_STATUS_OK;
 }
 
+static uds_status_t mock_read(uint32_t address,
+                               uint8_t *data,
+                               uint32_t length)
+{
+    uint32_t i;
+    (void)address;
+    s_read_call_count++;
+    if (s_read_fail) {
+        return UDS_STATUS_ERR_PLATFORM;
+    }
+    for (i = (uint32_t)0U; i < length; i++) {
+        data[i] = (uint8_t)(i & (uint32_t)0xFFU);
+    }
+    return UDS_STATUS_OK;
+}
+
 static const uds_flash_region_t k_mock_region[1U] = {
     {
         .base_address = MOCK_FLASH_BASE,
@@ -106,6 +131,7 @@ static const uds_flash_ops_t k_mock_ops = {
     .erase_cb         = mock_erase,
     .write_cb         = mock_write,
     .verify_cb        = mock_verify,
+    .read_cb          = mock_read,
     .memory_map       = k_mock_region,
     .region_count     = (uint8_t)1U,
     .max_block_length = (uint16_t)MOCK_BLOCK_LEN,
@@ -169,6 +195,8 @@ void setUp(void)
     s_write_call_count = 0U;
     s_last_write_addr  = 0U;
     s_last_write_len   = 0U;
+    s_read_fail        = false;
+    s_read_call_count  = 0U;
 
     (void)uds_safety_init();
 
@@ -413,6 +441,104 @@ ZTEST(svc_0x36, test_second_block_accepted)
 }
 
 /* ==========================================================================
+ * Upload direction helpers and tests
+ * ========================================================================== */
+
+/** Prime transfer context as if a successful 0x35 RequestUpload was processed. */
+static void prime_active_upload(uint32_t total_size)
+{
+    uds_transfer_ctx_t *tctx = uds_transfer_ctx_get();
+    uds_transfer_ctx_reset(tctx);
+
+    tctx->state                   = UDS_TRANSFER_ACTIVE;
+    tctx->direction               = UDS_TRANSFER_DIR_UPLOAD;
+    tctx->target_address          = MOCK_FLASH_BASE;
+    tctx->total_size_bytes        = total_size;
+    tctx->bytes_remaining         = total_size;
+    tctx->next_write_address      = MOCK_FLASH_BASE;
+    tctx->next_expected_block_seq = (uint8_t)0x01U;
+    tctx->crc_accumulator         = (uint32_t)0xFFFFFFFFUL;
+    tctx->write_buf_fill          = (uint16_t)0U;
+    tctx->write_buf_capacity      = (uint16_t)MOCK_BLOCK_LEN;
+}
+
+/* TC-0x36-UL-001  Upload: [0x36, 0x01] → response [0x76, 0x01, data[0..N]] */
+ZTEST(svc_0x36, test_upload_block_accepted)
+{
+    prime_active_upload(0x100U);
+
+    /* Upload request: only SID + blockSeqCounter, no payload from tester. */
+    s_req.data[0] = 0x36U;
+    s_req.data[1] = 0x01U;
+    s_req.length  = 2U;
+
+    zassert_equal(UDS_STATUS_OK,
+                  uds_service_0x36_handler(&s_srv, &s_req, &s_resp), "");
+
+    /* Response: [0x76, 0x01, read data...] */
+    zassert_equal(0x76U, s_resp.data[0], "RSID must be 0x76");
+    zassert_equal(0x01U, s_resp.data[1], "echo block seq 0x01");
+    /* Response length = 2 header + MOCK_BLOCK_LEN data bytes. */
+    zassert_equal((uint16_t)(2U + (uint16_t)MOCK_BLOCK_LEN),
+                  s_resp.length, "upload response length");
+    zassert_equal((uint32_t)1U, s_read_call_count, "read_cb must be called once");
+}
+
+/* TC-0x36-UL-002  Upload: read_cb failure → ERR_PLATFORM (NRC 0x72) */
+ZTEST(svc_0x36, test_upload_read_cb_failure)
+{
+    prime_active_upload(0x100U);
+    s_read_fail = true;
+
+    s_req.data[0] = 0x36U;
+    s_req.data[1] = 0x01U;
+    s_req.length  = 2U;
+
+    zassert_equal(UDS_STATUS_ERR_PLATFORM,
+                  uds_service_0x36_handler(&s_srv, &s_req, &s_resp), "");
+    /* Transfer must be reset to IDLE on read failure. */
+    zassert_equal(UDS_TRANSFER_IDLE,
+                  uds_transfer_ctx_get()->state,
+                  "transfer must be IDLE after read failure");
+}
+
+/* TC-0x36-UL-003  Upload: bytes_remaining decremented after each block */
+ZTEST(svc_0x36, test_upload_bytes_remaining_decremented)
+{
+    prime_active_upload(0x200U);
+
+    s_req.data[0] = 0x36U;
+    s_req.data[1] = 0x01U;
+    s_req.length  = 2U;
+
+    zassert_equal(UDS_STATUS_OK,
+                  uds_service_0x36_handler(&s_srv, &s_req, &s_resp), "");
+
+    /* One block of MOCK_BLOCK_LEN bytes read; bytes_remaining reduced accordingly. */
+    zassert_equal((uint32_t)(0x200U - (uint32_t)MOCK_BLOCK_LEN),
+                  uds_transfer_ctx_get()->bytes_remaining,
+                  "bytes_remaining must decrease by MOCK_BLOCK_LEN after upload block");
+}
+
+/* TC-0x36-UL-004  Upload: block counter wraps 0xFF → 0x01 (REQ-DL-001 applies) */
+ZTEST(svc_0x36, test_upload_block_counter_wrap)
+{
+    prime_active_upload(0x2000U);
+    uds_transfer_ctx_get()->next_expected_block_seq = (uint8_t)0xFFU;
+
+    s_req.data[0] = 0x36U;
+    s_req.data[1] = 0xFFU;
+    s_req.length  = 2U;
+
+    zassert_equal(UDS_STATUS_OK,
+                  uds_service_0x36_handler(&s_srv, &s_req, &s_resp), "");
+
+    zassert_equal(0x01U,
+                  uds_transfer_ctx_get()->next_expected_block_seq,
+                  "REQ-DL-001: upload counter must wrap 0xFF → 0x01");
+}
+
+/* ==========================================================================
  * run_all_tests
  * ========================================================================== */
 
@@ -435,4 +561,8 @@ void run_all_tests(void)
     RUN_TEST(svc_0x36__test_flash_ops_null_after_active_transfer);
     RUN_TEST(svc_0x36__test_payload_capped_at_bytes_remaining);
     RUN_TEST(svc_0x36__test_second_block_accepted);
+    RUN_TEST(svc_0x36__test_upload_block_accepted);
+    RUN_TEST(svc_0x36__test_upload_read_cb_failure);
+    RUN_TEST(svc_0x36__test_upload_bytes_remaining_decremented);
+    RUN_TEST(svc_0x36__test_upload_block_counter_wrap);
 }


### PR DESCRIPTION
## Summary

- Implements ISO 14229-1:2020 §14.5 `RequestUpload` (SID 0x35) as the symmetric counterpart to 0x34 `RequestDownload`. The ECU reads a requested memory region and transfers it block-by-block back to the tester via the existing 0x36/0x37 state machine.
- Primary use cases: calibration data readback, NVM log extraction, flash image verification readout.
- `read_cb = NULL` in `uds_flash_ops_t` is fully backward-compatible — download-only configurations are unaffected.

## Files changed

| File | Change |
|---|---|
| `core/uds_services/service_0x35.c` | New — RequestUpload handler |
| `core/uds_services/service_transfer_common.h` | New — shared parse/validate helpers for 0x34 and 0x35 |
| `core/uds_services/service_0x34.c` | Migrated to shared helpers (no behaviour change) |
| `core/uds_services/service_0x36.c` | Direction-aware dispatch; upload reads via `read_cb` into reused `write_buf` |
| `platform/uds_flash_ops.h` | Added nullable `read_cb` field to `uds_flash_ops_t` |
| `core/uds_transfer_ctx.h/.c` | `uds_transfer_direction_t` enum + `direction` field |
| `core/uds_access_table.h/.c` | 0x35 ACL entry (Programming session + Level 1); count 13→14 |
| `core/uds_services/services.h` | 0x35 handler declaration; table count 14→15 |
| `core/uds_services/service_registration.c` | 0x35 entry in dispatch table |
| `core/uds_types.h` | `UDS_SID_REQUEST_UPLOAD` constant |
| `tests/unit_runnable/test_service_0x35.c` | New — 16 unit TCs |
| `tests/unit_runnable/test_service_0x36.c` | 4 new upload TCs |
| `tests/unit_runnable/test_phase5_access_table.c` | Updated count assertion 13→14 |
| `build_tests.sh` | Added `service_0x35.c` to `STACK_SRCS`, `test_service_0x35` to `TESTS` |
| `CHANGELOG.md` / `CONTRIBUTING.md` / `README.md` / `.github/workflows/ci.yml` | Count and service list updates |

## Test plan

- [x] All 38 unit test modules pass locally (`bash build_tests.sh` → `38 passed, 0 failed`)
- [x] 16 new TCs in `test_service_0x35.c` cover: NULL guards, min-length, `read_cb=NULL` NRC 0x22, field length validation, address/size range checks, valid happy path, direction set, state set, erase NOT called, re-entry aborts and restarts
- [x] 4 new upload TCs in `test_service_0x36.c` cover: happy-path data readback, `read_cb` failure NRC, `bytes_remaining` decrement, counter wrap 0xFF→0x01
- [x] No `malloc`/`free`/`calloc`/`realloc` introduced (CI grep gate)
- [x] `read_cb = NULL` does not break `uds_flash_ops_register()` (no change to validation logic)
- [x] Existing download TCs in `test_service_0x36.c` all still pass

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)