### PR TITLE
docs: make the open-core boundary explicit and upfront

### DIFF
--- a/COMMERCIAL_NOTICE.md
+++ b/COMMERCIAL_NOTICE.md
@@ -5,6 +5,27 @@ boundary explicit for anyone reading or contributing to this repository.
 
 ---
 
+## The short version
+
+**You can clone this repo and build, run, study, and modify the full
+diagnostics stack and every bundled example for free, under GPL v2.** The
+examples ship their generated C (`examples/*/generated/`), so `west build`
+works with no license.
+
+A commercial license is required for two things:
+
+1. **Running the code generator on your own config** — `tools/codegen.py`
+   is readable and runs, but the Jinja2 templates it needs
+   (`tools/templates/`) are the commercial deliverable and are not in this
+   repo. Running codegen without them fails with a message pointing here.
+2. **Shipping proprietary (closed-source) firmware** — GPL v2 requires you
+   to release the source of anything you link the runtime into; a
+   commercial license lifts that so you can keep your firmware private.
+
+If neither applies to you, you owe nothing. Details below.
+
+---
+
 ## What is free (GPL v2)
 
 The following components are open source under the GNU General Public
@@ -44,9 +65,12 @@ paid commercial license from Xaloqi:
 | `tools/config_parser.py` | Publicly readable. Used by `codegen.py` — same license requirement applies. |
 | `tools/templates/` | All Jinja2 code generation templates |
 | `ide/vscode-extension/` | VS Code extension for EDS |
-| `docs/EDS_Safety_Manual_*` | Safety Manual (Professional tier) |
-| `docs/MISRA_DEVIATION_LOG.md` | MISRA C Deviation Log (Professional tier) |
-| `docs/EDS_Requirements_Traceability_Matrix.csv` | RTM (Professional tier) |
+| `tools/arxml_parser.py`, `tools/mcp_server.py`, `tools/eds_ai.py` | ARXML importer, MCP server, AI assistant (Developer tier) |
+
+The safety documentation package — Safety Manual (EDS-SM-001), HARA, Tool
+Qualification Argument, MISRA Deviation Log, Requirements Traceability
+Matrix, and OEM Key Provisioning Guide — is **not in this repository**. It
+is delivered as part of the **Professional** tier ZIP.
 
 Using any of the above files in a project — commercial or otherwise —
 without a valid Xaloqi commercial license is a violation of Xaloqi's
@@ -56,12 +80,16 @@ intellectual property rights.
 
 ## How to get a commercial license
 
-Three tiers are available at **https://xaloqi.com**:
+EDS is available in two tiers at **https://xaloqi.com**:
 
 | Tier | Price | Includes |
 |---|---|---|
-| Developer | €690 / year | Runtime + codegen + testgen + templates + VS Code extension + Integration Guide |
-| Professional | €1,990 / year | Developer tier + Safety Manual + MISRA Log + RTM + priority support |
+| Developer | €690 / year | Runtime + codegen + testgen + templates + ARXML importer + VS Code extension + MCP/AI tools + Integration Guide |
+| Professional | €1,990 / year | Developer tier + 68-test integration harness + safety documentation package (Safety Manual, HARA, TQA, MISRA Log, RTM, Key Provisioning Guide) + priority support |
+
+Xaloqi TestLab (the validation campaign runner) and the discounted
+**Developer + TestLab** and **Professional + TestLab** bundles are also
+available at xaloqi.com.
 
 A commercial license grants you the right to use Xaloqi EDS in one
 proprietary project per seat, ship binary firmware to your customers,

--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ EDS replaces that with a configuration-driven workflow. Define your ECU's diagno
 
 ---
 
+## Open-core: what's free, what's licensed
+
+EDS is dual-licensed. The runtime stack is GPL v2 and the whole thing builds and runs out of the box — the commercial license is for **generating your own configs** and **shipping proprietary firmware**.
+
+| Free — GPL v2 (runtime) / Apache-2.0 (examples) | Licensed — Developer / Professional |
+|---|---|
+| Full runtime stack: UDS server, ISO-TP, DoIP, security access, ASIL-B safety chain (`core/`, `transport/`, `config/`, `platform/`) | The code generator's **templates** — `tools/codegen.py` is readable and runs, but needs the commercial `tools/templates/` to produce output |
+| Every bundled example **including its committed generated C** — `west build` and run today, no license needed | Test generator (`testgen.py`), ARXML importer, VS Code extension, MCP server, AI assistant |
+| Study, modify, and redistribute under GPL v2 | Generating code for **proprietary** firmware; shipping closed-source firmware |
+| | Safety documentation package (Professional tier) |
+
+**In short:** clone this repo and you can build, run, and study the full stack and every example for free. A [Developer license](COMMERCIAL_NOTICE.md) adds the generator templates (regenerate from your own YAML) and the right to ship proprietary firmware. Full boundary: [COMMERCIAL_NOTICE.md](COMMERCIAL_NOTICE.md).
+
+---
+
 ## 60-second walkthrough
 
 **1. Describe your ECU's diagnostic interface:**


### PR DESCRIPTION
Sets expectations about the free/licensed split *before* anyone runs a command, so the boundary reads as deliberate open-core positioning rather than something you discover when codegen fails. First thing incoming Zephyr-registry / west-module traffic will read.

## README

New **Open-core: what's free, what's licensed** section right before the 60-second walkthrough — a two-column table (free runtime + examples incl. committed generated C · licensed generator templates, testgen, tooling, safety docs) and a one-line summary: clone and build everything for free; a Developer license adds config generation and the right to ship proprietary firmware.

## COMMERCIAL_NOTICE.md

- **New 'short version' up top** answering the actual question a reader has — *what can I do for free, and what costs money* — including the fact that examples build with no license because `generated/` is committed.
- **Fixed stale references:** the safety docs were listed as `docs/EDS_Safety_Manual_*` etc., but they are not in the public repo — they ship in the Professional ZIP. Now described accurately.
- **Fixed 'Three tiers' → two** EDS tiers with correct contents; added a pointer to TestLab and the Dev/Pro + TestLab bundles; listed the arxml/mcp/ai tools under licensed.

No code changes. Pairs with the codegen error-message clarity in #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)