### PR TITLE
chore(release): v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+---
+
+## [1.10.1] — 2026-08-27
+
 ### Fixed
 
 - **`build_harness.sh` now explains itself on a community clone.** (#68, #70)
@@ -20,6 +24,23 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   `__version__` bumped to 1.10.0, the SOVD stamp now derives from it, and a
   CI step asserts `__version__` matches the top entry of this file so the
   next release bump cannot miss it.
+
+### Changed
+
+- **Safety Manual reference updated to Rev 1.3.** (#75) INSTALL.md's tier
+  description and document table pointed at the superseded Rev 1.1; the
+  Professional ZIP has shipped Rev 1.3 since the 2026-07-07 rebuild.
+- **codegen's "no templates" error now explains the license boundary.** (#77)
+  Running `codegen.py` without the Developer/Professional templates used to
+  fail with a bare "template directory not found." The error now states
+  plainly that the runtime stack and example outputs are GPL and free to use,
+  while the code generator requires a license — with a pointer to
+  `COMMERCIAL_NOTICE.md`.
+- **README and COMMERCIAL_NOTICE spell out the open-core boundary up front.**
+  (#78) A new "what's free, what's licensed" section in the README, and a
+  corrected COMMERCIAL_NOTICE (it previously referenced non-existent
+  `docs/EDS_Safety_Manual_*` paths and undercounted the license tiers),
+  so the free/paid line is explicit before a user hits it as an error.
 
 ---
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 > repo. Community users cloning the public repo can ignore this file.
 
 **Product:** Xaloqi EDS (Xaloqi Embedded Diagnostic Suite)  
-**Version:** v1.10.0  
+**Version:** v1.10.1  
 **Support:** contact@xaloqi.com
 
 ---
@@ -50,7 +50,7 @@ cd EDS
 Verify you are on the correct version:
 
 ```bash
-git checkout v1.10.0
+git checkout v1.10.1
 ```
 
 ---
@@ -59,10 +59,10 @@ git checkout v1.10.0
 
 ```bash
 # From the EDS repo root:
-unzip -o /path/to/xaloqi-eds-developer-v1.10.0.zip
+unzip -o /path/to/xaloqi-eds-developer-v1.10.1.zip
 
 # Or for Professional:
-unzip -o /path/to/xaloqi-eds-professional-v1.10.0.zip
+unzip -o /path/to/xaloqi-eds-professional-v1.10.1.zip
 ```
 
 The `-o` flag overwrites existing files without prompting — required when updating an existing installation.
@@ -75,7 +75,7 @@ The `-o` flag overwrites existing files without prompting — required when upda
 >
 > ```bash
 > rm -f tools/templates tools/testgen.py tools/_license.py harness
-> unzip -o /path/to/xaloqi-eds-developer-v1.10.0.zip
+> unzip -o /path/to/xaloqi-eds-developer-v1.10.1.zip
 > ```
 
 This extracts the toolchain files directly into the repo tree. No separate directory. After extraction you will have:
@@ -185,7 +185,7 @@ Expected output:
 
 ```
 ========================================================================
-  Xaloqi EDS — Code Generator v1.10.0
+  Xaloqi EDS — Code Generator v1.10.1
 ========================================================================
   Config   : examples/bms_ecu/diagnostics_config.yaml
   ...

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Xaloqi Embedded Diagnostics Suite
 
 [![CI](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml/badge.svg)](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-v1.10.0-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.10.0)
+[![Version](https://img.shields.io/badge/version-v1.10.1-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.10.1)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](LICENSE)
 [![Zephyr](https://img.shields.io/badge/Zephyr-v3.7%2B-brightgreen)](https://zephyrproject.org)
 
@@ -154,7 +154,7 @@ manifest:
   projects:
     - name: EDS
       remote: xaloqi
-      revision: v1.10.0
+      revision: v1.10.1
       path: modules/eds
 ```
 
@@ -178,7 +178,7 @@ The `ZEPHYR_EDS_MODULE_DIR` variable is set automatically by west when the modul
 
 ```bash
 pip install west
-west init -m https://github.com/Xaloqi/EDS --mr v1.10.0 eds-workspace
+west init -m https://github.com/Xaloqi/EDS --mr v1.10.1 eds-workspace
 cd eds-workspace && west update
 pip install -r tools/requirements.txt
 ```

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -100,7 +100,7 @@ except ImportError:
     print("ERROR: Jinja2 is required.  pip install jinja2", file=sys.stderr)
     sys.exit(2)
 
-__version__ = "1.10.0"
+__version__ = "1.10.1"
 
 # =============================================================================
 # Constants


### PR DESCRIPTION
## What
Rolls `[Unreleased]` into `[1.10.1]`. No functional code changes — this is the CHANGELOG roll + version bump for a release that's already merged content (#68, #70, #71, #75, #77, #78 all landed on main since the v1.10.0 tag).

## CHANGELOG entries added for previously-undocumented PRs
- #75 Safety Manual Rev 1.1 → Rev 1.3 reference fix
- #77 codegen license-boundary error message
- #78 README/COMMERCIAL_NOTICE open-core clarity

## Version bumps (kept in lockstep — CI guard checks codegen.py `__version__` against top CHANGELOG entry)
- `tools/codegen.py` `__version__`: 1.10.0 → 1.10.1
- `INSTALL.md`: 6 references
- `README.md`: version badge + west manifest examples (3 references)

## Verification
- `bash build_tests.sh`: **42/42 passed**
- Local CHANGELOG/codegen version-guard check: PASS

## After merge
1. Tag `v1.10.1` on main
2. EDS-toolchain: bump `EDS_VERSION` default, rebuild ZIPs via `build_release.sh` (release gate auto-runs)
3. Upload to `delivery-v1.10.1` + Polar (founder action per ops/release-runbook.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)