### PR TITLE
chore: gitignore CLAUDE.md and .claude/ (local agent context)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,11 @@ tools/mcp_server.py
 tools/jobrunner.py
 tools/testlab.py
 tools/job_library/
+# Local agent context — references private infrastructure and local paths;
+# must never reach the public repo. The file exists locally on dev machines.
+CLAUDE.md
+.claude/
+
 # Delivered by the commercial ZIP (or dev-workflow symlinks to EDS-toolchain).
 # Never commit: as committed symlinks they dangle for every customer clone
 # and block the documented `unzip -o` install (see issue #67).


### PR DESCRIPTION
Companion to the knowledge-base pointer rollout (EDS-toolchain#43, TestLab#34). For this **public** repo, the agent-context CLAUDE.md stays local-only — it references private infrastructure and local paths that must not be published. This gitignore entry guarantees a broad `git add` can never commit it.

The local file itself is created directly on the dev machine (untracked by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)