### PR TITLE
chore: bump README to v1.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Xaloqi Embedded Diagnostics Suite
 
 [![CI](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml/badge.svg)](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-v1.9.0-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.9.0)
+[![Version](https://img.shields.io/badge/version-v1.10.0-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.10.0)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](LICENSE)
 [![Zephyr](https://img.shields.io/badge/Zephyr-v3.7%2B-brightgreen)](https://zephyrproject.org)
 
@@ -137,7 +137,7 @@ manifest:
   projects:
     - name: EDS
       remote: xaloqi
-      revision: v1.9.0
+      revision: v1.10.0
       path: modules/eds
 ```
 
@@ -161,7 +161,7 @@ The `ZEPHYR_EDS_MODULE_DIR` variable is set automatically by west when the modul
 
 ```bash
 pip install west
-west init -m https://github.com/Xaloqi/EDS --mr v1.9.0 eds-workspace
+west init -m https://github.com/Xaloqi/EDS --mr v1.10.0 eds-workspace
 cd eds-workspace && west update
 pip install -r tools/requirements.txt
 ```


### PR DESCRIPTION
Updates version badge and west init command from v1.9.0 to v1.10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)