### PR TITLE
fix: remove committed symlinks that break the ZIP overlay install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,12 @@ tools/mcp_server.py
 tools/jobrunner.py
 tools/testlab.py
 tools/job_library/
+# Delivered by the commercial ZIP (or dev-workflow symlinks to EDS-toolchain).
+# Never commit: as committed symlinks they dangle for every customer clone
+# and block the documented `unzip -o` install (see issue #67).
+tools/templates
+tools/testgen.py
+tools/_license.py
+harness
+safety_docs/
+tools/arxml_parser.py

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -67,12 +67,23 @@ unzip -o /path/to/xaloqi-eds-professional-v1.10.0.zip
 
 The `-o` flag overwrites existing files without prompting — required when updating an existing installation.
 
+> **Upgrading a clone made before 2026-07-06?** Earlier repo revisions contained
+> `tools/templates`, `tools/testgen.py`, `tools/_license.py`, and `harness` as
+> symbolic links, which caused `unzip -o` to fail with
+> `checkdir error: cannot create tools/templates: File exists`. If you see that
+> error, remove the stale links once and re-extract:
+>
+> ```bash
+> rm -f tools/templates tools/testgen.py tools/_license.py harness
+> unzip -o /path/to/xaloqi-eds-developer-v1.10.0.zip
+> ```
+
 This extracts the toolchain files directly into the repo tree. No separate directory. After extraction you will have:
 
 ```
 EDS/
 ├── tools/
-│   ├── templates/      ← now populated (was stub)
+│   ├── templates/      ← new
 │   ├── testgen.py      ← new
 │   ├── mcp_server.py   ← new
 │   └── _license.py     ← new

--- a/harness
+++ b/harness
@@ -1,1 +1,0 @@
-../EDS-toolchain/harness

--- a/tools/_license.py
+++ b/tools/_license.py
@@ -1,1 +1,0 @@
-../../EDS-toolchain/tools/_license.py

--- a/tools/templates
+++ b/tools/templates
@@ -1,1 +1,0 @@
-../../EDS-toolchain/tools/templates

--- a/tools/testgen.py
+++ b/tools/testgen.py
@@ -1,1 +1,0 @@
-../../EDS-toolchain/tools/testgen.py


### PR DESCRIPTION
## Problem (#67)

`tools/templates`, `tools/testgen.py`, `tools/_license.py`, and `harness` were committed as symlinks (mode 120000) pointing into a sibling `EDS-toolchain` checkout. In every customer/community clone they dangle, and the documented install (INSTALL.md Step 2, `unzip -o`) cannot replace a dangling directory symlink:

```
checkdir error:  cannot create tools/templates
                 File exists
```

Result: Developer customers never get the codegen templates (`codegen.py` exits 2 with *Template directory not found*), Professional customers never get the 68-test harness. Affects the shipped `v1.9.0` tag and `main`. Windows clones additionally materialize the links as plain text files.

## Fix

- `git rm --cached` the four symlinks — CI (`ci.yml` guards on `-f harness/harness_main.c`, "public repo does not ship _license.py or the Jinja2 templates") and `codegen.py`'s license fallback already treat these paths as not-shipped, so untracking restores the intended layout.
- Gitignore them (plus `safety_docs/` and `tools/arxml_parser.py`, which the ZIP also delivers) so the sibling-symlink developer workflow stays out of git and `git status` is clean after a ZIP install.
- INSTALL.md: migration note for existing clones (`rm -f` the stale links once, then re-extract) and the now-obsolete "was stub" annotation removed.

## Verification

On a fresh clone of this branch:
- `unzip -o xaloqi-eds-developer-v1.10.0.zip` → exit 0, templates installed, `codegen.py --safety-wrappers --asil-level B --test-gen` completes on `examples/bms_ecu`
- `unzip -o xaloqi-eds-professional-v1.10.0.zip` → exit 0, `harness/` + `safety_docs/` installed
- `git status` after extraction shows no untracked commercial files
- `build_tests.sh` on the branch: 42/42 pass

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)