### PR TITLE
docs(codegen): name the license boundary when templates are absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ dtcs:
 
 **2. Generate everything:**
 
+> **Licensed step** — `tools/codegen.py` requires an EDS Developer or Professional license; the code-generation templates are the commercial deliverable. The runtime stack and the committed example outputs (`examples/*/generated/`) are fully GPL. See [COMMERCIAL_NOTICE.md](COMMERCIAL_NOTICE.md) or [xaloqi.com](https://xaloqi.com).
+
 ```bash
 python3 tools/codegen.py \
   --config diagnostics_config.yaml \
@@ -168,14 +170,16 @@ pip install -r tools/requirements.txt
 
 ### Run the basic ECU example
 
+> **No license? Skip the codegen step.** This example's generated code is committed under `examples/basic_ecu/generated/`, so `west build` works out of the box on the GPL runtime. The `codegen.py` step below regenerates it and **requires a Developer/Professional license** (templates are commercial — see [COMMERCIAL_NOTICE.md](COMMERCIAL_NOTICE.md)).
+
 ```bash
-# Generate code from the bundled example config
+# Generate code from the bundled example config  (licensed step — see note above)
 python3 tools/codegen.py \
   --config examples/basic_ecu/diagnostics_config.yaml \
   --out    examples/basic_ecu/generated/ \
   --safety-wrappers --asil-level B --test-gen
 
-# Build and run in simulator
+# Build and run in simulator  (works without a license — generated/ is committed)
 west build -b native_sim examples/basic_ecu \
   -- -DDTC_OVERLAY_FILE=boards/native_sim/native_sim.overlay
 west build -t run
@@ -188,6 +192,8 @@ west build -t run
 git clone --depth=1 https://github.com/FreeRTOS/FreeRTOS-Kernel.git /opt/freertos-kernel
 
 # Generate code (same YAML as basic_ecu)
+# Licensed step — requires a Developer/Professional license (templates are commercial).
+# No license? This example's generated/ is committed; skip straight to west build.
 python3 tools/codegen.py \
   --config examples/basic_ecu_freertos/diagnostics_config.yaml \
   --out    examples/basic_ecu_freertos/generated/ \
@@ -235,7 +241,7 @@ cd examples/basic_ecu/generated/tests && pytest test_services.py test_did_*.py -
 ```
 diagnostics_config.yaml
         │
-        ▼  python3 tools/codegen.py
+        ▼  python3 tools/codegen.py   (licensed — Developer/Professional)
 ┌─────────────────────────────────────────┐
 │  Generated C (ASIL-B)                   │
 │  did_handlers.c  did_safety_wrappers.c  │
@@ -244,7 +250,7 @@ diagnostics_config.yaml
                  │
 ┌────────────────▼────────────────────────┐
 │  UDS Server Core  (core/)               │
-│  15 service handlers · session FSM      │
+│  19 service handlers · session FSM      │
 │  security manager · ASIL-B dispatcher   │
 └────────────────┬────────────────────────┘
                  │

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -211,6 +211,26 @@ def _fatal(message: str, code: int = 1) -> None:
     sys.exit(code)
 
 
+def _fatal_no_templates(template_dir: "Path") -> None:
+    """Fatal exit when the Jinja2 templates are absent.
+
+    The templates are the commercial deliverable, so their absence in a
+    community clone is a licensing boundary, not a bug — say so plainly, or
+    a GPL user reads 'template directory not found' as broken software.
+    """
+    _fatal(
+        f"Code generator templates not found: {template_dir}\n"
+        "       The templates are part of the Xaloqi EDS Developer license.\n"
+        "       The runtime stack and the committed example outputs "
+        "(examples/*/generated/) are fully GPL and free to use; the code\n"
+        "       generator itself requires a license. See COMMERCIAL_NOTICE.md,\n"
+        "       or https://xaloqi.com to obtain a Developer or Professional license.\n"
+        "       (Already licensed? Extract the toolchain ZIP into the repo root, "
+        "or pass --template-dir to point at your templates.)",
+        code=2,
+    )
+
+
 def _warn(message: str) -> None:
     """Print a non-fatal warning to stderr."""
     print(f"[codegen] WARN: {message}", file=sys.stderr)
@@ -1207,11 +1227,7 @@ def render_and_write(
         SystemExit(2): if the template directory does not exist.
     """
     if not template_dir.is_dir():
-        _fatal(
-            f"Template directory not found: {template_dir}. "
-            "Pass --template-dir to specify an alternate location.",
-            code=2
-        )
+        _fatal_no_templates(template_dir)
 
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1314,10 +1330,7 @@ def render_safety_wrappers(
         SystemExit(3): on any Jinja2 rendering error.
     """
     if not template_dir.is_dir():
-        _fatal(
-            f"Template directory not found: {template_dir}.",
-            code=2
-        )
+        _fatal_no_templates(template_dir)
 
     output_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Why

A GPL user who clones the public repo and runs the README's codegen command hits `Template directory not found`. The templates are the commercial deliverable (0 ship in the public repo), so this is a **licensing boundary** — but the error and the README present it as if codegen should just work, so it reads as broken software or crippleware. This is the most likely trigger behind #76 (not confirmed), from a community contributor whose issue history shows she wants to generate her own ECU configs — exactly what the template paywall blocks.

The open-core model is fine; the *presentation* manufactured the grievance. This makes the boundary honest and upfront.

## Changes

- **codegen.py** — both template-missing exit sites now call `_fatal_no_templates()`, which states plainly: templates are part of the EDS Developer license; the runtime stack and the committed example outputs (`examples/*/generated/`) are fully GPL; the generator requires a license (→ COMMERCIAL_NOTICE.md / xaloqi.com). Keeps the `--template-dir` hint for licensed users who extracted elsewhere.
- **README** — all four `tools/codegen.py` invocations marked as licensed steps. For the two bundled-example sections, the note also surfaces the fact that `generated/` **is committed**, so `west build` works with no license and the codegen step can be skipped — directly defusing the exact wall a GPL user hits.
- Corrected a stale `15 service handlers` → **19** in the architecture diagram being edited (same drift class as run-009).

## Verified

- Community-clone path (no templates): new message fires, exit 2. ✅
- Licensed path (templates present): codegen completes normally — no regression. ✅

Pairs with the #76 reply (which can now point at the clarified boundary) and strengthens the OD-15 free-tier case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)