### PR TITLE
Automate the public GitHub Release on every version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Publish GitHub Release
+
+# Automates the public Release object for every version tag — closes the
+# failure class found 2026-08-27 (O-10, xaloqi-knowledge
+# reviews/FINDINGS.md): v1.10.1 was tagged and shipped, but no GitHub
+# Release was ever published for it, so this repo's public Releases page
+# kept showing v1.10.0 as "Latest" for a full release cycle. A git tag and
+# a GitHub Release are different objects — creating one does not create
+# the other, and a purely manual "don't forget" step is exactly the kind
+# of step that gets forgotten.
+#
+# Deliberately does NOT automate the CHANGELOG roll, version bumps, or the
+# docs sweep (scripts/check_release_docs.py in xaloqi-knowledge) — those
+# must all happen and pass BEFORE a tag is pushed, and involve judgment
+# calls a workflow shouldn't make unattended. This only fires once a tag
+# already exists and only creates the Release for it.
+#
+# Release notes are extracted verbatim from the tagged CHANGELOG section
+# (scripts/extract_changelog_section.py) — mechanical, not hand-polished
+# prose. `gh release edit <tag> --notes-file ...` afterward if nicer
+# wording is wanted; the goal here is that a Release always exists and is
+# always marked Latest, not that its wording matches past releases exactly.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch: {}   # manual re-run, e.g. after fixing a CHANGELOG typo
+
+permissions:
+  contents: write   # gh release create/edit in this same repo — no external secret needed
+
+jobs:
+  release:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Create the Release (idempotent) if this is a real tag push
+        if: github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/ci_publish_release.sh "${GITHUB_REF_NAME}"

--- a/scripts/ci_publish_release.sh
+++ b/scripts/ci_publish_release.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# scripts/ci_publish_release.sh — create the public GitHub Release for a
+# tag, idempotently, with notes drawn from CHANGELOG.md. Called by
+# .github/workflows/release.yml on every v* tag push. See that workflow's
+# header comment for why this exists (O-10, xaloqi-knowledge
+# reviews/FINDINGS.md) and what it deliberately does NOT automate.
+#
+# Usage: ci_publish_release.sh vX.Y.Z
+# Requires GH_TOKEN in the environment (contents: write on this repo).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TAG="${1:?Usage: ci_publish_release.sh vX.Y.Z}"
+VERSION="${TAG#v}"
+GH_REPO="Xaloqi/EDS"
+
+if gh release view "$TAG" --repo "$GH_REPO" >/dev/null 2>&1; then
+  echo "Release $TAG already exists — skipping creation."
+else
+  notes_file="$(mktemp)"
+  python3 "$REPO_ROOT/scripts/extract_changelog_section.py" \
+    "$REPO_ROOT/CHANGELOG.md" "$VERSION" > "$notes_file"
+  {
+    echo
+    echo "---"
+    echo
+    echo "**Full changelog:** [CHANGELOG.md](https://github.com/${GH_REPO}/blob/main/CHANGELOG.md)"
+  } >> "$notes_file"
+
+  gh release create "$TAG" \
+    --repo "$GH_REPO" \
+    --title "EDS $TAG" \
+    --notes-file "$notes_file" \
+    --latest
+
+  echo "Created Release $TAG."
+fi
+
+# Idempotent safety net: a Release can exist without being Latest (e.g.
+# --latest was omitted on manual creation once, or an older tag got
+# re-marked latest by mistake) — this is exactly the O-10 failure shape,
+# just checked here instead of by a separate script run after the fact.
+latest="$(gh api "repos/${GH_REPO}/releases/latest" --jq .tag_name)"
+if [ "$latest" != "$TAG" ]; then
+  echo "Release $TAG exists but repo Latest is $latest — fixing."
+  gh release edit "$TAG" --repo "$GH_REPO" --latest
+else
+  echo "OK: $TAG is the repo's Latest release."
+fi

--- a/scripts/extract_changelog_section.py
+++ b/scripts/extract_changelog_section.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Extract one version's section from a Keep-a-Changelog CHANGELOG.md,
+for use as GitHub Release notes.
+
+Used by .github/workflows/release.yml so a Release's notes are drawn
+mechanically from the tagged CHANGELOG section rather than depending on
+someone hand-drafting them — that dependency is exactly how a tag has
+shipped with no public Release before (O-10, xaloqi-knowledge
+reviews/FINDINGS.md): a manual step with no hard trigger is a manual step
+that gets skipped.
+
+Finds the line matching `## [<version>]` (anything may follow on that
+line, e.g. " — 2026-08-27" or " *(tag updated ...)*"), and returns
+everything up to (not including) the next `## [` heading, with leading/
+trailing blank lines and a lone trailing `---` separator stripped.
+
+Usage:
+    python3 scripts/extract_changelog_section.py CHANGELOG.md 1.10.1
+
+Exit 1 with a message on stderr if the version heading isn't found —
+loud failure, not an empty/silent release body.
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+
+def extract(changelog_text: str, version: str) -> str:
+    lines = changelog_text.splitlines()
+    heading_re = re.compile(r"^## \[")
+    target_re = re.compile(r"^## \[" + re.escape(version) + r"\]")
+
+    start = None
+    for i, line in enumerate(lines):
+        if target_re.match(line):
+            start = i + 1
+            break
+    if start is None:
+        raise SystemExit(
+            f"ERROR: no '## [{version}]' heading found in changelog. "
+            "Was the CHANGELOG roll (runbook step 1) actually done before tagging?"
+        )
+
+    end = len(lines)
+    for j in range(start, len(lines)):
+        if heading_re.match(lines[j]):
+            end = j
+            break
+
+    section = lines[start:end]
+
+    # Trim leading/trailing blank lines, and a lone trailing '---' separator
+    # (the format between sections is: content, blank, '---', blank, next heading).
+    while section and not section[0].strip():
+        section.pop(0)
+    while section and not section[-1].strip():
+        section.pop()
+    if section and section[-1].strip() == "---":
+        section.pop()
+        while section and not section[-1].strip():
+            section.pop()
+
+    return "\n".join(section)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} CHANGELOG.md VERSION", file=sys.stderr)
+        return 1
+    path, version = sys.argv[1], sys.argv[2]
+    with open(path, encoding="utf-8") as fh:
+        text = fh.read()
+    print(extract(text, version))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Same failure class TestLab hit twice this week (O-16, O-17, xaloqi-knowledge
`reviews/FINDINGS.md`) already happened here too: `v1.10.1` was tagged and
shipped 2026-08-27, but no GitHub Release was ever published for it —
this repo's public Releases page kept showing `v1.10.0` as "Latest" for a
full release cycle (found only via `check_github_release.py`, run after
the fact). Runbook steps 4-5 currently rely on a human/agent remembering
to run `gh release create` manually every single release.

## What

`.github/workflows/release.yml` fires on every `v*` tag push:
1. Skips if a Release for the tag already exists (idempotent)
2. Otherwise creates one — title `EDS vX.Y.Z`, notes extracted **verbatim**
   from the tagged `## [X.Y.Z]` section of `CHANGELOG.md`
   (`scripts/extract_changelog_section.py`), `--latest`
3. Separately verifies the repo's actual Latest release points at this
   tag, and fixes it if not — the O-10 shape itself, checked automatically
   instead of by a human running `check_github_release.py` after the fact

Uses the workflow's own default `GITHUB_TOKEN` (no new secret needed —
this workflow only touches its own repo, unlike TestLab's cross-repo sync).

## What this deliberately does NOT automate

The CHANGELOG roll, version bumps, and the docs sweep
(`check_release_docs.py`) all still need a human/agent judgment call and
must happen **before** a tag is pushed — this workflow only fires once a
tag already exists. Tagging itself (`git tag && git push`, runbook step 4)
stays manual too.

Release notes are mechanical extraction, not the hand-polished prose some
past releases have — `gh release edit <tag> --notes-file ...` afterward if
nicer wording is wanted. The goal is a Release that always exists and is
always Latest, not perfect wording every time.

## Verified

- `extract_changelog_section.py` against 3 real cases: `v1.10.1` (normal),
  `v1.10.0` (a parenthetical-suffix heading — `*(tag updated ...)*`), and a
  nonexistent version (fails loudly, exit 1, doesn't emit an empty body)
- `ci_publish_release.sh`'s idempotent path against the real `v1.10.1`
  release — read-only, confirmed "already exists" + "is Latest", created
  nothing
- YAML parses clean (`python3 -m yaml`) and `bash -n` on the shell script
  — the exact class of bug that bit TestLab's equivalent workflow (PR #49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)