### PR TITLE
docs: fix unqualified ASIL-B ready claim + UDS-without-AUTOSAR line

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@
 
 Software Bill of Materials: [sbom.json](sbom.json) (CycloneDX 1.4)
 
-**Production-grade UDS diagnostics for Zephyr RTOS and FreeRTOS — configured in YAML, generated in seconds.**
+**UDS without AUTOSAR — production-grade ISO 14229 diagnostics for Zephyr RTOS and FreeRTOS, configured in YAML, generated in seconds.**
 
-Describe your DIDs and DTCs once. Get ISO 14229-compliant C code, ASIL-B safety wrappers, a full pytest suite, and CANoe CAPL scripts — all from a single `diagnostics_config.yaml`. No boilerplate. No hand-rolled session logic. Runs on `native_sim` in CI and on real CAN hardware the same day.
+No AUTOSAR Classic RTE/COM stack to adopt just to get session control,
+security access, and DTC handling. Describe your DIDs and DTCs once. Get ISO 14229-compliant C code, ASIL-B safety wrappers, a full pytest suite, and CANoe CAPL scripts — all from a single `diagnostics_config.yaml`. No boilerplate. No hand-rolled session logic. Runs on `native_sim` in CI and on real CAN hardware the same day.
 
 ---
 

--- a/docs/assets/gui_dashboard.svg
+++ b/docs/assets/gui_dashboard.svg
@@ -397,7 +397,7 @@
   <!-- ASIL-B status -->
   <text x="776" y="642" font-size="10" fill="#64748b" font-weight="600" letter-spacing="0.8">SAFETY</text>
   <rect x="776" y="650" width="120" height="22" rx="4" fill="#052e16" stroke="#166534" stroke-width="1"/>
-  <text x="836" y="665" font-size="10" fill="#4ade80" font-weight="700" text-anchor="middle">ASIL-B Ready</text>
+  <text x="836" y="665" font-size="10" fill="#4ade80" font-weight="700" text-anchor="middle">ASIL-B Oriented</text>
   <text x="776" y="685" font-size="10" fill="#64748b">5-step wrapper</text>
   <circle cx="884" cy="682" r="4" fill="#10b981"/>
   <text x="776" y="700" font-size="10" fill="#64748b">Safety self-test</text>


### PR DESCRIPTION
## What
- `docs/assets/gui_dashboard.svg`: "ASIL-B Ready" → "ASIL-B Oriented" in the dashboard mockup safety badge.
- `README.md`: fold in the "UDS without AUTOSAR" positioning line (adopted in `xaloqi-knowledge/strategy/positioning.md`) on the first screen.

## Why
Roadmap Now #2 ([xaloqi-knowledge/roadmap/ROADMAP.md](https://github.com/Xaloqi/xaloqi-knowledge/blob/master/roadmap/ROADMAP.md)): the code is genuinely ASIL-B-*oriented* (5-step chain, MISRA-clean, static allocation, self-test) but **not** ASIL-B qualified — no independent assessment exists. The repo description (fixed separately via `gh repo edit`, not a file change — now reads "ASIL-B-oriented architecture") and this SVG asset were the only two places carrying the unqualified "ready" claim.

Audited `README.md`, `docs/`, `examples/*/README.md`, `SECURITY.md`, `CONTRIBUTING.md`, `CHANGELOG.md` for the phrase — everywhere else (`Safety_Model.md`, `INSTALL.md`, `INTEGRATION_GUIDE.md`, etc.) already correctly says "ASIL-B candidate" / hedges appropriately. Nothing else to fix in this repo.

Also picks up Now #1's positioning line ("UDS without AUTOSAR" — names the buyer's actual alternative, adopted from an external GTM review, see ROADMAP.md's "Rejected prescriptions" section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)