### PR TITLE
fix: make tests/CMakeLists.txt actually configure and build (parity with build_tests.sh)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,6 +429,49 @@ jobs:
           print(f"PASS: codegen __version__ {cg} matches CHANGELOG {cl}")
           PYEOF
 
+  # ── Job 1b: CMake/CTest build (parity with build_tests.sh) ─────────────────
+  #
+  # [EDS#88] tests/CMakeLists.txt is a second, independently documented way
+  # to build and run the 43 host unit tests (cmake -S tests -B build && ...).
+  # It previously did not configure at all — wrong generated/ path, missing
+  # compile definitions, and hand-maintained per-target source lists that had
+  # drifted from the real dependency graph — and nothing in CI ever exercised
+  # it, so the breakage went unnoticed. This job runs that path for real on
+  # every PR so it cannot silently rot again. It is intentionally separate
+  # from the unit-tests job above (which runs build_tests.sh): the two build
+  # systems must both work, and a failure in either should be attributed
+  # to that path specifically.
+  cmake-ctest-build:
+    name: "CMake/CTest Build (parity with build_tests.sh)"
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends gcc cmake python3 python3-pip
+
+      - name: Install Python dependencies
+        run: pip install pyyaml jinja2
+
+      - name: Verify pre-committed generated files are present
+        run: |
+          for f in examples/basic_ecu/generated/uds_init.c \
+                   examples/basic_ecu/generated/did_handlers.c \
+                   examples/basic_ecu/generated/safety_config.h \
+                   examples/basic_ecu/generated/generated_config.h; do
+            test -f "$f" && echo "OK: $f" || (echo "MISSING: $f" && exit 1)
+          done
+
+      - name: Configure (cmake -S tests -B build)
+        run: cmake -S tests -B build
+
+      - name: Build all test targets
+        run: cmake --build build -j4
+
+      - name: Run CTest
+        run: ctest --test-dir build --output-on-failure
 
   # ── Job 5: Generated integration tests (simulator mode) ───────────────────
   #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,39 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   no longer needs to work around the bug with delta-based counter
   assertions.
 
+### Fixed — CI / build system
+
+- **`tests/CMakeLists.txt` (the CTest build path) now actually configures,
+  builds, and passes — and is CI-enforced.** (#88) Previously broken at three
+  independent levels, none of which CI caught because CI only ran
+  `bash build_tests.sh` and never invoked CMake:
+  - Configure failed outright: `add_executable()` pointed generated sources
+    at `<repo-root>/generated/`, which does not exist. Generated sources live
+    under `examples/basic_ecu/generated/`, same as `build_tests.sh`.
+  - Every target then failed `core/uds_types.h`'s `_Static_assert` on
+    `uds_msg_buf_t` size: the compile definitions `build_tests.sh` passes
+    (`UNIT_TEST`, `NVM_STORE_HOST_MOCK`, `ISOTP_ENABLE_CAN_FD`,
+    `ISOTP_TX_PADDING`, `EDS_MSG_BUF_MAX_STACK_BYTES=8192`) were missing from
+    the CMake path entirely.
+  - Each `add_diag_test()` call carried its own hand-maintained, drifted
+    `SOURCES` list instead of linking the full stack, so targets that did
+    link failed with undefined-reference errors the moment one dependency
+    was added.
+
+  Fixed by introducing a single `DIAG_STACK_SRCS` list that mirrors
+  `build_tests.sh`'s `STACK_SRCS` array file-for-file and is linked into
+  every test executable, pointing generated-source references at
+  `examples/basic_ecu/generated/`, and adding the missing compile
+  definitions directory-wide. Also added the three targets that existed in
+  `build_tests.sh`'s `TESTS` array but had no CMake equivalent
+  (`test_service_0x2F`, `test_service_0x35`, `test_service_0x23_0x3D`),
+  bringing the CMake path to parity: 43 modules, matching `build_tests.sh`.
+
+  A new CI job, `"CMake/CTest Build (parity with build_tests.sh)"`, runs
+  `cmake -S tests -B build && cmake --build build -j4 && ctest --test-dir
+  build --output-on-failure` on every PR so this path cannot silently
+  diverge from `build_tests.sh` again without CI going red.
+
 ### Security
 
 - **SecurityAccess entropy fallback now fails closed in production builds.**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,37 +2,50 @@
 # Xaloqi EDS
 # FILE: tests/CMakeLists.txt
 #
-# PURPOSE: Host-native CMake build for all 37 unit test modules.
-#          Compiles each test_*.c file together with its production sources
-#          and the Unity framework into a standalone executable. CTest then
-#          runs each executable and reports pass/fail based on exit code.
+# PURPOSE: Host-native CMake build for all 43 unit test modules.
+#          Compiles each test_*.c file together with the FULL diagnostics
+#          stack (mirroring build_tests.sh's STACK_SRCS) and the Unity
+#          framework into a standalone executable. CTest then runs each
+#          executable and reports pass/fail based on exit code.
 #
 #          Architecture:
 #            tests/CMakeLists.txt (this file)
 #              -> tests/runner/test_main.c         (Unity main + lifecycle)
 #              -> tests/runner/ztest_shim.h        (ZTEST-to-Unity macro map)
 #              -> project/unity/unity.c            (Unity assertion engine)
-#              -> tests/unit_runnable/test_<module>.c  (canonical test cases — 40 modules)
-#              -> <production sources>             (modules under test)
-#              -> generated/ did_handlers.c etc.  (generated stubs)
+#              -> tests/unit_runnable/test_<module>.c  (canonical test cases — 43 modules)
+#              -> <production sources>             (the entire diagnostics stack)
+#              -> examples/basic_ecu/generated/ did_handlers.c etc. (generated stubs)
 #
-#          This design allows all 40 modules to be tested on a CI runner
+#          This design allows all 43 modules to be tested on a CI runner
 #          without a Zephyr SDK or hardware target, using only GCC/Clang
 #          and CMake. Each test module compiles independently to avoid
 #          link-time symbol conflicts between test modules.
 #
+#          [EDS#88 FIX] This file previously (a) pointed generated sources at
+#          <repo-root>/generated/, which does not exist — the real location
+#          is examples/basic_ecu/generated/, matching build_tests.sh; (b) did
+#          not define the compile flags build_tests.sh's CFLAGS array passes
+#          (UNIT_TEST, NVM_STORE_HOST_MOCK, ISOTP_ENABLE_CAN_FD,
+#          ISOTP_TX_PADDING, EDS_MSG_BUF_MAX_STACK_BYTES), so every target
+#          failed core/uds_types.h's _Static_assert; and (c) gave each
+#          add_diag_test() call its own hand-maintained, drifted SOURCES list
+#          instead of linking the whole stack the way build_tests.sh does,
+#          so targets failed to link with undefined-reference errors. Fixed
+#          by introducing DIAG_STACK_SRCS below, which mirrors
+#          build_tests.sh's STACK_SRCS array file-for-file.
+#
 # USAGE:
 #   # Build and run all tests:
-#   mkdir -p tests/build && cd tests/build
-#   cmake .. -DCMAKE_BUILD_TYPE=Debug
-#   cmake --build .
-#   ctest --output-on-failure
+#   cmake -S tests -B build
+#   cmake --build build -j4
+#   ctest --test-dir build --output-on-failure
 #
 #   # Run a single test module:
-#   ./test_uds_session
+#   ./build/test_uds_session
 #
 #   # Run with verbose output:
-#   ctest -V
+#   ctest --test-dir build -V
 #
 # CI INTEGRATION:
 #   ctest returns 0 on all pass, non-zero on any failure.
@@ -41,14 +54,14 @@
 #
 # SAFETY CONTEXT : Test infrastructure — not safety-assessed.
 # CODING STANDARD: MISRA C:2012 alignment intended (advisory for test code).
-# VERSION        : 1.7.0 (40 modules wired, unit_runnable/ is the single canonical test directory)
+# VERSION        : 1.8.0 (43 modules wired — parity with build_tests.sh; see EDS#88)
 # SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 
 cmake_minimum_required(VERSION 3.16)
 
 project(diag_unit_tests
-    VERSION     1.7.0
+    VERSION     1.8.0
     LANGUAGES   C
     DESCRIPTION "Host-native Unity unit tests — Xaloqi EDS"
 )
@@ -82,16 +95,52 @@ set(DIAG_ROOT          "${CMAKE_CURRENT_SOURCE_DIR}/..")
 set(DIAG_CORE          "${DIAG_ROOT}/core")
 set(DIAG_SERVICES      "${DIAG_ROOT}/core/uds_services")
 set(DIAG_TRANSPORT     "${DIAG_ROOT}/transport")
+set(DIAG_TRANSPORT_DOIP "${DIAG_ROOT}/transport/doip")
 set(DIAG_CONFIG        "${DIAG_ROOT}/config")
 set(DIAG_PLATFORM      "${DIAG_ROOT}/platform")
 set(DIAG_PLATFORM_ZEPHYR "${DIAG_ROOT}/platform/zephyr")
-set(DIAG_GENERATED     "${DIAG_ROOT}/generated")
+# [EDS#88] Generated sources live under the example that owns them, not at
+# <repo-root>/generated/ (which does not exist — see .gitignore comment "Root
+# generated/ removed — each example owns its own generated/ subfolder").
+# This matches build_tests.sh's STACK_SRCS / INCLUDES exactly.
+set(DIAG_GENERATED     "${DIAG_ROOT}/examples/basic_ecu/generated")
 set(DIAG_UNITY         "${DIAG_ROOT}/project/unity")
-# [M2] Canonical test directory is unit_runnable/ (40 modules).
+# [M2] Canonical test directory is unit_runnable/ (43 modules).
 # tests/legacy_unit/ has been removed — unit_runnable/ is the single source of truth.
 # build_tests.sh and this CMakeLists.txt both reference unit_runnable/.
 set(TEST_UNIT_DIR      "${CMAKE_CURRENT_SOURCE_DIR}/unit_runnable")
 set(TEST_RUNNER_DIR    "${CMAKE_CURRENT_SOURCE_DIR}/runner")
+set(TEST_MOCKS_DIR     "${CMAKE_CURRENT_SOURCE_DIR}/mocks")
+
+# ---------------------------------------------------------------------------
+# Global compile definitions [EDS#88 — Level 2 fix]
+#
+# Mirrors build_tests.sh's CFLAGS array exactly. Applied to every target in
+# this directory (the unity library and all add_diag_test() executables),
+# the same way build_tests.sh applies its CFLAGS to every gcc invocation.
+#
+#   UNIT_TEST=1                  activates test-only resets/hooks
+#   NVM_STORE_HOST_MOCK=1        substitutes a malloc-backed NVM store for
+#                                 the Zephyr flash driver
+#   ISOTP_ENABLE_CAN_FD=1        enables CAN FD ISO-TP paths (test_isotp_canfd)
+#   ISOTP_TX_PADDING=1           enables TX padding code path
+#   EDS_MSG_BUF_MAX_STACK_BYTES=8192
+#                                 suppresses the uds_msg_buf_t stack-size
+#                                 _Static_assert in core/uds_types.h on host
+#                                 builds (host has an 8 MB process stack; the
+#                                 assert exists to guard embedded targets,
+#                                 which default to 256 bytes)
+#
+# ZTEST_HOST_SHIM=1 is defined below via DIAG_TEST_COMPILE_OPTIONS (it was
+# already correct and applies only to test executables, not the unity lib).
+# ---------------------------------------------------------------------------
+add_compile_definitions(
+    UNIT_TEST=1
+    NVM_STORE_HOST_MOCK=1
+    ISOTP_ENABLE_CAN_FD=1
+    ISOTP_TX_PADDING=1
+    EDS_MSG_BUF_MAX_STACK_BYTES=8192
+)
 
 # ---------------------------------------------------------------------------
 # Unity static library
@@ -114,17 +163,22 @@ target_compile_options(unity PRIVATE
 
 # ---------------------------------------------------------------------------
 # Common include directories for production code
+#
+# Mirrors build_tests.sh's INCLUDES array (adds transport/doip and
+# tests/mocks, which the previous version of this file omitted).
 # ---------------------------------------------------------------------------
 set(DIAG_INCLUDE_DIRS
     "${DIAG_CORE}"
     "${DIAG_SERVICES}"
     "${DIAG_TRANSPORT}"
+    "${DIAG_TRANSPORT_DOIP}"
     "${DIAG_CONFIG}"
     "${DIAG_PLATFORM}"
     "${DIAG_PLATFORM_ZEPHYR}"
     "${DIAG_GENERATED}"
     "${DIAG_UNITY}"
     "${TEST_RUNNER_DIR}"
+    "${TEST_MOCKS_DIR}"
 )
 
 # ---------------------------------------------------------------------------
@@ -143,14 +197,19 @@ set(DIAG_TEST_COMPILE_OPTIONS
 )
 
 # ---------------------------------------------------------------------------
-# Helper function: add_diag_test(name sources... [EXTRA_DEFINES ...])
+# Helper function: add_diag_test(name SOURCES sources... [DEFINES ...])
 #
 # Creates a test executable named 'name' that:
-#   - Compiles the listed source files
+#   - Compiles the listed source files, plus tests/runner/test_main.c
 #   - Links against Unity
 #   - Includes all DIAG_INCLUDE_DIRS
 #   - Applies DIAG_TEST_COMPILE_OPTIONS
 #   - Registers with CTest via add_test()
+#
+# NOTE: test_main.c is added here unconditionally — do not also list it in
+# a call's SOURCES (CMake errors on a source file listed twice in one
+# add_executable). Likewise unity.c is provided via the 'unity' link
+# library, not as a direct source, to avoid linking its symbols twice.
 # ---------------------------------------------------------------------------
 function(add_diag_test TEST_NAME)
     cmake_parse_arguments(ARG "" "" "SOURCES;DEFINES" ${ARGN})
@@ -186,54 +245,37 @@ function(add_diag_test TEST_NAME)
 endfunction()
 
 # ===========================================================================
-# Common production source sets
+# DIAG_STACK_SRCS [EDS#88 — Level 3 fix]
 #
-# Groups of sources required by multiple test modules. Using lists avoids
-# duplication and ensures consistent compilation across related test targets.
+# The FULL diagnostics stack, linked into EVERY test executable — exactly
+# mirroring build_tests.sh's STACK_SRCS array (same files, same order,
+# 1:1). Every test module exercises integration between modules, not just
+# the module under test in isolation. This is what makes the individual
+# per-target hand-maintained SOURCES lists (previously the pattern in this
+# file) unnecessary and prone to drift: one dependency graph, one list.
+#
+# Two files from STACK_SRCS's bash array are deliberately NOT repeated here:
+#   - project/unity/unity.c   — provided via the 'unity' static library
+#                                (target_link_libraries), not as a direct
+#                                source; listing it again would double-link
+#                                its symbols.
+#   - tests/runner/test_main.c — added unconditionally inside add_diag_test()
+#                                 above; listing it again is a duplicate
+#                                 source file, which CMake rejects.
 # ===========================================================================
-
-set(DIAG_SRCS_SESSION
-    "${DIAG_CORE}/uds_session.c"
-)
-
-set(DIAG_SRCS_SECURITY
-    "${DIAG_CORE}/uds_security.c"
-)
-
-set(DIAG_SRCS_SAFETY
-    "${DIAG_CORE}/uds_safety.c"
-)
-
-set(DIAG_SRCS_SERVER
+set(DIAG_STACK_SRCS
+    # UDS core
     "${DIAG_CORE}/uds_server.c"
     "${DIAG_CORE}/uds_session.c"
+    "${DIAG_CORE}/uds_session_stats.c"
     "${DIAG_CORE}/uds_security.c"
-)
-
-set(DIAG_SRCS_DID
-    "${DIAG_CONFIG}/did_database.c"
-    "${DIAG_CONFIG}/dtc_database.c"
-    "${DIAG_GENERATED}/did_handlers.c"
-)
-
-set(DIAG_SRCS_SAFETY_WRAPPERS
-    "${DIAG_GENERATED}/did_safety_wrappers.c"
+    "${DIAG_CORE}/uds_aes_cmac.c"          # [P1-SEC] AES-128-CMAC primitive
+    "${DIAG_CORE}/uds_security_algo.c"
+    "${DIAG_CORE}/uds_security_nvm.c"
     "${DIAG_CORE}/uds_safety.c"
-    "${DIAG_CORE}/uds_session.c"
-    "${DIAG_CORE}/uds_security.c"
-    "${DIAG_CONFIG}/did_database.c"
-    "${DIAG_CONFIG}/dtc_database.c"
-    "${DIAG_GENERATED}/did_handlers.c"
-)
-
-set(DIAG_SRCS_SERVICES_FULL
-    # NOTE: this list is INCOMPLETE — missing service_0x23.c, service_0x2F.c,
-    # service_0x35.c, service_0x3D.c (added to the stack after this list was
-    # last updated). Not caught by CI: this CMakeLists.txt path is not
-    # currently invoked by CI or build_tests.sh (see EDS#73 for the sibling
-    # gap in add_diag_test() entries — likely the same root cause). Building
-    # any test that exercises those SIDs via this CMake path will link-fail.
-    # Listed here: SIDs 0x10/11/14/19/22/27/28/2A/2E/31/34/36/37/3E/85
+    "${DIAG_CORE}/uds_access_table.c"
+    "${DIAG_CORE}/uds_comm_control.c"
+    # Service handlers
     "${DIAG_SERVICES}/service_registration.c"
     "${DIAG_SERVICES}/service_0x10.c"
     "${DIAG_SERVICES}/service_0x11.c"
@@ -242,309 +284,326 @@ set(DIAG_SRCS_SERVICES_FULL
     "${DIAG_SERVICES}/service_0x22.c"
     "${DIAG_SERVICES}/service_0x27.c"
     "${DIAG_SERVICES}/service_0x28.c"
-    "${DIAG_SERVICES}/service_0x2A.c"  # ADDED — ReadDataByPeriodicIdentifier
+    "${DIAG_SERVICES}/service_0x2A.c"   # [0x2A] ReadDataByPeriodicIdentifier
+    "${DIAG_CORE}/uds_periodic.c"       # [0x2A] periodic scheduler
     "${DIAG_SERVICES}/service_0x2E.c"
-    "${DIAG_CORE}/uds_periodic.c"      # ADDED — periodic scheduler
+    "${DIAG_SERVICES}/service_0x2F.c"   # InputOutputControlByIdentifier
     "${DIAG_SERVICES}/service_0x31.c"
-    "${DIAG_SERVICES}/service_0x34.c"
-    "${DIAG_SERVICES}/service_0x36.c"
-    "${DIAG_SERVICES}/service_0x37.c"
     "${DIAG_SERVICES}/service_0x3E.c"
     "${DIAG_SERVICES}/service_0x85.c"
-    "${DIAG_CORE}/uds_server.c"
-    "${DIAG_CORE}/uds_session.c"
-    "${DIAG_CORE}/uds_security.c"
-    "${DIAG_CORE}/uds_safety.c"
-    "${DIAG_CORE}/uds_access_table.c"
-    "${DIAG_CORE}/uds_comm_control.c"
-    "${DIAG_CORE}/uds_transfer_ctx.c"
+    # DFU services — service_registration.c references all three handlers
+    # in g_uds_service_table[]; omitting any of these causes every test
+    # binary to fail at link with undefined reference errors.
+    "${DIAG_SERVICES}/service_0x23.c"   # ReadMemoryByAddress
+    "${DIAG_SERVICES}/service_0x34.c"   # RequestDownload
+    "${DIAG_SERVICES}/service_0x35.c"   # RequestUpload
+    "${DIAG_SERVICES}/service_0x36.c"   # TransferData
+    "${DIAG_SERVICES}/service_0x37.c"   # RequestTransferExit
+    "${DIAG_SERVICES}/service_0x3D.c"   # WriteMemoryByAddress
+    "${DIAG_CORE}/uds_transfer_ctx.c"   # DFU transfer state machine
+    "${DIAG_PLATFORM}/uds_flash_ops.c"  # Flash ops singleton
+    # Transport
+    "${DIAG_TRANSPORT}/isotp.c"
+    "${DIAG_TRANSPORT}/can_transport.c"
+    # DoIP transport (core logic only, no platform/network deps)
+    "${DIAG_TRANSPORT_DOIP}/doip_server.c"
+    # Config databases
     "${DIAG_CONFIG}/did_database.c"
     "${DIAG_CONFIG}/dtc_database.c"
+    "${DIAG_CONFIG}/dtc_mirror.c"
     "${DIAG_CONFIG}/routine_database.c"
+    # Generated sources (pre-committed under examples/basic_ecu/generated/;
+    # run tools/codegen.py to regenerate — see build_tests.sh header)
     "${DIAG_GENERATED}/did_handlers.c"
     "${DIAG_GENERATED}/did_safety_wrappers.c"
     "${DIAG_GENERATED}/routine_handlers.c"
-    "${DIAG_PLATFORM}/uds_flash_ops.c"
-)
-
-# Source set for Phase 2 — ISO-TP STmin and session matrix tests
-set(DIAG_SRCS_PHASE2_ISOTP
-    "${DIAG_TRANSPORT}/isotp.c"
-    "${DIAG_TRANSPORT}/can_transport.c"
-)
-
-set(DIAG_SRCS_PHASE2_SESSION
-    "${DIAG_CORE}/uds_session.c"
-)
-
-# Source set for Phase 2 suppress-bit — needs full server + services
-set(DIAG_SRCS_PHASE2_SUPPRESS
-    ${DIAG_SRCS_SERVICES_FULL}
-)
-
-# Source set for Phase 3 — NVM-backed modules
-set(DIAG_SRCS_PHASE3_NVM
+    # Platform: host mock replaces Zephyr flash driver
     "${DIAG_PLATFORM_ZEPHYR}/nvm_store_mock.c"
-    "${DIAG_CONFIG}/dtc_mirror.c"
-    "${DIAG_CONFIG}/dtc_database.c"
-    "${DIAG_CORE}/uds_session_stats.c"
-    "${DIAG_CORE}/uds_security_nvm.c"
-    "${DIAG_CORE}/uds_security.c"
-    "${DIAG_CORE}/uds_session.c"
-)
-
-# Source set for Phase 5 — access table + security algo
-set(DIAG_SRCS_PHASE5_ACCESS
-    "${DIAG_CORE}/uds_access_table.c"
-    "${DIAG_CORE}/uds_security.c"
-    "${DIAG_CORE}/uds_session.c"
-)
-
-set(DIAG_SRCS_PHASE5_SECURITY_ALGO
-    "${DIAG_CORE}/uds_security_algo.c"
-    "${DIAG_CORE}/uds_aes_cmac.c"
-    "${DIAG_CORE}/uds_security.c"
-    "${DIAG_CORE}/uds_session.c"
-)
-
-# Source set for routine database
-set(DIAG_SRCS_ROUTINE_DB
-    "${DIAG_CONFIG}/routine_database.c"
+    # Host mocks for Zephyr kernel APIs
+    "${TEST_MOCKS_DIR}/zephyr_port_mock.c"
 )
 
 # ===========================================================================
-# Test targets — one per module under test
+# Test targets — one per module under test (43 total, matching
+# build_tests.sh's TESTS array 1:1 — see EDS#88)
 # ===========================================================================
 
-# ---------------------------------------------------------------------------
-# 1. test_uds_session
-#    Module under test: core/uds_session.c
-# ---------------------------------------------------------------------------
 add_diag_test(test_uds_session
     SOURCES
         "${TEST_UNIT_DIR}/test_uds_session.c"
-        ${DIAG_SRCS_SESSION}
+        ${DIAG_STACK_SRCS}
 )
 
-# ---------------------------------------------------------------------------
-# 2. test_uds_security
-#    Module under test: core/uds_security.c
-# ---------------------------------------------------------------------------
 add_diag_test(test_uds_security
     SOURCES
         "${TEST_UNIT_DIR}/test_uds_security.c"
-        ${DIAG_SRCS_SECURITY}
-        ${DIAG_SRCS_SESSION}
+        ${DIAG_STACK_SRCS}
 )
 
-# ---------------------------------------------------------------------------
-# 3. test_uds_safety
-#    Module under test: core/uds_safety.c
-#    Requires: did_database, dtc_database (for verify_did_database test)
-# ---------------------------------------------------------------------------
 add_diag_test(test_uds_safety
     SOURCES
         "${TEST_UNIT_DIR}/test_uds_safety.c"
-        ${DIAG_SRCS_SAFETY}
-        ${DIAG_SRCS_SESSION}
-        ${DIAG_SRCS_SECURITY}
-        "${DIAG_CONFIG}/did_database.c"
-        "${DIAG_CONFIG}/dtc_database.c"
-        "${DIAG_GENERATED}/did_handlers.c"
+        ${DIAG_STACK_SRCS}
 )
 
-# ---------------------------------------------------------------------------
-# 4. test_uds_server
-#    Module under test: core/uds_server.c
-# ---------------------------------------------------------------------------
 add_diag_test(test_uds_server
     SOURCES
         "${TEST_UNIT_DIR}/test_uds_server.c"
-        ${DIAG_SRCS_SERVER}
-        ${DIAG_SRCS_SAFETY}
-        "${DIAG_CONFIG}/did_database.c"
-        "${DIAG_CONFIG}/dtc_database.c"
-        "${DIAG_GENERATED}/did_handlers.c"
-        "${DIAG_SERVICES}/service_registration.c"
-        "${DIAG_SERVICES}/service_0x10.c"
-        "${DIAG_SERVICES}/service_0x11.c"
-        "${DIAG_SERVICES}/service_0x22.c"
-        "${DIAG_SERVICES}/service_0x27.c"
-        "${DIAG_SERVICES}/service_0x2E.c"
-        "${DIAG_SERVICES}/service_0x3E.c"
-        "${DIAG_GENERATED}/did_safety_wrappers.c"
+        ${DIAG_STACK_SRCS}
 )
 
-# ---------------------------------------------------------------------------
-# 5. test_did_database
-#    Module under test: config/did_database.c
-# ---------------------------------------------------------------------------
 add_diag_test(test_did_database
     SOURCES
         "${TEST_UNIT_DIR}/test_did_database.c"
-        "${DIAG_CONFIG}/did_database.c"
+        ${DIAG_STACK_SRCS}
 )
 
-# ---------------------------------------------------------------------------
-# 6. test_dtc_database
-#    Module under test: config/dtc_database.c
-# ---------------------------------------------------------------------------
 add_diag_test(test_dtc_database
     SOURCES
         "${TEST_UNIT_DIR}/test_dtc_database.c"
-        "${DIAG_CONFIG}/dtc_database.c"
+        ${DIAG_STACK_SRCS}
 )
 
-# ---------------------------------------------------------------------------
-# 6b. test_dtc_mirror
-#     Module under test: config/dtc_mirror.c — DTC NVM persistence module
-#
-#     Focused unit test covering:
-#       - dtc_mirror_init() pre-condition guards and idempotence
-#       - dtc_mirror_load() soft-degrade when NVM not ready (H3 fix path)
-#       - dtc_mirror_flush_all() / save_one() / clear_all() API contract
-#       - Three H3 fix integration tests proving fault history survives reset
-#
-#     Source set: DIAG_SRCS_PHASE3_NVM (same as test_phase3_nvm_dtc).
-#     NVM mock activated via NVM_STORE_HOST_MOCK=1.
-# ---------------------------------------------------------------------------
 add_diag_test(test_dtc_mirror
     SOURCES
         "${TEST_UNIT_DIR}/test_dtc_mirror.c"
-        ${DIAG_SRCS_PHASE3_NVM}
-    DEFINES
-        NVM_STORE_HOST_MOCK=1
+        ${DIAG_STACK_SRCS}
 )
 
-# ---------------------------------------------------------------------------
-# 7. test_did_handlers
-#    Module under test: generated/did_handlers.c
-#    Also exercises generated/did_safety_wrappers.c
-# ---------------------------------------------------------------------------
+add_diag_test(test_routine_database
+    SOURCES
+        "${TEST_UNIT_DIR}/test_routine_database.c"
+        ${DIAG_STACK_SRCS}
+)
+
 add_diag_test(test_did_handlers
     SOURCES
         "${TEST_UNIT_DIR}/test_did_handlers.c"
-        ${DIAG_SRCS_SAFETY_WRAPPERS}
+        ${DIAG_STACK_SRCS}
 )
 
-# ---------------------------------------------------------------------------
-# 8. test_did_safety_wrappers
-#    Module under test: generated/did_safety_wrappers.c
-# ---------------------------------------------------------------------------
 add_diag_test(test_did_safety_wrappers
     SOURCES
         "${TEST_UNIT_DIR}/test_did_safety_wrappers.c"
-        ${DIAG_SRCS_SAFETY_WRAPPERS}
+        ${DIAG_STACK_SRCS}
 )
 
-# ---------------------------------------------------------------------------
-# 9. test_can_transport
-#    Module under test: transport/can_transport.c
-# ---------------------------------------------------------------------------
 add_diag_test(test_can_transport
     SOURCES
         "${TEST_UNIT_DIR}/test_can_transport.c"
-        "${DIAG_TRANSPORT}/can_transport.c"
+        ${DIAG_STACK_SRCS}
 )
 
-# ---------------------------------------------------------------------------
-# 10. test_isotp
-#     Module under test: transport/isotp.c
-# ---------------------------------------------------------------------------
 add_diag_test(test_isotp
     SOURCES
         "${TEST_UNIT_DIR}/test_isotp.c"
-        "${DIAG_TRANSPORT}/isotp.c"
-        "${DIAG_TRANSPORT}/can_transport.c"
+        ${DIAG_STACK_SRCS}
 )
 
-# ---------------------------------------------------------------------------
-# 11. test_isotp_concurrent
-#     Module under test: transport/isotp.c (concurrent-request / mid-reassembly)
-#
-#     Tests SF interrupting a multi-frame, new FF restarting reassembly,
-#     CF-without-FF rejection, wrong SN recovery, and N_Cr timeout recovery.
-#     These scenarios are distinct from test_isotp (which covers timer logic)
-#     and test_phase2_isotp_stmin (which covers STmin/BS/FC state machine).
-# ---------------------------------------------------------------------------
 add_diag_test(test_isotp_concurrent
     SOURCES
         "${TEST_UNIT_DIR}/test_isotp_concurrent.c"
-        "${DIAG_TRANSPORT}/isotp.c"
-        "${DIAG_TRANSPORT}/can_transport.c"
+        ${DIAG_STACK_SRCS}
 )
 
-# ---------------------------------------------------------------------------
-# 11. test_service_0x10
-#     Module under test: core/uds_services/service_0x10.c
-# ---------------------------------------------------------------------------
 add_diag_test(test_service_0x10
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x10.c"
-        ${DIAG_SRCS_SERVICES_FULL}
+        ${DIAG_STACK_SRCS}
 )
 
-# ---------------------------------------------------------------------------
-# 12. test_service_0x11
-#     Module under test: core/uds_services/service_0x11.c
-# ---------------------------------------------------------------------------
 add_diag_test(test_service_0x11
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x11.c"
-        ${DIAG_SRCS_SERVICES_FULL}
-        # zephyr_port.c removed: service_0x11 no longer includes zephyr_port.h.
-        # The zephyr_port_* stubs remain in tests/mocks/zephyr_port_mock.c
-        # which is already included via DIAG_SRCS_SERVICES_FULL mock set.
+        ${DIAG_STACK_SRCS}
 )
 
-# ---------------------------------------------------------------------------
-# 13. test_service_0x22
-#     Module under test: core/uds_services/service_0x22.c
-# ---------------------------------------------------------------------------
+add_diag_test(test_service_0x14
+    SOURCES
+        "${TEST_UNIT_DIR}/test_service_0x14.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_service_0x19
+    SOURCES
+        "${TEST_UNIT_DIR}/test_service_0x19.c"
+        ${DIAG_STACK_SRCS}
+)
+
 add_diag_test(test_service_0x22
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x22.c"
-        ${DIAG_SRCS_SERVICES_FULL}
+        ${DIAG_STACK_SRCS}
 )
 
-# ---------------------------------------------------------------------------
-# 14. test_service_0x27
-#     Module under test: core/uds_services/service_0x27.c
-# ---------------------------------------------------------------------------
 add_diag_test(test_service_0x27
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x27.c"
-        ${DIAG_SRCS_SERVICES_FULL}
+        ${DIAG_STACK_SRCS}
 )
 
-# ---------------------------------------------------------------------------
-# 15. test_service_0x3E
-#     Module under test: core/uds_services/service_0x3E.c
-# ---------------------------------------------------------------------------
-add_diag_test(test_service_0x3E
+add_diag_test(test_service_0x28
     SOURCES
-        "${TEST_UNIT_DIR}/test_service_0x3E.c"
-        ${DIAG_SRCS_SERVICES_FULL}
+        "${TEST_UNIT_DIR}/test_service_0x28.c"
+        ${DIAG_STACK_SRCS}
 )
 
-# ---------------------------------------------------------------------------
-# 38. test_uds_periodic
-#     Module under test: core/uds_periodic.c (SID 0x2A scheduler)
-# ---------------------------------------------------------------------------
 add_diag_test(test_uds_periodic
     SOURCES
         "${TEST_UNIT_DIR}/test_uds_periodic.c"
-        ${DIAG_SRCS_SERVICES_FULL}
+        ${DIAG_STACK_SRCS}
 )
 
-# ---------------------------------------------------------------------------
-# 39. test_service_0x2A
-#     Module under test: core/uds_services/service_0x2A.c
-# ---------------------------------------------------------------------------
 add_diag_test(test_service_0x2A
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x2A.c"
-        ${DIAG_SRCS_SERVICES_FULL}
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_service_0x2F
+    SOURCES
+        "${TEST_UNIT_DIR}/test_service_0x2F.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_service_0x31
+    SOURCES
+        "${TEST_UNIT_DIR}/test_service_0x31.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_service_0x23_0x3D
+    SOURCES
+        "${TEST_UNIT_DIR}/test_service_0x23_0x3D.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_service_0x34
+    SOURCES
+        "${TEST_UNIT_DIR}/test_service_0x34.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_service_0x35
+    SOURCES
+        "${TEST_UNIT_DIR}/test_service_0x35.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_service_0x36
+    SOURCES
+        "${TEST_UNIT_DIR}/test_service_0x36.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_service_0x37
+    SOURCES
+        "${TEST_UNIT_DIR}/test_service_0x37.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_service_0x3E
+    SOURCES
+        "${TEST_UNIT_DIR}/test_service_0x3E.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_service_0x85
+    SOURCES
+        "${TEST_UNIT_DIR}/test_service_0x85.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_phase2_suppress_bit
+    SOURCES
+        "${TEST_UNIT_DIR}/test_phase2_suppress_bit.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_phase2_session_matrix
+    SOURCES
+        "${TEST_UNIT_DIR}/test_phase2_session_matrix.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_phase2_isotp_stmin
+    SOURCES
+        "${TEST_UNIT_DIR}/test_phase2_isotp_stmin.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_phase3_nvm_security
+    SOURCES
+        "${TEST_UNIT_DIR}/test_phase3_nvm_security.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_phase3_nvm_dtc
+    SOURCES
+        "${TEST_UNIT_DIR}/test_phase3_nvm_dtc.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_phase3_nvm_integration
+    SOURCES
+        "${TEST_UNIT_DIR}/test_phase3_nvm_integration.c"
+        ${DIAG_STACK_SRCS}
+)
+
+# ---------------------------------------------------------------------------
+# test_phase5_security_algo  [P1-SEC — AES-128-CMAC + TRNG]
+#     Module under test: core/uds_security_algo.c + core/uds_aes_cmac.c
+#     Covers: known-answer tests, OEM override, key injection, replay
+#     protection. uds_safety.c is required (already part of DIAG_STACK_SRCS):
+#     uds_security_algo.c calls uds_safety_record_platform_violation() on
+#     TRNG fault, and the dev-mode TRNG regression tests assert on the
+#     safety context.
+# ---------------------------------------------------------------------------
+add_diag_test(test_phase5_security_algo
+    SOURCES
+        "${TEST_UNIT_DIR}/test_phase5_security_algo.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_phase5_access_table
+    SOURCES
+        "${TEST_UNIT_DIR}/test_phase5_access_table.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_phase5_server_access
+    SOURCES
+        "${TEST_UNIT_DIR}/test_phase5_server_access.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_phase5_replay_protection
+    SOURCES
+        "${TEST_UNIT_DIR}/test_phase5_replay_protection.c"
+        ${DIAG_STACK_SRCS}
+)
+
+add_diag_test(test_doip_server
+    SOURCES
+        "${TEST_UNIT_DIR}/test_doip_server.c"
+        ${DIAG_STACK_SRCS}
+)
+
+# ---------------------------------------------------------------------------
+# test_trng_fail_closed  [SEC-TRNG-FAILCLOSED-01]
+#      Module under test: core/uds_security_algo.c in its PRODUCTION
+#      configuration, plus core/uds_security.c end-to-end.
+#      Compiled with CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0 so the entropy gate
+#      selects fail-closed; that cannot be reached from the default host
+#      build used by every other module here. Mirrors build_tests.sh's
+#      extra_flags_for_test().
+# ---------------------------------------------------------------------------
+add_diag_test(test_trng_fail_closed
+    SOURCES
+        "${TEST_UNIT_DIR}/test_trng_fail_closed.c"
+        ${DIAG_STACK_SRCS}
+    DEFINES
+        CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0
 )
 
 # ===========================================================================
@@ -555,268 +614,4 @@ add_custom_target(list_tests
     COMMENT "[DIAG TEST] Registered test modules:"
 )
 
-# ✅ End of tests/CMakeLists.txt
-
-# ---------------------------------------------------------------------------
-# 16. test_phase5_security_algo  [P1-SEC — AES-128-CMAC + TRNG]
-#     Module under test: core/uds_security_algo.c + core/uds_aes_cmac.c
-#     Covers: known-answer tests, OEM override, key injection, replay protection
-# ---------------------------------------------------------------------------
-add_diag_test(test_phase5_security_algo
-    SOURCES
-        "${TEST_UNIT_DIR}/test_phase5_security_algo.c"
-        "${DIAG_CORE}/uds_security_algo.c"
-        "${DIAG_CORE}/uds_aes_cmac.c"
-        # uds_safety.c is required: uds_security_algo.c calls
-        # uds_safety_record_platform_violation() on TRNG fault, and the
-        # dev-mode TRNG regression tests assert on the safety context.
-        # Omitting it left this target failing to link (pre-existing;
-        # this path is not CI-invoked — see FINDINGS O-1/O-9).
-        "${DIAG_CORE}/uds_safety.c"
-)
-
-# ---------------------------------------------------------------------------
-# 16b. test_trng_fail_closed  [SEC-TRNG-FAILCLOSED-01]
-#      Module under test: core/uds_security_algo.c in its PRODUCTION
-#      configuration, plus core/uds_security.c end-to-end.
-#      Compiled with CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0 so the entropy gate
-#      selects fail-closed; that cannot be reached from the default host
-#      build used by every other module here. Mirrors build_tests.sh.
-# ---------------------------------------------------------------------------
-add_diag_test(test_trng_fail_closed
-    SOURCES
-        "${TEST_UNIT_DIR}/test_trng_fail_closed.c"
-        "${DIAG_CORE}/uds_security_algo.c"
-        "${DIAG_CORE}/uds_aes_cmac.c"
-        "${DIAG_CORE}/uds_safety.c"
-        "${DIAG_CORE}/uds_security.c"
-    DEFINES
-        CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0
-)
-
-# ===========================================================================
-# Tests 17–35: Phase 2/3/5 + new services + routine database
-# All modules source from unit_runnable/ — the single canonical test tree.
-# ===========================================================================
-
-# ---------------------------------------------------------------------------
-# 17. test_phase2_isotp_stmin  [P2]
-#     Module under test: transport/isotp.c — STmin timing enforcement
-# ---------------------------------------------------------------------------
-add_diag_test(test_phase2_isotp_stmin
-    SOURCES
-        "${TEST_UNIT_DIR}/test_phase2_isotp_stmin.c"
-        ${DIAG_SRCS_PHASE2_ISOTP}
-)
-
-# ---------------------------------------------------------------------------
-# 18. test_phase2_session_matrix  [P2]
-#     Module under test: core/uds_session.c — session transition matrix
-# ---------------------------------------------------------------------------
-add_diag_test(test_phase2_session_matrix
-    SOURCES
-        "${TEST_UNIT_DIR}/test_phase2_session_matrix.c"
-        ${DIAG_SRCS_PHASE2_SESSION}
-)
-
-# ---------------------------------------------------------------------------
-# 19. test_phase2_suppress_bit  [P2]
-#     Module under test: uds_server.c — suppressPosRspMsgIndicationBit
-# ---------------------------------------------------------------------------
-add_diag_test(test_phase2_suppress_bit
-    SOURCES
-        "${TEST_UNIT_DIR}/test_phase2_suppress_bit.c"
-        ${DIAG_SRCS_PHASE2_SUPPRESS}
-    DEFINES
-        NVM_STORE_HOST_MOCK=1
-)
-
-# ---------------------------------------------------------------------------
-# 20. test_phase3_nvm_dtc  [P3]
-#     Module under test: config/dtc_mirror.c — DTC NVM persistence
-# ---------------------------------------------------------------------------
-add_diag_test(test_phase3_nvm_dtc
-    SOURCES
-        "${TEST_UNIT_DIR}/test_phase3_nvm_dtc.c"
-        ${DIAG_SRCS_PHASE3_NVM}
-    DEFINES
-        NVM_STORE_HOST_MOCK=1
-)
-
-# ---------------------------------------------------------------------------
-# 21. test_phase3_nvm_integration  [P3]
-#     Module under test: platform/nvm_store.c — full NVM integration
-# ---------------------------------------------------------------------------
-add_diag_test(test_phase3_nvm_integration
-    SOURCES
-        "${TEST_UNIT_DIR}/test_phase3_nvm_integration.c"
-        ${DIAG_SRCS_PHASE3_NVM}
-    DEFINES
-        NVM_STORE_HOST_MOCK=1
-)
-
-# ---------------------------------------------------------------------------
-# 22. test_phase3_nvm_security  [P3]
-#     Module under test: core/uds_security_nvm.c — security attempt persistence
-# ---------------------------------------------------------------------------
-add_diag_test(test_phase3_nvm_security
-    SOURCES
-        "${TEST_UNIT_DIR}/test_phase3_nvm_security.c"
-        ${DIAG_SRCS_PHASE3_NVM}
-    DEFINES
-        NVM_STORE_HOST_MOCK=1
-)
-
-# ---------------------------------------------------------------------------
-# 23. test_phase5_access_table  [P5]
-#     Module under test: core/uds_access_table.c — ACL lookup and enforcement
-# ---------------------------------------------------------------------------
-add_diag_test(test_phase5_access_table
-    SOURCES
-        "${TEST_UNIT_DIR}/test_phase5_access_table.c"
-        ${DIAG_SRCS_PHASE5_ACCESS}
-)
-
-# ---------------------------------------------------------------------------
-# 24. test_phase5_replay_protection  [P5]
-#     Module under test: core/uds_security_algo.c — replay protection via nonce
-# ---------------------------------------------------------------------------
-add_diag_test(test_phase5_replay_protection
-    SOURCES
-        "${TEST_UNIT_DIR}/test_phase5_replay_protection.c"
-        ${DIAG_SRCS_PHASE5_SECURITY_ALGO}
-)
-
-# ---------------------------------------------------------------------------
-# 25. test_phase5_server_access  [P5]
-#     Module under test: core/uds_server.c — srv_check_access_rights()
-# ---------------------------------------------------------------------------
-add_diag_test(test_phase5_server_access
-    SOURCES
-        "${TEST_UNIT_DIR}/test_phase5_server_access.c"
-        ${DIAG_SRCS_SERVICES_FULL}
-    DEFINES
-        NVM_STORE_HOST_MOCK=1
-)
-
-# ---------------------------------------------------------------------------
-# 26. test_routine_database
-#     Module under test: config/routine_database.c — RID registry
-# ---------------------------------------------------------------------------
-add_diag_test(test_routine_database
-    SOURCES
-        "${TEST_UNIT_DIR}/test_routine_database.c"
-        ${DIAG_SRCS_ROUTINE_DB}
-        "${DIAG_GENERATED}/routine_handlers.c"
-)
-
-# ---------------------------------------------------------------------------
-# 27. test_service_0x14
-#     Module under test: core/uds_services/service_0x14.c — ClearDiagInfo
-# ---------------------------------------------------------------------------
-add_diag_test(test_service_0x14
-    SOURCES
-        "${TEST_UNIT_DIR}/test_service_0x14.c"
-        ${DIAG_SRCS_SERVICES_FULL}
-    DEFINES
-        NVM_STORE_HOST_MOCK=1
-)
-
-# ---------------------------------------------------------------------------
-# 28. test_service_0x19
-#     Module under test: core/uds_services/service_0x19.c — ReadDTCInformation
-# ---------------------------------------------------------------------------
-add_diag_test(test_service_0x19
-    SOURCES
-        "${TEST_UNIT_DIR}/test_service_0x19.c"
-        ${DIAG_SRCS_SERVICES_FULL}
-)
-
-# ---------------------------------------------------------------------------
-# 29. test_service_0x28
-#     Module under test: core/uds_services/service_0x28.c — CommunicationControl
-# ---------------------------------------------------------------------------
-add_diag_test(test_service_0x28
-    SOURCES
-        "${TEST_UNIT_DIR}/test_service_0x28.c"
-        ${DIAG_SRCS_SERVICES_FULL}
-)
-
-# ---------------------------------------------------------------------------
-# 30. test_service_0x31
-#     Module under test: core/uds_services/service_0x31.c — RoutineControl
-# ---------------------------------------------------------------------------
-add_diag_test(test_service_0x31
-    SOURCES
-        "${TEST_UNIT_DIR}/test_service_0x31.c"
-        ${DIAG_SRCS_SERVICES_FULL}
-)
-
-# ---------------------------------------------------------------------------
-# 33. test_service_0x34
-#     Module under test: core/uds_services/service_0x34.c — RequestDownload
-#     Tests: NULL ctx, flash ops gate (NRC 0x22), ALFID parsing, address range
-#            validation, erase failure (NRC 0x70), positive response format,
-#            transfer context initialisation (REQ-DL-001/002).
-# ---------------------------------------------------------------------------
-add_diag_test(test_service_0x34
-    SOURCES
-        "${TEST_UNIT_DIR}/test_service_0x34.c"
-        ${DIAG_SRCS_SERVICES_FULL}
-)
-
-# ---------------------------------------------------------------------------
-# 34. test_service_0x36
-#     Module under test: core/uds_services/service_0x36.c — TransferData
-#     Tests: block counter validation (NRC 0x73), wrap 0xFF→0x01 (REQ-DL-001),
-#            bytes_remaining decrement (REQ-DL-002), write flush, CRC update,
-#            write failure → IDLE reset (REQ-DL-003).
-# ---------------------------------------------------------------------------
-add_diag_test(test_service_0x36
-    SOURCES
-        "${TEST_UNIT_DIR}/test_service_0x36.c"
-        ${DIAG_SRCS_SERVICES_FULL}
-)
-
-# ---------------------------------------------------------------------------
-# 35. test_service_0x37
-#     Module under test: core/uds_services/service_0x37.c — RequestTransferExit
-#     Tests: incomplete transfer gate (NRC 0x31), partial buffer flush, CRC-32
-#            verify path, CRC mismatch (NRC 0x72), verify failure, transfer
-#            reset on success and failure (REQ-DL-003).
-# ---------------------------------------------------------------------------
-add_diag_test(test_service_0x37
-    SOURCES
-        "${TEST_UNIT_DIR}/test_service_0x37.c"
-        ${DIAG_SRCS_SERVICES_FULL}
-)
-
-# ---------------------------------------------------------------------------
-# 31. test_service_0x3E  (was 15, now also confirmed in full set)
-#     Module under test: core/uds_services/service_0x3E.c — TesterPresent
-#     Note: also registered as test 15 above using the legacy target name.
-#     This duplicate target uses _v2 suffix to avoid CMake name collision.
-# ---------------------------------------------------------------------------
-# (already covered as test 15 — no duplicate needed)
-
-# ---------------------------------------------------------------------------
-# 32. test_service_0x85
-#     Module under test: core/uds_services/service_0x85.c — ControlDTCSetting
-# ---------------------------------------------------------------------------
-add_diag_test(test_service_0x85
-    SOURCES
-        "${TEST_UNIT_DIR}/test_service_0x85.c"
-        ${DIAG_SRCS_SERVICES_FULL}
-)
-
-# ---------------------------------------------------------------------------
-# 37. test_doip_server
-#     Module under test: transport/doip/doip_server.c
-# ---------------------------------------------------------------------------
-add_diag_test(test_doip_server
-    SOURCES
-        "${TEST_UNIT_DIR}/test_doip_server.c"
-        "${DIAG_TRANSPORT}/doip/doip_server.c"
-        ${DIAG_SRCS_SERVICES_FULL}
-)
-
+# End of tests/CMakeLists.txt


### PR DESCRIPTION
Closes #88.

## Problem

`tests/CMakeLists.txt` (the CTest build path) did not configure, let alone build, at three
independent levels, as described in #88:

1. **Configure failed** — `add_executable()` pointed generated sources at
   `<repo-root>/generated/`, which does not exist (root `generated/` was removed; each
   example owns its own `generated/` subfolder — see `.gitignore`). The real location is
   `examples/basic_ecu/generated/`, same as `build_tests.sh`.
2. **Every target then failed a `_Static_assert`** in `core/uds_types.h` on `uds_msg_buf_t`
   size, because the compile definitions `build_tests.sh`'s `CFLAGS` array passes
   (`UNIT_TEST=1`, `NVM_STORE_HOST_MOCK=1`, `ISOTP_ENABLE_CAN_FD=1`, `ISOTP_TX_PADDING=1`,
   `EDS_MSG_BUF_MAX_STACK_BYTES=8192`) were entirely absent from the CMake path.
3. **Per-target `SOURCES` lists were hand-maintained and incomplete** — unlike
   `build_tests.sh`, which links the entire diagnostics stack into every test binary via one
   `STACK_SRCS` array, `add_diag_test()` gave each target its own short list, so targets that
   got past (1) and (2) still failed to link with undefined-reference errors.

Because CI only ran `bash build_tests.sh` and never invoked CMake, none of this was ever
caught.

## Fix

Mirrors `build_tests.sh` rather than retiring the CMake path (per #88's suggested direction):

- **`DIAG_STACK_SRCS`** — one shared CMake list matching `build_tests.sh`'s `STACK_SRCS`
  array file-for-file (~45 sources: core UDS server/session/security/safety, all
  `uds_services/*.c`, transport, config databases, generated sources, platform mocks), linked
  into every `add_diag_test()` executable. `unity.c` and `tests/runner/test_main.c` are
  intentionally excluded from this list — `unity.c` is provided via the `unity` static
  library (`target_link_libraries`) and `test_main.c` is added unconditionally inside
  `add_diag_test()` itself; including either again would double-link/duplicate-source-file
  error.
- **`DIAG_GENERATED`** now points at `examples/basic_ecu/generated/` instead of the
  nonexistent `<repo-root>/generated/`.
- **Missing compile definitions** added directory-wide via `add_compile_definitions()`:
  `UNIT_TEST=1`, `NVM_STORE_HOST_MOCK=1`, `ISOTP_ENABLE_CAN_FD=1`, `ISOTP_TX_PADDING=1`,
  `EDS_MSG_BUF_MAX_STACK_BYTES=8192` (`ZTEST_HOST_SHIM=1` was already present via
  `DIAG_TEST_COMPILE_OPTIONS` and is left as-is).
- **Every `add_diag_test()` call reworked** to `SOURCES = ${DIAG_STACK_SRCS}` plus that
  module's own test file. `test_trng_fail_closed` keeps its
  `CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0` override (mirrors `build_tests.sh`'s
  `extra_flags_for_test()`); `test_phase5_security_algo` needs no override now that
  `uds_safety.c` is part of the shared stack by default.
- **Added the 3 missing targets** that existed in `build_tests.sh`'s `TESTS` array but had no
  CMake equivalent at all: `test_service_0x2F`, `test_service_0x35`, `test_service_0x23_0x3D`.
  This brings the CMake path to full parity: **43 modules**, matching `build_tests.sh`
  exactly (verified by diffing the two `TESTS`/`add_diag_test()` name lists).
- Also added `transport/doip` and `tests/mocks` to `DIAG_INCLUDE_DIRS` (needed by
  `test_doip_server.c`'s `#include "doip_server.h"` and to match `build_tests.sh`'s
  `INCLUDES` array) — this was a latent gap not mentioned in the issue but caught while
  wiring `test_doip_server` into the shared stack.
- Updated the stale header comment ("37 modules" / "40 modules") to the correct **43**.

## CI

Added a new job, `cmake-ctest-build` / `"CMake/CTest Build (parity with build_tests.sh)"`, to
`.github/workflows/ci.yml`, placed immediately after `unit-tests`. It uses the same runner
(`ubuntu-22.04`) and the same `Install build tools` / `Install Python dependencies` /
`Verify pre-committed generated files are present` steps as `unit-tests`, then runs:

```
cmake -S tests -B build
cmake --build build -j4
ctest --test-dir build --output-on-failure
```

This is what closes the loop the issue calls out — "the root cause here is that nothing runs
it."

## Verification (run for real, not eyeballed)

**Generated sources**: already pre-committed at `examples/basic_ecu/generated/` in this
worktree — codegen was not re-run.

### `cmake -S tests -B build` (configure)

```
-- The C compiler identification is GNU 15.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring done (0.2s)
-- Generating done (0.2s)
-- Build files have been written to: /tmp/cmake-verify-build2
```
Exit code: `0`

### `cmake --build build -j4`

Full log is 2305 lines (43 executables, each linking the full stack). Reaches 100% with no
errors — grep for `error` across the whole log returns nothing; only pre-existing benign
`-Wunused-function` warnings from test files where a `ztest_shim` macro selects a subset of
defined test-case functions (same warnings `build_tests.sh` would emit compiling the same
sources, not introduced by this change). Tail:

```
[100%] Building C object CMakeFiles/test_trng_fail_closed.dir/.../config/routine_database.c.o
[100%] Building C object CMakeFiles/test_trng_fail_closed.dir/.../examples/basic_ecu/generated/did_handlers.c.o
[100%] Building C object CMakeFiles/test_trng_fail_closed.dir/.../examples/basic_ecu/generated/routine_handlers.c.o
[100%] Building C object CMakeFiles/test_trng_fail_closed.dir/.../examples/basic_ecu/generated/did_safety_wrappers.c.o
[100%] Building C object CMakeFiles/test_trng_fail_closed.dir/.../platform/zephyr/nvm_store_mock.c.o
[100%] Building C object CMakeFiles/test_trng_fail_closed.dir/mocks/zephyr_port_mock.c.o
[100%] Linking C executable test_trng_fail_closed
[100%] Built target test_trng_fail_closed
```
Exit code: `0`

### `ctest --test-dir build`

```
Test project /tmp/cmake-verify-build2
      Start  1: test_uds_session
 1/43 Test  #1: test_uds_session .................   Passed    0.00 sec
...
      Start 43: test_trng_fail_closed
43/43 Test #43: test_trng_fail_closed ............   Passed    0.00 sec

100% tests passed, 0 tests failed out of 43

Total Test time (real) =   0.09 sec
```
Exit code: `0`

## Gates (unaffected paths, run to confirm)

### `bash build_tests.sh`

```
================================================================
  Xaloqi EDS — Host Unit Tests  (43 modules)
================================================================

  test_uds_session                               PASS
  ... (all 43 modules) ...
  test_trng_fail_closed                          PASS

================================================================
  === Unit Test Summary: 43 passed, 0 failed ===
================================================================
```
**43 passed, 0 failed** — unaffected by this change (script itself untouched).

### `bash build_harness.sh --run`

(`harness/` symlinked in locally per the gitignored commercial-tier convention — not part of
this diff.)

```
=== HARNESS SUMMARY ===
  Total:  68
  Pass:   68
  Fail:   0

  ALL 68 HARNESS TESTS PASSED
```
**68/68** — unaffected by this change.

## Notes

- No changes to `core/`, `transport/`, `config/`, or `platform/` — only `tests/CMakeLists.txt`
  (test infra), `.github/workflows/ci.yml` (CI config), and `CHANGELOG.md`. No CLA required
  per CONTRIBUTING.md.
- Filed #91 separately for a pre-existing, unrelated stale-count issue noticed while working
  on this (`ci.yml`'s header comment says "8 jobs", `CONTRIBUTING.md` says both "13" and "10"
  CI jobs, none matching the actual count) — left out of this PR to keep the diff scoped to
  #88.
- `CHANGELOG.md` updated under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
