### PR TITLE
fix(codegen): bump __version__ 1.7.0 → 1.10.0; bind it to CHANGELOG in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,6 +410,25 @@ jobs:
                 && echo "      If a deviation is required, document it per ISO 26262-8 §7 before changing." \
                 && exit 1)
 
+      # codegen's banner and the SOVD generatedBy stamp use __version__.
+      # It drifted to v1.7.0 while the product shipped v1.10.0 (INSTALL.md
+      # promises the current version in its expected output). Bind it to the
+      # top CHANGELOG entry so a release bump cannot miss it.
+      - name: Assert codegen __version__ matches top CHANGELOG version
+        run: |
+          python3 - <<'PYEOF'
+          import re, sys
+          changelog = re.search(r"^## \[(\d+\.\d+\.\d+)\]", open("CHANGELOG.md").read(), re.M)
+          codegen   = re.search(r"^__version__ = \"(\d+\.\d+\.\d+)\"", open("tools/codegen.py").read(), re.M)
+          assert changelog and codegen, "could not locate version strings"
+          cl, cg = changelog.group(1), codegen.group(1)
+          if cl != cg:
+              print(f"FAIL: tools/codegen.py __version__ is {cg} but CHANGELOG.md top entry is {cl}")
+              print("      Bump __version__ in tools/codegen.py as part of the release commit.")
+              sys.exit(1)
+          print(f"PASS: codegen __version__ {cg} matches CHANGELOG {cl}")
+          PYEOF
+
 
   # ── Job 5: Generated integration tests (simulator mode) ───────────────────
   #

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -100,7 +100,7 @@ except ImportError:
     print("ERROR: Jinja2 is required.  pip install jinja2", file=sys.stderr)
     sys.exit(2)
 
-__version__ = "1.7.0"
+__version__ = "1.10.0"
 
 # =============================================================================
 # Constants
@@ -851,7 +851,7 @@ def build_sovd_cda(cfg):
 
     cda = {
         "sovdVersion": "1.0.0",
-        "generatedBy": "Xaloqi EDS codegen v1.7.0",
+        "generatedBy": f"Xaloqi EDS codegen v{__version__}",
         "generatedAt": _now_utc(),
         "ecuIdentification": {
             "name":    meta["ecu_name"],


### PR DESCRIPTION
## Problem (validation report Bug 12)

`tools/codegen.py` printed `Code Generator v1.7.0` on a v1.10.0 product — INSTALL.md's expected-output block promises the current version. A second hardcoded `v1.7.0` lived in the SOVD `generatedBy` stamp.

## Fix

- `__version__` → `1.10.0`.
- `generatedBy` derives from `__version__` — one drift point instead of two.
- New CI step asserts `__version__` equals the top `CHANGELOG.md` entry, so the next release bump cannot miss it.

## Verification

- Banner prints `Code Generator v1.10.0`; generated `sovd_cda.json` stamps `Xaloqi EDS codegen v1.10.0`.
- CI guard logic self-tested against current files (PASS) and workflow YAML validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)