### PR TITLE
fix: uds_safety_reset_counters() now clears platform_violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **`uds_safety_reset_counters()` now clears `platform_violations`.** (#86)
+  `platform_violations` was added to `uds_safety_ctx_t` by the `[HIGH-2]` fix
+  after `uds_safety_reset_counters()` was already written, and was never
+  wired into it — every other counter (`null_check_violations`,
+  `session_check_violations`, `security_check_violations`,
+  `bounds_check_violations`, `total_checks_performed`,
+  `last_violation_code`) was reset, but `platform_violations` survived the
+  call. `uds_safety_init()` already zeroed it correctly; only the
+  test-harness-only reset path was affected — this function must not be
+  called in production firmware. `tests/unit_runnable/test_uds_safety.c`
+  gained a regression test, and `tests/unit_runnable/test_trng_fail_closed.c`
+  no longer needs to work around the bug with delta-based counter
+  assertions.
+
 ### Security
 
 - **SecurityAccess entropy fallback now fails closed in production builds.**

--- a/core/uds_safety.c
+++ b/core/uds_safety.c
@@ -269,6 +269,7 @@ uds_status_t uds_safety_reset_counters(void)
     s_safety_ctx.session_check_violations  = 0U;
     s_safety_ctx.security_check_violations = 0U;
     s_safety_ctx.bounds_check_violations   = 0U;
+    s_safety_ctx.platform_violations       = 0U;  /* [HIGH-2] */
     s_safety_ctx.total_checks_performed    = 0U;
     s_safety_ctx.last_violation_code       = UDS_STATUS_OK;
 

--- a/tests/unit_runnable/test_trng_fail_closed.c
+++ b/tests/unit_runnable/test_trng_fail_closed.c
@@ -143,21 +143,15 @@ ZTEST(test_trng_fail_closed, tc001_no_rng_cb_production_refuses)
     uint8_t out_len = SENTINEL_BYTE;
     uds_status_t rc;
     const uds_safety_ctx_t *ctx;
-    uint32_t violations_before;
 
     uds_security_algo_reset();
     (void)uds_safety_init();
+    (void)uds_safety_reset_counters();
 
-    /*
-     * [pre-existing bug, tracked separately] uds_safety_reset_counters()
-     * does not reset platform_violations (see uds_safety.c) -- it was added
-     * by the HIGH-2 fix after reset_counters() was written and never wired
-     * in. Assert on the delta across this call rather than an absolute
-     * value so this test does not depend on that counter starting at zero.
-     */
     ctx = uds_safety_get_ctx();
     zassert_not_null(ctx, "safety ctx must be available");
-    violations_before = ctx->platform_violations;
+    zassert_equal(ctx->platform_violations, 0U,
+        "platform_violations must start at 0 after reset_counters()");
 
     fill_sentinel(seed, sizeof(seed));
 
@@ -168,8 +162,8 @@ ZTEST(test_trng_fail_closed, tc001_no_rng_cb_production_refuses)
     zassert_true(buf_is_sentinel(seed, sizeof(seed)),
         "seed buffer must be left untouched -- no seed was ever issued");
 
-    zassert_equal(ctx->platform_violations, violations_before + 1U,
-        "exactly one new platform violation must be recorded");
+    zassert_equal(ctx->platform_violations, 1U,
+        "exactly one platform violation must be recorded");
     zassert_equal(ctx->last_violation_code, UDS_STATUS_ERR_SEC_SEED_UNAVAILABLE,
         "production hard refusal must record SEED_UNAVAILABLE, not PLATFORM");
 }
@@ -184,22 +178,23 @@ ZTEST(test_trng_fail_closed, tc002_failing_rng_cb_production_refuses)
     uint8_t out_len = SENTINEL_BYTE;
     uds_status_t rc;
     const uds_safety_ctx_t *ctx;
-    uint32_t violations_before;
     uint32_t fallback_before;
 
     uds_security_algo_reset();
     (void)uds_safety_init();
+    (void)uds_safety_reset_counters();
     uds_security_algo_set_rng_cb(stub_rng_cb_always_fails);
 
-    /*
-     * [pre-existing bug, tracked separately] uds_safety_reset_counters()
-     * does not reset platform_violations -- see the comment in TC-TFC-001.
-     * Use deltas so this test does not depend on counters starting at zero.
-     */
     ctx = uds_safety_get_ctx();
     zassert_not_null(ctx, "safety ctx must be available");
-    violations_before = ctx->platform_violations;
-    fallback_before    = uds_security_algo_get_trng_fallback_count();
+    zassert_equal(ctx->platform_violations, 0U,
+        "platform_violations must start at 0 after reset_counters()");
+    /*
+     * uds_security_algo_get_trng_fallback_count() is a module-global counter
+     * outside uds_safety_ctx_t with no reset hook, so it is still asserted
+     * on a delta across this call.
+     */
+    fallback_before = uds_security_algo_get_trng_fallback_count();
 
     fill_sentinel(seed, sizeof(seed));
 
@@ -219,8 +214,8 @@ ZTEST(test_trng_fail_closed, tc002_failing_rng_cb_production_refuses)
 
     zassert_equal(uds_security_algo_get_trng_fallback_count(), fallback_before + 1U,
         "exactly one new TRNG call failure must be counted");
-    zassert_equal(ctx->platform_violations, violations_before + 1U,
-        "exactly one new platform violation must be recorded");
+    zassert_equal(ctx->platform_violations, 1U,
+        "exactly one platform violation must be recorded");
     zassert_equal(ctx->last_violation_code, UDS_STATUS_ERR_SEC_SEED_UNAVAILABLE,
         "production hard refusal must record SEED_UNAVAILABLE, not PLATFORM");
 

--- a/tests/unit_runnable/test_uds_safety.c
+++ b/tests/unit_runnable/test_uds_safety.c
@@ -263,6 +263,29 @@ ZTEST(test_safety_lifecycle, test_reset_counters_clears_violations)
                   "total checks cleared after reset");
 }
 
+/**
+ * TC-SAFE-LIFE-004: uds_safety_reset_counters() zeroes platform_violations.
+ *
+ * Regression test for issue #86: platform_violations (added by the [HIGH-2]
+ * fix) was never wired into uds_safety_reset_counters(), so a platform
+ * violation recorded before a reset would survive it.
+ */
+ZTEST(test_safety_lifecycle, test_reset_counters_clears_platform_violations)
+{
+    uds_safety_init();
+    uds_safety_reset_counters();
+    const uds_safety_ctx_t *ctx = uds_safety_get_ctx();
+
+    uds_safety_record_platform_violation(UDS_STATUS_ERR_PLATFORM);
+    zassert_true(ctx->platform_violations > 0U,
+                 "Platform violation must have been recorded");
+
+    uds_status_t rc = uds_safety_reset_counters();
+    zassert_equal(rc, UDS_STATUS_OK, "reset_counters must succeed");
+    zassert_equal(ctx->platform_violations, 0U,
+                  "platform_violations cleared after reset");
+}
+
 /* =========================================================================
  * Test suite: uds_safety_check_null_ptr (REQ-SAFE-004)
  * ========================================================================= */
@@ -955,6 +978,7 @@ ZTEST(test_safety_integrity, test_self_test_passes)
 extern void test_safety_lifecycle__test_init_and_get_ctx(void);
 extern void test_safety_lifecycle__test_get_ctx_not_null(void);
 extern void test_safety_lifecycle__test_reset_counters_clears_violations(void);
+extern void test_safety_lifecycle__test_reset_counters_clears_platform_violations(void);
 extern void test_safety_null_ptr__test_null_ptr_detected(void);
 extern void test_safety_null_ptr__test_non_null_ok(void);
 extern void test_safety_null_ptr__test_total_checks_increments(void);
@@ -1003,6 +1027,7 @@ void run_all_tests(void)
     RUN_TEST(test_safety_lifecycle__test_init_and_get_ctx);
     RUN_TEST(test_safety_lifecycle__test_get_ctx_not_null);
     RUN_TEST(test_safety_lifecycle__test_reset_counters_clears_violations);
+    RUN_TEST(test_safety_lifecycle__test_reset_counters_clears_platform_violations);
     RUN_TEST(test_safety_null_ptr__test_null_ptr_detected);
     RUN_TEST(test_safety_null_ptr__test_non_null_ok);
     RUN_TEST(test_safety_null_ptr__test_total_checks_increments);


### PR DESCRIPTION
Closes #86.

## Bug

`uds_safety_reset_counters()` in `core/uds_safety.c` reset every violation
counter (`null_check_violations`, `session_check_violations`,
`security_check_violations`, `bounds_check_violations`,
`total_checks_performed`, `last_violation_code`) except
`platform_violations`. That field was added later by the `[HIGH-2]` fix and
never wired into this function. `uds_safety_init()` already zeroed it
correctly — only the test-harness-only reset path was affected (the
function's own doc comment: "must NOT be called in production firmware").

This was already noticed in PR #85: `test_trng_fail_closed.c` worked around
it with before/after-delta assertions on `platform_violations` instead of
absolute values, specifically because the reset couldn't be trusted.

## Fix

Added `s_safety_ctx.platform_violations = 0U;` to `uds_safety_reset_counters()`,
matching the style/ordering already used in `uds_safety_init()`'s reset block.

## Tests

- `tests/unit_runnable/test_uds_safety.c` — new regression case
  (`TC-SAFE-LIFE-004`, `test_reset_counters_clears_platform_violations`):
  records a platform violation via `uds_safety_record_platform_violation()`,
  calls `uds_safety_reset_counters()`, and asserts `platform_violations == 0`
  via `uds_safety_get_ctx()`.
- `tests/unit_runnable/test_trng_fail_closed.c` (bonus/polish) — simplified
  `TC-TFC-001` and `TC-TFC-002` to call `uds_safety_reset_counters()` up front
  and assert absolute `platform_violations` values (0 before, 1 after) instead
  of before/after deltas, now that the reset path can be trusted. The
  unrelated TRNG-fallback counter (`uds_security_algo_get_trng_fallback_count()`,
  which has no reset hook of its own) keeps its delta-based assertion.

`CHANGELOG.md` — added an `[Unreleased]` / `Fixed` entry.

## Gates (all run locally)

- `bash build_tests.sh` — **43 passed, 0 failed**
- `bash build_harness.sh --run` — **68/68 passed**
- `python3 misra_analysis.py --gcc-only --src-dirs core` — **0 open
  violations** (cppcheck not available in this environment; sanity-checked
  `core/uds_safety.c` directly with `gcc -std=c11 -E -Wall -Wcomment`, no
  nested-comment warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
