### PR TITLE
docs(security): state the 4-byte key-response truncation honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   `UDS_STATUS_ERR_SEC_SEED_UNAVAILABLE` for the production hard refusal).
   See `SECURITY.md` for the full dev-vs-production behaviour table.
 
+### Documentation
+
+- `SECURITY.md` / `README.md`: state the SecurityAccess key *response*
+  truncation (4 bytes; the seed stays 8 bytes) explicitly, and distinguish
+  online-guess hardness (bounded by the 4-byte truncation, defended by the
+  3-attempt NVM-persisted lockout) from key-derivation hardness (128-bit,
+  via AES-128-CMAC). Closes the gap an external security review's 4/10
+  rating was largely driven by — the public docs previously said only
+  "AES-128-CMAC" with no mention of the truncation.
+
 ---
 
 ## [1.10.1] — 2026-08-27

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The generator produces: DID handler stubs, ASIL-B safety wrappers, DTC registrat
 | **ISO-TP transport** | SF / FF / CF / FC · N_As / N_Bs / N_Cr timing · STmin sub-ms range |
 | **DoIP transport** | ISO 13400-2 server — Routing Activation · DiagnosticMessage dispatch · Positive/Negative Ack · Alive Check · Zephyr (zsock_*) and FreeRTOS+LwIP bindings · same UDS core, no code changes |
 | **ASIL-B safety chain** | 5-step DID validation enforced at codegen time — cannot be bypassed at runtime |
-| **Security** | AES-128-CMAC seed/key · TRNG-backed · configurable per-session levels · lockout with NVM persistence |
+| **Security** | AES-128-CMAC seed / 4-byte key response ([threat model](SECURITY.md#security-architecture-notes)) · TRNG-backed · configurable per-session levels · lockout with NVM persistence |
 | **DTC persistence** | NVM mirror survives power cycles · 0x14 ClearDTC · 0x19 ReadDTCInformation |
 | **Code generation** | YAML → 17 Jinja2 templates · CLI · reproducible deterministic output |
 | **Test generation** | YAML → pytest suite per DID and DTC · simulator mode (no hardware) · firmware harness mode |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -83,6 +83,22 @@ and credit you in the release notes unless you prefer to remain anonymous.
 in `core/uds_aes_cmac.c` is table-free and cache-timing resistant. Key material is
 scrubbed from stack memory after use.
 
+The key *response* sent back to the ECU is truncated to 4 bytes (the seed stays the full
+8 bytes). This is conventional for UDS SecurityAccess — ISO 14229-1 does not mandate a
+key length, and 2–4 byte responses are standard in production stacks. Two attacker
+models follow from this, with different actual strengths, and they should not be
+conflated:
+
+- *Guessing a valid response online* (sending seed/key attempts to the ECU over the bus)
+  is bounded by the 4-byte truncation — a 32-bit search space, not 128-bit. What makes
+  this impractical is not AES-128's hardness but attempt-limiting: `UDS_SECURITY_MAX_ATTEMPTS`
+  (3) consecutive failed attempts trigger a lockout whose state is persisted to NVM, so
+  it survives a power cycle.
+- *Deriving the level key* from captured `(seed, key)` pairs without brute-forcing online
+  is a separate, much harder problem — this is what the AES-128-CMAC construction
+  actually protects against, since CMAC is a secure PRF under the standard AES-128
+  hardness assumption.
+
 **Placeholder keys:** The repository ships with placeholder AES-128 keys
 (`0x00..0x0F` / `0x10..0x1F`). A compile-time gate (`CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY`)
 and a runtime guard in the generated init sequence prevent accidental deployment of


### PR DESCRIPTION
Roadmap Now #5's second half — "document the SecurityAccess threat model honestly."

An external security review rated EDS's security architecture 4/10, "driven largely by the 4-byte CMAC truncation." The public docs (`SECURITY.md`, `README.md`) said only "AES-128-CMAC" and never mentioned that the key **response** sent back to the ECU is truncated to 4 bytes (the seed stays 8 bytes) — which reads, to a skimming evaluator, as implying full 128-bit online-auth strength.

## The fix states the design honestly, not weaker than it is

2–4 byte key responses are conventional for UDS SecurityAccess — ISO 14229-1 does not mandate a length. The gap wasn't the design choice, it was the silence about it. Separates two attacker models that were being conflated:

- **Guessing a valid response online** — bounded by the 4-byte truncation (2³² search space, not 2¹²⁸). What actually makes this impractical is `UDS_SECURITY_MAX_ATTEMPTS` (3 consecutive failures) triggering an NVM-persisted lockout, not AES-128's hardness.
- **Deriving the level key** from captured `(seed, key)` pairs — the much harder problem AES-128-CMAC actually protects against, since CMAC is a secure PRF under the standard AES-128 hardness assumption.

## Mirrors the private doc's equivalent fix

[EDS-Safety#3](https://github.com/Xaloqi/EDS-Safety/pull/3) fixed the same class of overclaim in the private Security Integration Guide, which already disclosed the truncation but had one sentence ("Breaking it requires breaking AES-128") that read as covering both attacker models when it only covers the second.

## Gates

Docs-only. `bash build_tests.sh` confirmed unaffected: **43 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)