### PR TITLE
fix(security): wrong-level key counts as failed attempt [P4-SEC-01]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
+## [Unreleased]
+
+### Security
+
+- **[P4-SEC-01] SecurityAccess: wrong-level key now counts as a failed
+  attempt.** `uds_security_send_key()` previously returned
+  `REQUEST_OUT_OF_RANGE` immediately when the submitted key's security level
+  did not match the pending seed level, without incrementing
+  `failed_attempts` or clearing `seed_pending`. This allowed unbounded
+  probing of level/sub-function pairings without ever tripping the lockout
+  counter — an ASIL-B audit finding.
+
+  Fix: on level mismatch the seed is consumed (`seed_pending = false`),
+  `failed_attempts` is incremented, NVM persistence is called, and lockout
+  is engaged if `max_attempts` is reached. The return code remains
+  `REQUEST_OUT_OF_RANGE` so callers can distinguish a level mismatch from
+  a wrong-key submission. Two regression tests added (TC-SEC-KEY-007,
+  TC-SEC-KEY-008).
+
+---
+
 ## [1.10.0] — 2026-07-02
 
 ### Added

--- a/core/uds_security.c
+++ b/core/uds_security.c
@@ -255,6 +255,36 @@ uds_status_t uds_security_send_key(
 
     expected_seed_level = sec_key_level_to_seed_level(security_level);
     if (expected_seed_level != ctx->pending_level) {
+        /*
+         * [P4-SEC-01] Level mismatch must consume an attempt.
+         *
+         * An attacker can determine valid level/sub-function pairings by
+         * probing send_key with mismatched levels. Without consuming an
+         * attempt here, this probing never trips the lockout counter,
+         * undermining the ASIL-B security-access claim.
+         *
+         * Treatment: identical to an invalid key — seed consumed, counter
+         * incremented, lockout engaged if max_attempts reached — but NRC
+         * remains REQUEST_OUT_OF_RANGE so the caller can distinguish the
+         * error type from a wrong-key submission.
+         */
+        ctx->seed_pending = false;
+        ctx->failed_attempts++;
+
+        if (ctx->failed_attempts >= ctx->max_attempts) {
+            ctx->locked_out       = true;
+            ctx->lockout_timer_ms = ctx->lockout_duration_ms;
+            ctx->failed_attempts  = (uint8_t)0U;
+            if (ctx->nvm_save_cb != NULL) {
+                (void)ctx->nvm_save_cb((uint8_t)0U, ctx->lockout_timer_ms);
+            }
+            return UDS_STATUS_ERR_SEC_ATTEMPT_EXCEEDED;
+        }
+
+        if (ctx->nvm_save_cb != NULL) {
+            (void)ctx->nvm_save_cb(ctx->failed_attempts, (uint32_t)0U);
+        }
+
         return UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE;
     }
 

--- a/tests/unit_runnable/test_uds_security.c
+++ b/tests/unit_runnable/test_uds_security.c
@@ -455,6 +455,68 @@ ZTEST(test_uds_security_send_key, test_lockout_after_max_attempts)
                   "Request during lockout must return ATTEMPT_EXCEEDED");
 }
 
+/**
+ * TC-SEC-KEY-007: [P4-SEC-01] Key for wrong level → REQUEST_OUT_OF_RANGE,
+ *                 seed consumed, failed_attempts incremented.
+ *
+ * Seeds Level 1, then submits a Level 2 key.  Before the fix the early
+ * return left seed_pending = true and failed_attempts = 0, allowing
+ * unbounded level probing without triggering lockout.
+ */
+ZTEST(test_uds_security_send_key, test_wrong_level_key_consumed_as_failed_attempt)
+{
+    uds_security_ctx_t ctx;
+    zassert_equal(default_sec_init(&ctx), UDS_STATUS_OK, "init failed");
+
+    uint8_t seed[UDS_SECURITY_SEED_LEN]; uint8_t seed_len;
+    do_seed_request(&ctx, seed, &seed_len); /* seed pending at level 1 */
+
+    uint8_t key[UDS_SECURITY_KEY_LEN] = { 0x01U, 0x02U, 0x03U, 0x04U };
+    /* Submit Level-2 key while Level-1 seed is pending → mismatch */
+    uds_status_t rc = uds_security_send_key(&ctx, UDS_SEC_LEVEL_2_KEY,
+                                             key, (uint8_t)UDS_SECURITY_KEY_LEN);
+
+    zassert_equal(rc, UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE,
+                  "[P4-SEC-01] Level mismatch must return REQUEST_OUT_OF_RANGE");
+    zassert_false(ctx.seed_pending,
+                  "[P4-SEC-01] Seed must be consumed on level mismatch");
+    zassert_equal(ctx.failed_attempts, 1U,
+                  "[P4-SEC-01] Failed attempt must be counted on level mismatch");
+}
+
+/**
+ * TC-SEC-KEY-008: [P4-SEC-01] Three wrong-level submissions → lockout engaged.
+ *
+ * An attacker probing level/sub-function pairings must trip the lockout
+ * counter just like incorrect key values do.
+ */
+ZTEST(test_uds_security_send_key, test_wrong_level_triggers_lockout)
+{
+    uds_security_ctx_t ctx;
+    zassert_equal(default_sec_init(&ctx), UDS_STATUS_OK, "init failed");
+
+    uint8_t seed[UDS_SECURITY_SEED_LEN];
+    uint8_t seed_len = 0U;
+    uint8_t key[UDS_SECURITY_KEY_LEN] = { 0x01U, 0x02U, 0x03U, 0x04U };
+
+    for (int attempt = 1; attempt <= 3; attempt++) {
+        uds_status_t sr = do_seed_request(&ctx, seed, &seed_len);
+        if (ctx.locked_out) {
+            break;
+        }
+        zassert_equal(sr, UDS_STATUS_OK, "Seed request must succeed");
+        uds_security_send_key(&ctx, UDS_SEC_LEVEL_2_KEY,
+                              key, (uint8_t)UDS_SECURITY_KEY_LEN);
+    }
+
+    zassert_true(ctx.locked_out,
+                 "[P4-SEC-01] Must be locked out after 3 wrong-level submissions");
+
+    uds_status_t rc = do_seed_request(&ctx, seed, &seed_len);
+    zassert_equal(rc, UDS_STATUS_ERR_SEC_ATTEMPT_EXCEEDED,
+                  "Seed request after wrong-level lockout must return ATTEMPT_EXCEEDED");
+}
+
 /* =========================================================================
  * Test suite: uds_security_is_unlocked
  * ========================================================================= */


### PR DESCRIPTION
## Summary

`uds_security_send_key()` returned `REQUEST_OUT_OF_RANGE` immediately when the submitted key's security level didn't match the pending seed level — without touching `failed_attempts` or `seed_pending`. An attacker could enumerate valid level/sub-function pairings unboundedly without ever tripping the lockout counter.

**Root cause** — `core/uds_security.c:256-259` (pre-fix):
```c
expected_seed_level = sec_key_level_to_seed_level(security_level);
if (expected_seed_level != ctx->pending_level) {
    return UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE;  // seed not consumed, counter not incremented
}
```

**Fix** — on level mismatch: consume the seed (`seed_pending = false`), increment `failed_attempts`, call `nvm_save_cb`, engage lockout if `max_attempts` reached. Return code stays `REQUEST_OUT_OF_RANGE` so the caller can distinguish a level mismatch from a wrong-key error.

This is an ASIL-B audit finding (security hardening — not a customer-visible correctness bug, the key check and counter were intact for correct-level submissions).

## Files changed

- `core/uds_security.c`: mismatch branch now runs the full failed-attempt path
- `tests/unit_runnable/test_uds_security.c`: two new regression tests
  - **TC-SEC-KEY-007**: wrong-level key → `REQUEST_OUT_OF_RANGE`, `seed_pending = false`, `failed_attempts = 1`
  - **TC-SEC-KEY-008**: three wrong-level submissions → lockout engaged
- `CHANGELOG.md`: `[Unreleased]` section added

## Test plan

- [x] CI passes — 42 unit tests green (up from 40)
- [x] Harness: pre-existing `isotp_rx_complete_cb` warning unrelated to this fix (reproduces on `main` too)
- [x] TC-SEC-KEY-007 verifies mismatch consumes attempt
- [x] TC-SEC-KEY-008 verifies lockout fires after 3 wrong-level submissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)