### PR TITLE
chore(release): v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
-## [Unreleased]
+## [1.10.0] — 2026-07-02
 
 ### Added
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@
 #
 # SAFETY CONTEXT : Contains ASIL-B candidate modules (ISO 26262 Part 6).
 # CODING STANDARD: MISRA C:2012 alignment intended.
-# VERSION        : 1.9.0
+# VERSION        : 1.10.0
 # SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 
@@ -74,7 +74,7 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(zephyr_diagnostics_suite
-    VERSION     1.9.0
+    VERSION     1.10.0
     LANGUAGES   C
     DESCRIPTION "Production-grade UDS/ISO-TP diagnostics stack for Zephyr RTOS"
 )

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 > repo. Community users cloning the public repo can ignore this file.
 
 **Product:** Xaloqi EDS (Xaloqi Embedded Diagnostic Suite)  
-**Version:** v1.9.0  
+**Version:** v1.10.0  
 **Support:** contact@xaloqi.com
 
 ---
@@ -50,7 +50,7 @@ cd EDS
 Verify you are on the correct version:
 
 ```bash
-git checkout v1.9.0
+git checkout v1.10.0
 ```
 
 ---
@@ -59,10 +59,10 @@ git checkout v1.9.0
 
 ```bash
 # From the EDS repo root:
-unzip -o /path/to/xaloqi-eds-developer-v1.9.0.zip
+unzip -o /path/to/xaloqi-eds-developer-v1.10.0.zip
 
 # Or for Professional:
-unzip -o /path/to/xaloqi-eds-professional-v1.9.0.zip
+unzip -o /path/to/xaloqi-eds-professional-v1.10.0.zip
 ```
 
 The `-o` flag overwrites existing files without prompting — required when updating an existing installation.
@@ -174,7 +174,7 @@ Expected output:
 
 ```
 ========================================================================
-  Xaloqi EDS — Code Generator v1.9.0
+  Xaloqi EDS — Code Generator v1.10.0
 ========================================================================
   Config   : examples/bms_ecu/diagnostics_config.yaml
   ...

--- a/core/uds_types.h
+++ b/core/uds_types.h
@@ -32,14 +32,14 @@ extern "C" {
  *   - #define UDS_STACK_VERSION in generated/safety_config.h (template)
  *   - "Stack version" field in docs/INTEGRATION_GUIDE.md
  *
- * Bumped to 1.7.0 for the v1.7.0 commercial release.
+ * Bumped to 1.10.0 for the v1.10.0 release.
  * -------------------------------------------------------------------------- */
 #define UDS_SUITE_VERSION_MAJOR  (1U)
-#define UDS_SUITE_VERSION_MINOR  (7U)
+#define UDS_SUITE_VERSION_MINOR  (10U)
 #define UDS_SUITE_VERSION_PATCH  (0U)
 
 /** Compile-time version string — matches UDS_STACK_VERSION in safety_config.h. */
-#define UDS_SUITE_VERSION_STRING "1.7.0"
+#define UDS_SUITE_VERSION_STRING "1.10.0"
 
 /* --------------------------------------------------------------------------
  * Buffer and protocol sizing constants


### PR DESCRIPTION
## Summary

- Closes [Unreleased] → [1.10.0] — 2026-07-02
- Adds ReadMemoryByAddress (0x23) and WriteMemoryByAddress (0x3D) → 19 UDS services total
- NXP MR-CANHUBK3 (S32K344) board support
- NRC 0x24 fix for TransferData/RequestTransferExit sequence error

## Version files updated

| File | Change |
|---|---|
| `CHANGELOG.md` | `[Unreleased]` → `[1.10.0] — 2026-07-02` |
| `core/uds_types.h` | `1.7.0` → `1.10.0` (missed in v1.9.0 bump, fixing here) |
| `CMakeLists.txt` | `project(VERSION 1.9.0)` → `1.10.0` |
| `INSTALL.md` | All `v1.9.0` references → `v1.10.0` |

## Test plan

- [x] `bash build_tests.sh` — 42 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)