### PR TITLE
fix(build): clear Professional-tier message when harness/ sources are absent

### DIFF
--- a/build_harness.sh
+++ b/build_harness.sh
@@ -46,6 +46,26 @@ for arg in "$@"; do
 done
 
 # ---------------------------------------------------------------------------
+# Harness sources are a Professional-tier deliverable (issue #68).
+# A community clone of this repo does not contain harness/ — fail with a
+# clear explanation instead of a page of cc1 fatal errors.
+# ---------------------------------------------------------------------------
+if [[ ! -f "${ROOT}/harness/harness_main.c" ]]; then
+    echo "ERROR: harness/ sources not found."
+    echo ""
+    echo "The 68-test integration harness is part of the Xaloqi EDS"
+    echo "Professional tier and is not included in the public repository."
+    echo "It is delivered in the Professional ZIP — extract it into this"
+    echo "repo root first (see INSTALL.md Step 2), then re-run this script."
+    echo ""
+    echo "Tiers and pricing: see COMMERCIAL_NOTICE.md or https://xaloqi.com"
+    echo ""
+    echo "The public unit test suite needs no commercial files:"
+    echo "  bash build_tests.sh"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
 # Source files
 # ---------------------------------------------------------------------------
 HARNESS_SRCS=(


### PR DESCRIPTION
## Problem (#68)

`build_harness.sh` is public and referenced in CONTRIBUTING.md's new-service checklist, but `harness/` is a Professional-tier deliverable not present in a community clone. Running it on a fresh clone produced raw compiler errors (`cc1: fatal error: harness/harness_main.c: No such file or directory`) with no hint that this is expected.

## Fix

Early check before any compilation: if `harness/harness_main.c` is absent, exit 1 with a message explaining the harness is a Professional ZIP deliverable (with the INSTALL.md extraction pointer and COMMERCIAL_NOTICE.md/xaloqi.com reference), and point community users at `build_tests.sh`, which needs no commercial files.

## Verification

- Fresh worktree without `harness/`: clean explanatory error, exit 1, zero compiler output.
- With harness sources present: builds and runs normally, **68/68 pass**.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)