### PR TITLE
security: unify build-mode detection into EDS_BUILD_IS_PRODUCTION (issue #84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,31 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   init step present in the template but missing from 4 of the 12 examples)
   — tracked separately, not bundled into this security fix
   ([EDS-toolchain#50](https://github.com/Xaloqi/EDS-toolchain/issues/50)).
+  **`/code-review` caught and this fix corrects one real regression before
+  merge:** `ALGO_ENTROPY_FAIL_CLOSED`'s alias definition
+  (`#define ALGO_ENTROPY_FAIL_CLOSED EDS_BUILD_IS_PRODUCTION`) had no
+  `#if !defined(ALGO_ENTROPY_FAIL_CLOSED)` guard, so the documented
+  `-DALGO_ENTROPY_FAIL_CLOSED=1` command-line override (the CRIT-4
+  deviation escape hatch) was silently discarded — verified by compiling
+  with the override and `gcc -dM -E`, which showed the macro still
+  resolving to `EDS_BUILD_IS_PRODUCTION`'s value, with only a
+  "redefined" warning as the only trace. The guard is restored; also
+  fixed a naming typo in the CRIT-4 comment (`k_level_keys[]` →
+  `s_level_keys[]`, the actual identifier, in both new and pre-existing
+  prose), deduplicated `build_tests.sh`'s CRIT-4 negative-compile test
+  onto the existing shared `INCLUDES` array instead of a second
+  hand-maintained copy, removed a fully redundant regression-guard
+  compile (already proven by the ~42 other test modules built earlier in
+  the same script run), and centralized the 4 FreeRTOS examples'
+  `EDS_PLACEHOLDER_KEYS_ONLY` option into `cmake/eds_build_mode.cmake`
+  rather than duplicating it per example — mirroring this codebase's own
+  established convention (`cmake/eds_service_sources.cmake`) for exactly
+  this class of drift risk. Re-verified against a real ARM cross-compile
+  toolchain (`arm-none-eabi-gcc` + a fresh `FreeRTOS-Kernel` clone): every
+  object file compiles clean through link, including the patched
+  `uds_init.c`; the only remaining failure is the pre-existing, unrelated
+  callback-signature bug tracked as
+  [#96](https://github.com/Xaloqi/EDS/issues/96).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,15 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   is the intended remediation, but it is a real behaviour change for anyone
   who was unknowingly relying on the previously-broken, silently-inert
   gates. See `SECURITY.md` for the corrected dev-vs-production tables.
+  All 12 committed `examples/*/generated/uds_init.c` files carry the fixed
+  Step 7.1 guard (`#if EDS_BUILD_IS_PRODUCTION` in place of the broken
+  idiom) — applied as a targeted patch of that one block rather than a full
+  codegen regeneration, since `tools/templates/uds_init.c.j2` (private
+  EDS-toolchain repo) currently carries unrelated drift from what's
+  committed here (an ISO 26262 citation update, and a CommunicationControl
+  init step present in the template but missing from 4 of the 12 examples)
+  — tracked separately, not bundled into this security fix
+  ([EDS-toolchain#50](https://github.com/Xaloqi/EDS-toolchain/issues/50)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,68 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+### Security
+
+- **BREAKING: unified build-mode detection closes a silent bypass of both the
+  CRIT-4 placeholder-key gate and the TRNG fail-closed gate — on Zephyr
+  production builds and on EVERY FreeRTOS build.** (#84)
+  `[SEC-BUILD-MODE-01]` Two independently-authored copies of "is this a
+  production build?" existed in this codebase — the CRIT-4 placeholder-key
+  `#error` in `core/uds_security_algo.c`, and the Step 7.1 runtime guard
+  generated into every `examples/*/generated/uds_init.c` — and both used the
+  same broken idiom: `defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) &&
+  !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY`. Zephyr's generated `autoconf.h` emits
+  `#define CONFIG_X 1` for a Kconfig bool set to `y`, and OMITS the symbol
+  entirely for `n` — it never emits `#define CONFIG_X 0`. So on a real Zephyr
+  **production** build (the bool set to `n`, exactly what the docs told
+  integrators to do), `defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY)` was FALSE,
+  and both gates silently did nothing — the CRIT-4 `#error` never fired and
+  the Step 7.1 runtime refusal never triggered, in precisely the
+  configuration they exist to protect.
+  Both gates now derive from one shared primitive, `EDS_BUILD_IS_PRODUCTION`
+  (`core/uds_security_algo.h`), so they cannot drift apart again. The CRIT-4
+  gate is `EDS_BUILD_IS_PRODUCTION && !defined(UNIT_TEST)` (the
+  `!defined(UNIT_TEST)` carve-out is unchanged from before this fix — it lets
+  a host unit test force `EDS_BUILD_IS_PRODUCTION=1` to exercise a different
+  gate's production behaviour, e.g. `test_trng_fail_closed.c`, without also
+  tripping the placeholder-key `#error` against a test binary that was never
+  going to have real keys). `ALGO_ENTROPY_FAIL_CLOSED`
+  (`[SEC-TRNG-FAILCLOSED-01]`, added in #85) is now a plain alias for
+  `EDS_BUILD_IS_PRODUCTION`.
+  **FreeRTOS landmine, fixed the same change:** FreeRTOS has no Kconfig of
+  its own, and no FreeRTOS example ever defined
+  `CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY` anywhere in its build — so under the
+  OLD idiom, FreeRTOS was *always* unprotected by both gates (a second
+  instance of the same bug), and under a naive fail-closed-by-default fix it
+  would have flipped to refusing to build or initialise on *every* FreeRTOS
+  build, including CI, with no way to declare itself a development build.
+  All 4 FreeRTOS example `CMakeLists.txt` files
+  (`examples/basic_ecu_freertos`, `basic_ecu_doip_freertos`,
+  `sensor_ecu_freertos`, `safeboot_freertos_ecu`) now expose
+  `-DEDS_PLACEHOLDER_KEYS_ONLY=<ON|OFF>` (default `ON`, i.e. development —
+  mirroring Zephyr Kconfig's own `default y`), which feeds
+  `CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY` the same defined-and-1-or-0 signal
+  Zephyr's Kconfig always gave.
+  **This also retroactively closes a latent gap in the already-merged
+  `ALGO_ENTROPY_FAIL_CLOSED` fix (PR #85, #90) for FreeRTOS specifically:**
+  because that gate already had the corrected fail-closed-by-default
+  polarity, and FreeRTOS never defined the Kconfig symbol, a real FreeRTOS
+  build has always silently resolved to the production TRNG behaviour (hard
+  refusal on TRNG loss) with **no supported way to opt into the development
+  LFSR fallback** — a gap invisible to CI because the `freertos-qemu` job is
+  build-only and never exercises a live SecurityAccess request. It is fixed
+  by the same `-DEDS_PLACEHOLDER_KEYS_ONLY` CMake option.
+  **Breaking change:** any FreeRTOS build, and any Zephyr production build
+  that was silently bypassing the CRIT-4 key gate and/or the TRNG
+  fail-closed gate before this fix, will now correctly refuse to *compile*
+  (CRIT-4, if placeholder keys are still present) or *initialise* (Step 7.1
+  runtime guard) unless it explicitly declares itself a development build
+  (`CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=y` on Zephyr,
+  `-DEDS_PLACEHOLDER_KEYS_ONLY=ON` on FreeRTOS — both are the default). This
+  is the intended remediation, but it is a real behaviour change for anyone
+  who was unknowingly relying on the previously-broken, silently-inert
+  gates. See `SECURITY.md` for the corrected dev-vs-production tables.
+
 ### Fixed
 
 - **`uds_safety_reset_counters()` now clears `platform_violations`.** (#86)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -100,28 +100,70 @@ conflated:
   hardness assumption.
 
 **Placeholder keys:** The repository ships with placeholder AES-128 keys
-(`0x00..0x0F` / `0x10..0x1F`). A compile-time gate (`CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY`)
-and a runtime guard in the generated init sequence prevent accidental deployment of
-placeholder keys. See `docs/SECURITY_NOTICE.md` for entropy requirements. The full OEM key injection procedure is included with the Professional tier.
+(`0x00..0x0F` / `0x10..0x1F`). Two independent gates now reliably stop accidental
+deployment of placeholder keys, both derived from a single shared build-mode primitive,
+`EDS_BUILD_IS_PRODUCTION` (`core/uds_security_algo.h`, `[SEC-BUILD-MODE-01]`, issue #84):
+
+- **Compile-time gate** (`[SEC-KEY-GATE-01]` / CRIT-4, `core/uds_security_algo.c`):
+  a production build (`EDS_BUILD_IS_PRODUCTION == 1`) now **actually refuses to
+  compile** — an unconditional `#error` — while `core/uds_security_algo.c` still
+  contains the compile-time placeholder key data. This is not conditional on
+  detecting the specific placeholder byte pattern; it forces the integrator to
+  affirmatively prove intent (inject real keys via `uds_security_algo_set_level_key()`,
+  or edit the key array in a secure build) before a production flag is honoured.
+- **Runtime guard** in the generated init sequence (Step 7.1): refuses to start
+  (`UDS_STATUS_ERR_CONDITIONS_NOT_MET`) if `uds_security_algo_keys_are_placeholder()`
+  still reports placeholder keys in a production build.
+
+**Zephyr**: set `CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=n` in your production `prj.conf` to
+declare a production build (unchanged from before this fix — what changed is that this
+now actually works: previously, Zephyr's generated `autoconf.h` OMITS the Kconfig
+symbol entirely for `n` rather than emitting `0`, which meant both gates silently did
+nothing in exactly this configuration — see issue #84).
+
+**FreeRTOS** (new, issue #84): FreeRTOS has no Kconfig of its own. Every FreeRTOS
+example's `CMakeLists.txt` now exposes `-DEDS_PLACEHOLDER_KEYS_ONLY=<ON|OFF>` (default
+`ON`, i.e. development). Set `-DEDS_PLACEHOLDER_KEYS_ONLY=OFF` to declare a production
+FreeRTOS build. Before this fix, no FreeRTOS build — development or production — ever
+defined `CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY` at all, so both gates were silently inert
+on every FreeRTOS build, including CI. See `docs/SECURITY_NOTICE.md` for entropy
+requirements. The full OEM key injection procedure is included with the Professional
+tier.
 
 **TRNG:** Seed generation quality depends on the platform's hardware entropy source.
 Production deployments must supply a TRNG-backed callback via
 `uds_security_algo_set_rng_cb()`. Behaviour on loss of entropy is now **fail-closed
 in production, and unchanged in development/CI** — see `[SEC-TRNG-FAILCLOSED-01]` in
-`core/uds_security_algo.c`:
+`core/uds_security_algo.c`. `ALGO_ENTROPY_FAIL_CLOSED` is a plain alias for
+`EDS_BUILD_IS_PRODUCTION` (`[SEC-BUILD-MODE-01]`, issue #84) — the same shared
+build-mode primitive the placeholder-key gates above now use, so this and the
+placeholder-key protection can no longer drift apart the way they did before #84:
 
-- **Development/CI builds** (no `CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=n` Zephyr production
-  build): if no TRNG is registered, or a registered TRNG callback fails at runtime, the
-  stack falls back to a 16-bit software LFSR and logs a fault count. This is unchanged
-  legacy behaviour, intentional for CI and simulator builds only.
-- **Production builds** (Zephyr build with `CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=n`): the
-  LFSR is never used to satisfy a seed request. If no TRNG is registered, or the
-  registered TRNG callback fails, `SecurityAccess` seed generation is refused
-  (`UDS_STATUS_ERR_SEC_SEED_UNAVAILABLE`, surfaced to the tester as NRC 0x24) instead
-  of silently degrading to a predictable seed. The fault is recorded in the
-  `uds_safety` platform-violations counter either way; the two cases are distinguished
-  by `last_violation_code` (`UDS_STATUS_ERR_PLATFORM` for the dev-mode soft fallback vs.
+- **Development/CI builds** (Zephyr with `CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=y`,
+  FreeRTOS with `-DEDS_PLACEHOLDER_KEYS_ONLY=ON` — the default on both, or a host
+  unit-test build): if no TRNG is registered, or a registered TRNG callback fails at
+  runtime, the stack falls back to a 16-bit software LFSR and logs a fault count. This
+  is unchanged legacy behaviour, intentional for CI and simulator builds only.
+- **Production builds** (Zephyr with `CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=n`, or
+  FreeRTOS with `-DEDS_PLACEHOLDER_KEYS_ONLY=OFF`): the LFSR is never used to satisfy a
+  seed request. If no TRNG is registered, or the registered TRNG callback fails,
+  `SecurityAccess` seed generation is refused (`UDS_STATUS_ERR_SEC_SEED_UNAVAILABLE`,
+  surfaced to the tester as NRC 0x24) instead of silently degrading to a predictable
+  seed. The fault is recorded in the `uds_safety` platform-violations counter either
+  way; the two cases are distinguished by `last_violation_code`
+  (`UDS_STATUS_ERR_PLATFORM` for the dev-mode soft fallback vs.
   `UDS_STATUS_ERR_SEC_SEED_UNAVAILABLE` for the production hard refusal).
+
+**Retroactive fix (issue #84):** before this fix, no FreeRTOS build ever defined
+`CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY`, so `ALGO_ENTROPY_FAIL_CLOSED` always fell through
+to its own fail-closed default on FreeRTOS — a real FreeRTOS deployment with no TRNG
+registered has always gotten the production hard refusal, with **no supported way to
+opt into the development LFSR fallback**. This was a latent, CI-invisible gap in the
+already-merged TRNG fail-closed fix (PR #85): the `freertos-qemu` CI job is build-only
+(compiles, links, checks the ELF exists) and never exercises a live SecurityAccess
+request, so the gap never surfaced there. `-DEDS_PLACEHOLDER_KEYS_ONLY=ON` (the new
+FreeRTOS CMake default) now gives FreeRTOS the same supported development opt-in
+Zephyr's Kconfig always had.
 
 **ASIL-B DID access chain:** The 5-step validation chain is enforced at code generation
 time. It cannot be disabled by runtime configuration. Any mechanism that allows DID

--- a/build_tests.sh
+++ b/build_tests.sh
@@ -442,20 +442,18 @@ fi
 # rationale in uds_security_algo.c) must FAIL to compile, with an error
 # mentioning SEC-KEY-GATE-01.
 #
-# CASE B (regression guard): the default dev-mode compile every other test
-# in this script already performs (-DUNIT_TEST=1, no
-# CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) must still succeed.
+# No separate regression-guard compile: the default dev-mode compile
+# (-DUNIT_TEST=1, no CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) is already proven by
+# every one of the ~42 test modules built in the main loop above, all of
+# which link core/uds_security_algo.c under that exact configuration -- a
+# second compile here would only re-prove a fact the main loop already
+# established, on every single invocation of this script.
 # ---------------------------------------------------------------------------
 CRIT4_TMP_OBJ="$(mktemp -u /tmp/eds_crit4_negtest.XXXXXX.o)"
-CRIT4_INCLUDES=(
-    "-I${ROOT}/core"
-    "-I${ROOT}/core/uds_services"
-    "-I${ROOT}/transport"
-    "-I${ROOT}/config"
-    "-I${ROOT}/platform"
-    "-I${ROOT}/platform/zephyr"
-    "-I${ROOT}/examples/basic_ecu/generated"
-)
+# Reuses INCLUDES (defined above) rather than its own copy -- a second,
+# independently-maintained include-path array is exactly the "two copies of
+# the same fact drift apart" failure mode this PR fixes elsewhere; no reason
+# to reintroduce it here.
 
 echo ""
 echo "================================================================"
@@ -464,7 +462,7 @@ echo "================================================================"
 echo ""
 
 crit4_neg_out=$(
-    gcc -std=c11 -c -DCONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0 -DEDS_MSG_BUF_MAX_STACK_BYTES=8192         "${CRIT4_INCLUDES[@]}" "${ROOT}/core/uds_security_algo.c" -o "${CRIT4_TMP_OBJ}" 2>&1
+    gcc -std=c11 -c -DCONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0 -DEDS_MSG_BUF_MAX_STACK_BYTES=8192         "${INCLUDES[@]}" "${ROOT}/core/uds_security_algo.c" -o "${CRIT4_TMP_OBJ}" 2>&1
 ) && crit4_neg_rc=0 || crit4_neg_rc=$?
 rm -f "${CRIT4_TMP_OBJ}"
 
@@ -476,20 +474,6 @@ else
     echo "  FAIL: expected a SEC-KEY-GATE-01 compile failure, got:"
     echo "        rc=${crit4_neg_rc}"
     echo "${crit4_neg_out}" | sed 's/^/        /'
-    CRIT4_FAIL=1
-fi
-
-crit4_pos_out=$(
-    gcc -std=c11 -c -DUNIT_TEST=1 -DEDS_MSG_BUF_MAX_STACK_BYTES=8192         "${CRIT4_INCLUDES[@]}" "${ROOT}/core/uds_security_algo.c" -o "${CRIT4_TMP_OBJ}" 2>&1
-) && crit4_pos_rc=0 || crit4_pos_rc=$?
-rm -f "${CRIT4_TMP_OBJ}"
-
-if [[ ${crit4_pos_rc} -eq 0 ]]; then
-    echo "  PASS: default dev-mode compile (-DUNIT_TEST=1, no Kconfig symbol)"
-    echo "        still succeeds (regression guard)."
-else
-    echo "  FAIL: default dev-mode compile unexpectedly failed:"
-    echo "${crit4_pos_out}" | sed 's/^/        /'
     CRIT4_FAIL=1
 fi
 echo ""

--- a/build_tests.sh
+++ b/build_tests.sh
@@ -413,6 +413,93 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# [SEC-BUILD-MODE-01 / issue #84] EDS_BUILD_IS_PRODUCTION macro probe.
+#
+# Compiles tests/probe_eds_build_is_production.c under every build-mode -D
+# combination the codebase can present and checks the macro resolves
+# correctly in each -- see scripts/verify_build_mode_macro.sh for the full
+# truth table and rationale.
+# ---------------------------------------------------------------------------
+echo ""
+if bash "${ROOT}/scripts/verify_build_mode_macro.sh"; then
+    BUILD_MODE_PROBE_FAIL=0
+else
+    BUILD_MODE_PROBE_FAIL=1
+fi
+
+# ---------------------------------------------------------------------------
+# [SEC-KEY-GATE-01 / CRIT-4 / issue #84] Negative compile test.
+#
+# Proves the CRIT-4 placeholder-key #error is now actually REACHABLE in a
+# real production build -- it never was before this fix (the old
+# `defined(X) && !X` idiom never fires when Zephyr's autoconf.h omits the
+# symbol for a Kconfig bool set to `n`, which is exactly what a real
+# production build looks like).
+#
+# CASE A (negative): compiling core/uds_security_algo.c with
+# -DCONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0 and WITHOUT -DUNIT_TEST (i.e. not a
+# host-test build -- see the CRIT-4 gate's own `!defined(UNIT_TEST)`
+# rationale in uds_security_algo.c) must FAIL to compile, with an error
+# mentioning SEC-KEY-GATE-01.
+#
+# CASE B (regression guard): the default dev-mode compile every other test
+# in this script already performs (-DUNIT_TEST=1, no
+# CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) must still succeed.
+# ---------------------------------------------------------------------------
+CRIT4_TMP_OBJ="$(mktemp -u /tmp/eds_crit4_negtest.XXXXXX.o)"
+CRIT4_INCLUDES=(
+    "-I${ROOT}/core"
+    "-I${ROOT}/core/uds_services"
+    "-I${ROOT}/transport"
+    "-I${ROOT}/config"
+    "-I${ROOT}/platform"
+    "-I${ROOT}/platform/zephyr"
+    "-I${ROOT}/examples/basic_ecu/generated"
+)
+
+echo ""
+echo "================================================================"
+echo "  [SEC-KEY-GATE-01] CRIT-4 negative compile test"
+echo "================================================================"
+echo ""
+
+crit4_neg_out=$(
+    gcc -std=c11 -c -DCONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0 -DEDS_MSG_BUF_MAX_STACK_BYTES=8192         "${CRIT4_INCLUDES[@]}" "${ROOT}/core/uds_security_algo.c" -o "${CRIT4_TMP_OBJ}" 2>&1
+) && crit4_neg_rc=0 || crit4_neg_rc=$?
+rm -f "${CRIT4_TMP_OBJ}"
+
+CRIT4_FAIL=0
+if [[ ${crit4_neg_rc} -ne 0 ]] && echo "${crit4_neg_out}" | grep -q "SEC-KEY-GATE-01"; then
+    echo "  PASS: production build (CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0, no UNIT_TEST)"
+    echo "        correctly FAILS to compile, citing SEC-KEY-GATE-01."
+else
+    echo "  FAIL: expected a SEC-KEY-GATE-01 compile failure, got:"
+    echo "        rc=${crit4_neg_rc}"
+    echo "${crit4_neg_out}" | sed 's/^/        /'
+    CRIT4_FAIL=1
+fi
+
+crit4_pos_out=$(
+    gcc -std=c11 -c -DUNIT_TEST=1 -DEDS_MSG_BUF_MAX_STACK_BYTES=8192         "${CRIT4_INCLUDES[@]}" "${ROOT}/core/uds_security_algo.c" -o "${CRIT4_TMP_OBJ}" 2>&1
+) && crit4_pos_rc=0 || crit4_pos_rc=$?
+rm -f "${CRIT4_TMP_OBJ}"
+
+if [[ ${crit4_pos_rc} -eq 0 ]]; then
+    echo "  PASS: default dev-mode compile (-DUNIT_TEST=1, no Kconfig symbol)"
+    echo "        still succeeds (regression guard)."
+else
+    echo "  FAIL: default dev-mode compile unexpectedly failed:"
+    echo "${crit4_pos_out}" | sed 's/^/        /'
+    CRIT4_FAIL=1
+fi
+echo ""
+
+if [[ ${BUILD_MODE_PROBE_FAIL} -ne 0 || ${CRIT4_FAIL} -ne 0 ]]; then
+    echo "FAIL: build-mode gate verification (SEC-BUILD-MODE-01 / SEC-KEY-GATE-01) failed."
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
 # [P2-4] Coverage report
 # ---------------------------------------------------------------------------
 if [[ $COVERAGE -eq 1 ]]; then

--- a/cmake/eds_build_mode.cmake
+++ b/cmake/eds_build_mode.cmake
@@ -1,0 +1,35 @@
+# =============================================================================
+# cmake/eds_build_mode.cmake — FreeRTOS build-mode declaration [SEC-BUILD-MODE-01]
+#
+# USAGE (from any FreeRTOS example CMakeLists.txt, after DIAG_ROOT is set):
+#
+#   include(${DIAG_ROOT}/cmake/eds_build_mode.cmake)
+#   target_compile_definitions(<target> PRIVATE
+#       CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=$<BOOL:${EDS_PLACEHOLDER_KEYS_ONLY}>
+#   )
+#
+# WHY THIS FILE EXISTS (issue #84):
+#   FreeRTOS has no Kconfig of its own, so without this option
+#   CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY is never defined for a FreeRTOS build,
+#   and EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h) falls through to
+#   its PRODUCTION default on every build, including CI. This option mirrors
+#   Zephyr Kconfig's own `default y` for the same symbol: ON here means
+#   "development / CI build, placeholder keys explicitly permitted."
+#
+#   Previously each FreeRTOS example would have needed this option()
+#   declared identically in its own CMakeLists.txt. That is exactly the
+#   pattern cmake/eds_service_sources.cmake's own header warns about:
+#   per-example duplication of shared, security-relevant configuration
+#   causing real bugs when one example is missed on a future change.
+#
+# FLIPPING TO PRODUCTION:
+#   -DEDS_PLACEHOLDER_KEYS_ONLY=OFF declares a production build. This is
+#   what makes the CRIT-4 #error (core/uds_security_algo.c) and the Step 7.1
+#   runtime guard (generated/uds_init.c) reachable on FreeRTOS at all.
+#
+# ADDING A NEW FREERTOS EXAMPLE:
+#   include() this file and wire the one target_compile_definitions() line
+#   above. No other change required — this option is shared, not per-example.
+# =============================================================================
+
+option(EDS_PLACEHOLDER_KEYS_ONLY "Allow placeholder AES-128 security keys (DEVELOPMENT ONLY)" ON)

--- a/core/uds_security_algo.c
+++ b/core/uds_security_algo.c
@@ -60,31 +60,78 @@
  *
  * CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY is a Kconfig bool defined in Kconfig.
  * Default: y  (allows placeholder keys — development / CI builds).
- * Production: must be set to n in prj.conf.  When n, this #error fires if
- * the source file still contains the known placeholder key bytes, preventing
- * a production firmware image from being linked with insecure keys.
+ * Production: must be set to n in prj.conf.  When a build declares itself
+ * production (see EDS_BUILD_IS_PRODUCTION in uds_security_algo.h), this
+ * #error fires, preventing a production firmware image from being linked
+ * at all while k_level_keys[] still holds the compile-time placeholder
+ * values.
  *
- * The check is conservative: it detects the zero-based sequential pattern
- * 0x00,0x01,0x02,0x03 as the first four bytes of s_level_keys[0].  Any
- * real OEM key will differ from this pattern.  If an OEM key happens to
- * start with these bytes (extremely unlikely), the gate can be silenced by
- * setting CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=y in that build only — with a
- * deviation record filed per your ASIL-B change control process.
+ * WHAT THIS CHECK ACTUALLY DOES (corrected — see issue #84 PR discussion):
+ * this is NOT byte-pattern detection of s_level_keys[]'s contents. A C
+ * preprocessor #if cannot inspect a runtime array initializer's byte
+ * values, and no mechanism anywhere in this codebase extracts those bytes
+ * into a preprocessor-visible macro. The gate is an unconditional compile
+ * failure whenever a production build is declared: it forces the
+ * integrator to affirmatively prove intent — inject real keys via
+ * uds_security_algo_set_level_key() at runtime, or edit k_level_keys[]
+ * directly in a secure build environment — and then flip the build-mode
+ * signal to production, before CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=n (or
+ * the FreeRTOS/override equivalent) can be believed. The actual runtime
+ * check of whether real keys were injected is
+ * uds_security_algo_keys_are_placeholder(), called from the generated
+ * Step 7.1 init guard (see tools/templates/uds_init.c.j2) — this #error
+ * does not duplicate that check, it just refuses to build at all until
+ * the integrator has gone through the motions of declaring production.
+ * If an OEM's integration process needs to keep placeholder keys in a
+ * build that is otherwise production in every other respect, the gate can
+ * be silenced by keeping CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=y (or
+ * EDS_BUILD_IS_PRODUCTION=0) in that build only — with a deviation record
+ * filed per your ASIL-B change control process.
  *
- * For host-side unit test builds (UNIT_TEST=1) the gate is bypassed because
- * those builds do not include autoconf.h and the symbol is undefined.
+ * BUILD-MODE DERIVATION: see EDS_BUILD_IS_PRODUCTION in
+ * uds_security_algo.h (SEC-BUILD-MODE-01) for the full four-case
+ * derivation, including the Zephyr autoconf.h omission quirk that made
+ * the OLD version of this gate (`defined(X) && !X`) never fire on a real
+ * Zephyr production build. This gate no longer re-derives THAT logic —
+ * it consumes the shared primitive so the two cannot drift apart again.
+ *
+ * WHY THIS SITE ALSO KEEPS ITS OWN `!defined(UNIT_TEST)` ON TOP OF
+ * EDS_BUILD_IS_PRODUCTION: EDS_BUILD_IS_PRODUCTION answers "is this a
+ * production build" in general — it does not, and should not, also try to
+ * answer CRIT-4's narrower question: "does this specific compiled binary
+ * actually contain real, non-placeholder OEM keys." A host unit-test
+ * binary (build_tests.sh, build_harness.sh, the CMake test path) can
+ * deliberately force EDS_BUILD_IS_PRODUCTION=1 — via
+ * -DCONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0 — purely to exercise a gate's
+ * PRODUCTION *behaviour* (see test_trng_fail_closed.c, which forces this
+ * exact combination to reach ALGO_ENTROPY_FAIL_CLOSED's fail-closed
+ * path). That binary is not pretending to be a deployable image and never
+ * has real keys injected via OTP/HSM, so CRIT-4 firing there would be
+ * asserting something true but useless: it would make it permanently
+ * impossible to compile ANY host test that forces the production path for
+ * anything else in this file. `!defined(UNIT_TEST)` is this gate's own,
+ * narrow, CRIT-4-specific exemption for exactly that case — it is NOT a
+ * copy of the #84 bug and must not be folded into EDS_BUILD_IS_PRODUCTION
+ * itself (that would silently exempt every consumer of the shared macro,
+ * including ALGO_ENTROPY_FAIL_CLOSED, defeating the point of forcing the
+ * production path from a host test at all). UNIT_TEST is exclusively a
+ * host-test-build macro — it is never defined by any real Zephyr Kconfig,
+ * any FreeRTOS CMakeLists.txt, or any bare-metal toolchain in this
+ * codebase — so for every real firmware image (Zephyr or FreeRTOS, dev or
+ * production) `!defined(UNIT_TEST)` is always true and this condition
+ * reduces to exactly EDS_BUILD_IS_PRODUCTION, i.e. the #84 fix is intact
+ * for every build that matters.
  *
  * TRACEABILITY: SEC-KEY-GATE-01 / CRIT-4
  * ============================================================================= */
 
-#if defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && \
-    !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY && \
-    !defined(UNIT_TEST)
-#error "[SEC-KEY-GATE-01] CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=n but placeholder "\
-       "keys are still present in uds_security_algo.c. "\
+#if EDS_BUILD_IS_PRODUCTION && !defined(UNIT_TEST)
+#error "[SEC-KEY-GATE-01] Production build declared (EDS_BUILD_IS_PRODUCTION=1) "\
+       "but placeholder keys are still present in uds_security_algo.c. "\
        "Inject real OEM keys via uds_security_algo_set_level_key() before "\
        "building production firmware, then set CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=n "\
-       "in your production prj.conf."
+       "in your production prj.conf (or the FreeRTOS/EDS_BUILD_IS_PRODUCTION "\
+       "equivalent for non-Zephyr builds)."
 #endif
 
 /* =============================================================================
@@ -103,81 +150,46 @@
  * builds keep today's LFSR fallback so existing host/dev workflows are
  * unaffected; only real production firmware fails closed.
  *
- * WHY THREE CASES, NOT TWO — Zephyr's Kconfig -> autoconf.h quirk:
- * Zephyr's generated autoconf.h emits `#define CONFIG_X 1` for a Kconfig
- * bool set to `y`, and OMITS the symbol entirely for `n` — it never emits
- * `#define CONFIG_X 0`. A simple `#if !defined(X) || X` therefore cannot
- * tell "explicitly off" apart from "not a Zephyr build at all". The three
- * cases that must be distinguished are:
+ * [#84 UPDATE] ALGO_ENTROPY_FAIL_CLOSED is now a plain alias for
+ * EDS_BUILD_IS_PRODUCTION (see uds_security_algo.h, SEC-BUILD-MODE-01) —
+ * it no longer derives "is this production?" itself. This file used to
+ * carry an independent copy of the same four-case Zephyr autoconf.h /
+ * UNIT_TEST / omitted-symbol derivation that the CRIT-4 gate below carried
+ * too, and the two had drifted: the CRIT-4 gate used the older,
+ * broken `defined(X) && !X` idiom (never fired on a real Zephyr
+ * production build — the symbol is omitted, not defined-and-zero, when
+ * the Kconfig bool is `n`), while this gate already used the corrected
+ * "positive signal for development, fail closed by default" idiom. Two
+ * independently-authored copies of the same yes/no answer are exactly how
+ * that drift happened; unifying them into one primitive removes the
+ * ability for it to recur. The alias keeps the ALGO_ENTROPY_FAIL_CLOSED
+ * name — it is already used throughout this file's comments,
+ * test_trng_fail_closed.c, and SECURITY.md, and renaming it everywhere
+ * would be unrelated churn to already-shipped, already-reviewed code.
  *
- *   (a) CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY defined non-zero
- *       -> development/CI build (Kconfig bool = y) -> LFSR allowed.
- *   (b) CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY undefined, UNIT_TEST defined
- *       -> host unit-test / harness build (no autoconf.h at all)
- *       -> LFSR allowed.
- *   (c) anything else -- Zephyr with the bool set to n (symbol omitted),
- *       FreeRTOS, bare metal, or a platform not yet ported
- *       -> PRODUCTION -> fail closed. This is the DEFAULT: the safe state
- *       is what you get by omission, on every platform.
+ * RETROACTIVE FIX FOR FREERTOS: because EDS_BUILD_IS_PRODUCTION's default
+ * (omitted Kconfig symbol, no UNIT_TEST) is PRODUCTION, and FreeRTOS
+ * builds have never defined CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY, a real
+ * FreeRTOS build has always resolved ALGO_ENTROPY_FAIL_CLOSED to 1
+ * (fail-closed) with no supported way to opt into the LFSR dev fallback —
+ * a latent, CI-invisible gap in the already-merged PR #85 (FreeRTOS CI
+ * jobs are build-only; they never exercise a live SecurityAccess request).
+ * examples/*_freertos/CMakeLists.txt now defines
+ * CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY itself (default ON, i.e. development —
+ * mirroring Zephyr Kconfig's own `default y`), giving FreeRTOS integrators
+ * the same supported opt-in Zephyr already had. See SEC-BUILD-MODE-01 for
+ * the full four-case derivation this alias now inherits.
  *
- * A host test that wants to exercise the production (fail-closed) path
- * forces it by compiling with -DCONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0: the
- * symbol is then defined AND zero, so case (a)'s "defined non-zero" test is
- * false and the #elif/#else chain below falls through to the fail-closed
- * default — the same outcome as case (b) on real Zephyr production
- * hardware.
+ * ALGO_ENTROPY_FAIL_CLOSED may also be forced directly on the compiler
+ * command line (-DALGO_ENTROPY_FAIL_CLOSED=1), which overrides the alias
+ * below via the header's own `#if !defined(EDS_BUILD_IS_PRODUCTION)`
+ * guard not applying — set -DEDS_BUILD_IS_PRODUCTION=1 instead if the
+ * intent is to also force the CRIT-4 gate at the same time; the two are
+ * independent macros again only at the point of an explicit override.
  *
- * NOTE ON THE CRIT-4 #error ABOVE: that pre-existing gate uses the older
- * `defined(X) && !X` idiom, which does NOT handle case (b) above — on a
- * real Zephyr production build (symbol omitted) the CRIT-4 #error is
- * silently skipped rather than firing. This is a pre-existing gap, tracked
- * separately as issue #84, and is deliberately NOT changed here — this
- * gate only governs the TRNG entropy fallback, not the placeholder-key
- * #error check.
- *
- * TRACEABILITY: SEC-TRNG-FAILCLOSED-01
+ * TRACEABILITY: SEC-TRNG-FAILCLOSED-01 (derives from SEC-BUILD-MODE-01)
  * ============================================================================= */
-
-/*
- * The default is FAIL CLOSED. A firmware build must *explicitly* opt in to the
- * LFSR fallback; it is never inherited by omission. This ordering matters:
- * an earlier revision of this gate tried to identify production builds by
- * testing for __ZEPHYR__, which silently left every FreeRTOS and bare-metal
- * production build (examples/basic_ecu_freertos and its siblings, plus any
- * OEM bare-metal port) on the predictable LFSR — the exact failure this
- * change exists to prevent. Deriving
- * "development" from a positive signal instead makes the safe state the
- * default on every platform, including ones EDS does not ship a port for yet.
- *
- * ALGO_ENTROPY_FAIL_CLOSED may also be forced directly on the compiler command
- * line (-DALGO_ENTROPY_FAIL_CLOSED=1). That is the supported escape hatch for
- * the CRIT-4 deviation documented above: an OEM key that happens to collide
- * with the placeholder pattern requires CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=y in
- * a *production* image, which would otherwise re-enable the LFSR as a side
- * effect. Setting ALGO_ENTROPY_FAIL_CLOSED=1 keeps entropy failing closed
- * independently of the key gate.
- */
-#if !defined(ALGO_ENTROPY_FAIL_CLOSED)
-#  if defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY)
-     /* Kconfig symbol present and explicit. y -> development, n (compiled as
-      * an explicit 0, e.g. -DCONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0) -> production. */
-#    if CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY
-#      define ALGO_ENTROPY_FAIL_CLOSED (0)
-#    else
-#      define ALGO_ENTROPY_FAIL_CLOSED (1)
-#    endif
-#  elif defined(UNIT_TEST)
-     /* Host unit-test / harness build (build_tests.sh, build_harness.sh).
-      * No autoconf.h exists at all here; keep the LFSR so native_sim and the
-      * host suites behave exactly as before. */
-#    define ALGO_ENTROPY_FAIL_CLOSED (0)
-#  else
-     /* Any firmware build that did not explicitly enable placeholder keys:
-      * Zephyr with the Kconfig bool set to n (symbol omitted from autoconf.h),
-      * FreeRTOS, or bare metal. Fail closed. */
-#    define ALGO_ENTROPY_FAIL_CLOSED (1)
-#  endif
-#endif
+#define ALGO_ENTROPY_FAIL_CLOSED EDS_BUILD_IS_PRODUCTION
 
 /* --------------------------------------------------------------------------
  * Internal constants

--- a/core/uds_security_algo.c
+++ b/core/uds_security_algo.c
@@ -13,14 +13,14 @@
  * See uds_security_algo.h for full design and integration documentation.
  *
  * KEY STORAGE SECURITY NOTICE:
- *   k_level_keys[] below contains PLACEHOLDER KEYS only.
+ *   s_level_keys[] below contains PLACEHOLDER KEYS only.
  *   These are NOT secret and must be replaced before production deployment.
  *
  *   Required actions before vehicle deployment:
  *     1. Do NOT commit real OEM keys to source control.
  *     2. Inject keys at runtime via uds_security_algo_set_level_key()
  *        from a secure source (OTP fuses, HSM, secure boot chain), OR
- *        replace k_level_keys[] in a secure build environment, OR
+ *        replace s_level_keys[] in a secure build environment, OR
  *        register a uds_algo_derive_cb_t that calls your HSM directly.
  *
  * REPLAY PROTECTION:
@@ -63,7 +63,7 @@
  * Production: must be set to n in prj.conf.  When a build declares itself
  * production (see EDS_BUILD_IS_PRODUCTION in uds_security_algo.h), this
  * #error fires, preventing a production firmware image from being linked
- * at all while k_level_keys[] still holds the compile-time placeholder
+ * at all while s_level_keys[] still holds the compile-time placeholder
  * values.
  *
  * WHAT THIS CHECK ACTUALLY DOES (corrected — see issue #84 PR discussion):
@@ -73,7 +73,7 @@
  * into a preprocessor-visible macro. The gate is an unconditional compile
  * failure whenever a production build is declared: it forces the
  * integrator to affirmatively prove intent — inject real keys via
- * uds_security_algo_set_level_key() at runtime, or edit k_level_keys[]
+ * uds_security_algo_set_level_key() at runtime, or edit s_level_keys[]
  * directly in a secure build environment — and then flip the build-mode
  * signal to production, before CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=n (or
  * the FreeRTOS/override equivalent) can be believed. The actual runtime
@@ -174,22 +174,28 @@
  * (fail-closed) with no supported way to opt into the LFSR dev fallback —
  * a latent, CI-invisible gap in the already-merged PR #85 (FreeRTOS CI
  * jobs are build-only; they never exercise a live SecurityAccess request).
- * examples/*_freertos/CMakeLists.txt now defines
+ * Each FreeRTOS example's CMakeLists.txt now defines
  * CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY itself (default ON, i.e. development —
  * mirroring Zephyr Kconfig's own `default y`), giving FreeRTOS integrators
  * the same supported opt-in Zephyr already had. See SEC-BUILD-MODE-01 for
  * the full four-case derivation this alias now inherits.
  *
  * ALGO_ENTROPY_FAIL_CLOSED may also be forced directly on the compiler
- * command line (-DALGO_ENTROPY_FAIL_CLOSED=1), which overrides the alias
- * below via the header's own `#if !defined(EDS_BUILD_IS_PRODUCTION)`
- * guard not applying — set -DEDS_BUILD_IS_PRODUCTION=1 instead if the
- * intent is to also force the CRIT-4 gate at the same time; the two are
- * independent macros again only at the point of an explicit override.
+ * command line (-DALGO_ENTROPY_FAIL_CLOSED=<0|1>). The `#if !defined(...)`
+ * guard immediately below is what makes that override take effect: it
+ * skips the alias `#define` entirely when the command line already
+ * defined ALGO_ENTROPY_FAIL_CLOSED, so the literal command-line value
+ * stands on its own rather than being re-aliased to EDS_BUILD_IS_PRODUCTION.
+ * This is a SEPARATE override from -DEDS_BUILD_IS_PRODUCTION=<0|1>: forcing
+ * one does not force the other unless both are passed — set
+ * -DEDS_BUILD_IS_PRODUCTION=1 instead (or as well) if the intent is to also
+ * force the CRIT-4 gate at the same time.
  *
  * TRACEABILITY: SEC-TRNG-FAILCLOSED-01 (derives from SEC-BUILD-MODE-01)
  * ============================================================================= */
+#if !defined(ALGO_ENTROPY_FAIL_CLOSED)
 #define ALGO_ENTROPY_FAIL_CLOSED EDS_BUILD_IS_PRODUCTION
+#endif
 
 /* --------------------------------------------------------------------------
  * Internal constants
@@ -201,7 +207,7 @@
 /** Maximum number of security levels supported. */
 #define ALGO_MAX_LEVELS       (2U)
 
-/** Number of level keys defined in k_level_keys[]. */
+/** Number of level keys defined in s_level_keys[]. */
 #define ALGO_DEFINED_LEVELS   (2U)
 
 /* --------------------------------------------------------------------------

--- a/core/uds_security_algo.h
+++ b/core/uds_security_algo.h
@@ -76,6 +76,122 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+/* =============================================================================
+ * [SEC-BUILD-MODE-01] Shared build-mode primitive: EDS_BUILD_IS_PRODUCTION
+ *
+ * PROBLEM (issue #84): this codebase had TWO independently-authored copies
+ * of "is this a production build?" — the CRIT-4 placeholder-key #error in
+ * uds_security_algo.c, and the Step 7.1 runtime guard generated into every
+ * examples/*\/generated/uds_init.c from tools/templates/uds_init.c.j2 — and
+ * they drifted to the SAME wrong answer independently:
+ *
+ *   #if defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && \
+ *       !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY
+ *
+ * CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY is a Kconfig bool. Zephyr's generated
+ * autoconf.h emits `#define CONFIG_X 1` for a bool set to `y`, and OMITS
+ * the symbol entirely for `n` — it never emits `#define CONFIG_X 0`. So on
+ * a real Zephyr PRODUCTION build (the bool set to `n`, exactly what the
+ * docs tell integrators to do), defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY)
+ * is FALSE, and `defined(X) && !X` is false too — both gates silently did
+ * nothing in precisely the configuration they exist to protect.
+ *
+ * FIX: derive "is this production?" from ONE macro, defined here, and have
+ * every gate in this codebase (this file's own ALGO_ENTROPY_FAIL_CLOSED
+ * alias, the CRIT-4 #error in uds_security_algo.c, and the Step 7.1 guard
+ * in the uds_init.c.j2 template) reference it instead of re-deriving the
+ * same logic a second (or third) time. One definition cannot drift from
+ * itself; that is the actual root-cause fix for #84, not just a polarity
+ * flip on the two existing call sites.
+ *
+ * FOUR CASES, in priority order:
+ *
+ *   1. CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY is #defined (any value):
+ *      Kconfig bool was resolved to `y` by Zephyr's autoconf.h (value 1),
+ *      or a build explicitly forced it to a literal 0 or 1 on the command
+ *      line (e.g. -DCONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0, the convention
+ *      test_trng_fail_closed.c and build_tests.sh already use to reach the
+ *      production path from a host build; FreeRTOS's CMakeLists.txt now
+ *      does this too, unconditionally, via a $<BOOL:...> generator
+ *      expression — see examples/*_freertos/CMakeLists.txt). Non-zero ->
+ *      development/CI (placeholder keys explicitly permitted) -> NOT
+ *      production. Zero -> production.
+ *   2. Symbol undefined, but UNIT_TEST is defined:
+ *      Host unit-test / harness build (build_tests.sh, build_harness.sh).
+ *      No autoconf.h exists at all here and no build system defines the
+ *      Kconfig symbol. Treated as development so existing host suites keep
+ *      today's behaviour. NOTE: this case only applies when
+ *      CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY is undefined — case 1 takes
+ *      priority, so a host test that defines the symbol itself (to reach
+ *      the production path deliberately) is honoured over UNIT_TEST.
+ *   3. Neither symbol is defined:
+ *      Zephyr with the Kconfig bool set to `n` (symbol omitted from
+ *      autoconf.h — the case the old buggy idiom missed), FreeRTOS,
+ *      bare metal, or any platform not yet ported. PRODUCTION. This is
+ *      the default: the safe state is what you get by omission, on every
+ *      platform, including ones EDS does not ship a port for yet.
+ *
+ *      FreeRTOS has no Kconfig equivalent of its own, so without its build
+ *      system explicitly defining CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY it
+ *      would land here on EVERY build, including CI. Case 3 is why
+ *      examples/*_freertos/CMakeLists.txt now defines the symbol itself
+ *      (defaulting to development, mirroring Zephyr Kconfig's own
+ *      `default y`) — see SEC-KEY-GATE-01 and that CMakeLists.txt for the
+ *      mechanism. A FreeRTOS build that has NOT picked up that fix still
+ *      correctly falls through to this case and fails closed, rather than
+ *      silently doing nothing the way the pre-#84 gates did.
+ *
+ * ESCAPE HATCH: EDS_BUILD_IS_PRODUCTION may be forced directly on the
+ * compiler command line (-DEDS_BUILD_IS_PRODUCTION=<0|1>), overriding all
+ * of the above. This is the supported override for a build whose signals
+ * disagree with its actual intent (see the CRIT-4 deviation process
+ * documented at that gate for one example).
+ *
+ * HOST TEST NOTE: a host test that wants to force the production path
+ * compiles with -DCONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0 (defined AND zero).
+ * That hits case 1 above (the nested nonzero/zero check), not the
+ * omitted-symbol path of case 3 — but lands on the same production value,
+ * so it is a faithful stand-in for real Zephyr/FreeRTOS production
+ * hardware without needing a cross-compiled toolchain in a host test.
+ *
+ * NOT EVERY CONSUMER SHOULD STOP HERE: this macro answers ONE question —
+ * "is this a production build" — in general. A specific gate may be
+ * asking a narrower question that "production, in general" does not fully
+ * capture, and may need its own additional qualifier layered on top of
+ * EDS_BUILD_IS_PRODUCTION rather than folded into it. Worked example: the
+ * CRIT-4 placeholder-key #error in uds_security_algo.c is not just asking
+ * "is this production" — it's asking "does this compiled binary actually
+ * contain real OEM keys," which a host unit-test build forcing production
+ * *behaviour* (to exercise some other gate's logic, e.g.
+ * ALGO_ENTROPY_FAIL_CLOSED via test_trng_fail_closed.c) can never
+ * satisfy. CRIT-4 therefore guards itself with its own, additional
+ * `&& !defined(UNIT_TEST)` at its call site — see that gate's comment for
+ * the full reasoning. That qualifier belongs at CRIT-4's call site only,
+ * NOT here: baking it into EDS_BUILD_IS_PRODUCTION itself would silently
+ * exempt every consumer of this macro from ever seeing "production" while
+ * UNIT_TEST is defined, including ALGO_ENTROPY_FAIL_CLOSED — which would
+ * break the very host-test forcing mechanism this note just described.
+ * Add narrowing conditions at the consumer, never inside this primitive.
+ *
+ * TRACEABILITY: SEC-BUILD-MODE-01 (root cause of issue #84). Referenced by
+ * SEC-KEY-GATE-01 (CRIT-4, uds_security_algo.c) and SEC-TRNG-FAILCLOSED-01
+ * (ALGO_ENTROPY_FAIL_CLOSED, uds_security_algo.c) — neither redefines this
+ * logic; both derive from it.
+ * ============================================================================= */
+#if !defined(EDS_BUILD_IS_PRODUCTION)
+#  if defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY)
+#    if CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY
+#      define EDS_BUILD_IS_PRODUCTION (0)
+#    else
+#      define EDS_BUILD_IS_PRODUCTION (1)
+#    endif
+#  elif defined(UNIT_TEST)
+#    define EDS_BUILD_IS_PRODUCTION (0)
+#  else
+#    define EDS_BUILD_IS_PRODUCTION (1)
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/core/uds_security_algo.h
+++ b/core/uds_security_algo.h
@@ -81,9 +81,10 @@
  *
  * PROBLEM (issue #84): this codebase had TWO independently-authored copies
  * of "is this a production build?" — the CRIT-4 placeholder-key #error in
- * uds_security_algo.c, and the Step 7.1 runtime guard generated into every
- * examples/*\/generated/uds_init.c from tools/templates/uds_init.c.j2 — and
- * they drifted to the SAME wrong answer independently:
+ * uds_security_algo.c, and the Step 7.1 runtime guard generated into the
+ * uds_init.c under every example directory, from tools/templates/uds_init.c.j2
+ * (private EDS-toolchain repo) — and they drifted to the SAME wrong answer
+ * independently:
  *
  *   #if defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && \
  *       !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY
@@ -113,7 +114,7 @@
  *      test_trng_fail_closed.c and build_tests.sh already use to reach the
  *      production path from a host build; FreeRTOS's CMakeLists.txt now
  *      does this too, unconditionally, via a $<BOOL:...> generator
- *      expression — see examples/*_freertos/CMakeLists.txt). Non-zero ->
+ *      expression — see the FreeRTOS example CMakeLists.txt files). Non-zero ->
  *      development/CI (placeholder keys explicitly permitted) -> NOT
  *      production. Zero -> production.
  *   2. Symbol undefined, but UNIT_TEST is defined:
@@ -134,7 +135,7 @@
  *      FreeRTOS has no Kconfig equivalent of its own, so without its build
  *      system explicitly defining CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY it
  *      would land here on EVERY build, including CI. Case 3 is why
- *      examples/*_freertos/CMakeLists.txt now defines the symbol itself
+ *      each FreeRTOS example's CMakeLists.txt now defines the symbol itself
  *      (defaulting to development, mirroring Zephyr Kconfig's own
  *      `default y`) — see SEC-KEY-GATE-01 and that CMakeLists.txt for the
  *      mechanism. A FreeRTOS build that has NOT picked up that fix still

--- a/examples/ardep_ecu/generated/uds_init.c
+++ b/examples/ardep_ecu/generated/uds_init.c
@@ -551,10 +551,24 @@ uds_status_t uds_generated_init(
      *   uds_security_algo_set_level_key(0x01U, otp_key_level1_16bytes);
      *   uds_security_algo_set_level_key(0x03U, otp_key_level2_16bytes);
      *
-     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2)
+     * BUILD-MODE DERIVATION [SEC-BUILD-MODE-01 / issue #84]: this guard used
+     * to test `defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY`
+     * directly. Zephyr's generated autoconf.h omits the Kconfig symbol
+     * entirely (rather than emitting 0) when the bool is set to `n`, so that
+     * idiom silently never fired on a real Zephyr production build, and
+     * never fired on FreeRTOS at all (FreeRTOS never defined the symbol).
+     * It now consumes EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h),
+     * the single shared build-mode primitive the CRIT-4 #error in
+     * uds_security_algo.c also derives from, so the two cannot drift apart
+     * again. No `#include` change needed here — this file already includes
+     * uds_security_algo.h. Unlike the CRIT-4 site, this guard needs no
+     * `!defined(UNIT_TEST)` carve-out: no existing test compiles a
+     * generated uds_init.c under UNIT_TEST=1.
+     *
+     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2) /
+     *               SEC-BUILD-MODE-01 (build-mode derivation)
      */
-#if defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && \
-    !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY
+#if EDS_BUILD_IS_PRODUCTION
     {
         /* Production gate: refuse to start if keys or TRNG are missing. */
         if (uds_security_algo_keys_are_placeholder()) {
@@ -570,7 +584,7 @@ uds_status_t uds_generated_init(
             return UDS_STATUS_ERR_CONDITIONS_NOT_MET;
         }
     }
-#endif /* !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY */
+#endif /* EDS_BUILD_IS_PRODUCTION */
 
     /* ── Step 8: UDS server ────────────────────────────────────────────────
      *

--- a/examples/basic_ecu/generated/uds_init.c
+++ b/examples/basic_ecu/generated/uds_init.c
@@ -442,10 +442,24 @@ uds_status_t uds_generated_init(
      *   uds_security_algo_set_level_key(0x01U, otp_key_level1_16bytes);
      *   uds_security_algo_set_level_key(0x03U, otp_key_level2_16bytes);
      *
-     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2)
+     * BUILD-MODE DERIVATION [SEC-BUILD-MODE-01 / issue #84]: this guard used
+     * to test `defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY`
+     * directly. Zephyr's generated autoconf.h omits the Kconfig symbol
+     * entirely (rather than emitting 0) when the bool is set to `n`, so that
+     * idiom silently never fired on a real Zephyr production build, and
+     * never fired on FreeRTOS at all (FreeRTOS never defined the symbol).
+     * It now consumes EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h),
+     * the single shared build-mode primitive the CRIT-4 #error in
+     * uds_security_algo.c also derives from, so the two cannot drift apart
+     * again. No `#include` change needed here — this file already includes
+     * uds_security_algo.h. Unlike the CRIT-4 site, this guard needs no
+     * `!defined(UNIT_TEST)` carve-out: no existing test compiles a
+     * generated uds_init.c under UNIT_TEST=1.
+     *
+     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2) /
+     *               SEC-BUILD-MODE-01 (build-mode derivation)
      */
-#if defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && \
-    !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY
+#if EDS_BUILD_IS_PRODUCTION
     {
         /* Production gate: refuse to start if keys or TRNG are missing. */
         if (uds_security_algo_keys_are_placeholder()) {
@@ -461,7 +475,7 @@ uds_status_t uds_generated_init(
             return UDS_STATUS_ERR_CONDITIONS_NOT_MET;
         }
     }
-#endif /* !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY */
+#endif /* EDS_BUILD_IS_PRODUCTION */
 
     /* ── Step 8: UDS server ────────────────────────────────────────────────
      *

--- a/examples/basic_ecu_doip/generated/uds_init.c
+++ b/examples/basic_ecu_doip/generated/uds_init.c
@@ -442,10 +442,24 @@ uds_status_t uds_generated_init(
      *   uds_security_algo_set_level_key(0x01U, otp_key_level1_16bytes);
      *   uds_security_algo_set_level_key(0x03U, otp_key_level2_16bytes);
      *
-     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2)
+     * BUILD-MODE DERIVATION [SEC-BUILD-MODE-01 / issue #84]: this guard used
+     * to test `defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY`
+     * directly. Zephyr's generated autoconf.h omits the Kconfig symbol
+     * entirely (rather than emitting 0) when the bool is set to `n`, so that
+     * idiom silently never fired on a real Zephyr production build, and
+     * never fired on FreeRTOS at all (FreeRTOS never defined the symbol).
+     * It now consumes EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h),
+     * the single shared build-mode primitive the CRIT-4 #error in
+     * uds_security_algo.c also derives from, so the two cannot drift apart
+     * again. No `#include` change needed here — this file already includes
+     * uds_security_algo.h. Unlike the CRIT-4 site, this guard needs no
+     * `!defined(UNIT_TEST)` carve-out: no existing test compiles a
+     * generated uds_init.c under UNIT_TEST=1.
+     *
+     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2) /
+     *               SEC-BUILD-MODE-01 (build-mode derivation)
      */
-#if defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && \
-    !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY
+#if EDS_BUILD_IS_PRODUCTION
     {
         /* Production gate: refuse to start if keys or TRNG are missing. */
         if (uds_security_algo_keys_are_placeholder()) {
@@ -461,7 +475,7 @@ uds_status_t uds_generated_init(
             return UDS_STATUS_ERR_CONDITIONS_NOT_MET;
         }
     }
-#endif /* !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY */
+#endif /* EDS_BUILD_IS_PRODUCTION */
 
     /* ── Step 8: UDS server ────────────────────────────────────────────────
      *

--- a/examples/basic_ecu_doip_freertos/CMakeLists.txt
+++ b/examples/basic_ecu_doip_freertos/CMakeLists.txt
@@ -56,6 +56,17 @@ set(CMAKE_C_EXTENSIONS        OFF)
 # Required parameters
 # ---------------------------------------------------------------------------
 
+# [SEC-BUILD-MODE-01 / issue #84] FreeRTOS has no Kconfig of its own, so
+# without this option CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY is never defined for
+# a FreeRTOS build and EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h)
+# falls through to its PRODUCTION default on every build, including CI.
+# Mirrors Zephyr Kconfig's own `default y` for the same symbol: ON here
+# means "development / CI build, placeholder keys explicitly permitted."
+# Flip to OFF (-DEDS_PLACEHOLDER_KEYS_ONLY=OFF) to declare a production
+# build — this is what makes the CRIT-4 #error and the Step 7.1 runtime
+# guard in generated/uds_init.c reachable on FreeRTOS for the first time.
+option(EDS_PLACEHOLDER_KEYS_ONLY "Allow placeholder AES-128 security keys (DEVELOPMENT ONLY)" ON)
+
 if(NOT DEFINED FREERTOS_DIR)
     message(FATAL_ERROR "FREERTOS_DIR must point to FreeRTOS-Kernel directory")
 endif()
@@ -182,6 +193,12 @@ target_compile_definitions(eds_freertos_doip PRIVATE
     EDS_DOIP_ONLY_BUILD=1
     FREERTOS_DOIP_TASK_STACK_WORDS=1024
     FREERTOS_DOIP_TASK_PRIORITY=6
+    # [SEC-BUILD-MODE-01 / issue #84] Give EDS_BUILD_IS_PRODUCTION the same
+    # defined-and-1-or-0 signal Zephyr's Kconfig already gives it. The
+    # $<BOOL:...> generator expression emits 1 when EDS_PLACEHOLDER_KEYS_ONLY
+    # is ON, 0 when OFF -- production is declared with
+    # -DEDS_PLACEHOLDER_KEYS_ONLY=OFF (see the option() above).
+    CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=$<BOOL:${EDS_PLACEHOLDER_KEYS_ONLY}>
 )
 
 # ---------------------------------------------------------------------------

--- a/examples/basic_ecu_doip_freertos/CMakeLists.txt
+++ b/examples/basic_ecu_doip_freertos/CMakeLists.txt
@@ -56,16 +56,6 @@ set(CMAKE_C_EXTENSIONS        OFF)
 # Required parameters
 # ---------------------------------------------------------------------------
 
-# [SEC-BUILD-MODE-01 / issue #84] FreeRTOS has no Kconfig of its own, so
-# without this option CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY is never defined for
-# a FreeRTOS build and EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h)
-# falls through to its PRODUCTION default on every build, including CI.
-# Mirrors Zephyr Kconfig's own `default y` for the same symbol: ON here
-# means "development / CI build, placeholder keys explicitly permitted."
-# Flip to OFF (-DEDS_PLACEHOLDER_KEYS_ONLY=OFF) to declare a production
-# build — this is what makes the CRIT-4 #error and the Step 7.1 runtime
-# guard in generated/uds_init.c reachable on FreeRTOS for the first time.
-option(EDS_PLACEHOLDER_KEYS_ONLY "Allow placeholder AES-128 security keys (DEVELOPMENT ONLY)" ON)
 
 if(NOT DEFINED FREERTOS_DIR)
     message(FATAL_ERROR "FREERTOS_DIR must point to FreeRTOS-Kernel directory")
@@ -85,6 +75,11 @@ endif()
 # ---------------------------------------------------------------------------
 
 set(DIAG_ROOT         "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+
+# [SEC-BUILD-MODE-01 / issue #84] shared FreeRTOS build-mode option -- see
+# cmake/eds_build_mode.cmake for why this is centralized rather than
+# declared per-example (same lesson as cmake/eds_service_sources.cmake).
+include(${DIAG_ROOT}/cmake/eds_build_mode.cmake)
 set(FREERTOS_PORT_DIR "${FREERTOS_DIR}/portable/GCC/ARM_CM4F")
 
 # ---------------------------------------------------------------------------
@@ -197,7 +192,7 @@ target_compile_definitions(eds_freertos_doip PRIVATE
     # defined-and-1-or-0 signal Zephyr's Kconfig already gives it. The
     # $<BOOL:...> generator expression emits 1 when EDS_PLACEHOLDER_KEYS_ONLY
     # is ON, 0 when OFF -- production is declared with
-    # -DEDS_PLACEHOLDER_KEYS_ONLY=OFF (see the option() above).
+    # -DEDS_PLACEHOLDER_KEYS_ONLY=OFF (see cmake/eds_build_mode.cmake).
     CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=$<BOOL:${EDS_PLACEHOLDER_KEYS_ONLY}>
 )
 

--- a/examples/basic_ecu_doip_freertos/generated/uds_init.c
+++ b/examples/basic_ecu_doip_freertos/generated/uds_init.c
@@ -442,10 +442,24 @@ uds_status_t uds_generated_init(
      *   uds_security_algo_set_level_key(0x01U, otp_key_level1_16bytes);
      *   uds_security_algo_set_level_key(0x03U, otp_key_level2_16bytes);
      *
-     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2)
+     * BUILD-MODE DERIVATION [SEC-BUILD-MODE-01 / issue #84]: this guard used
+     * to test `defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY`
+     * directly. Zephyr's generated autoconf.h omits the Kconfig symbol
+     * entirely (rather than emitting 0) when the bool is set to `n`, so that
+     * idiom silently never fired on a real Zephyr production build, and
+     * never fired on FreeRTOS at all (FreeRTOS never defined the symbol).
+     * It now consumes EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h),
+     * the single shared build-mode primitive the CRIT-4 #error in
+     * uds_security_algo.c also derives from, so the two cannot drift apart
+     * again. No `#include` change needed here — this file already includes
+     * uds_security_algo.h. Unlike the CRIT-4 site, this guard needs no
+     * `!defined(UNIT_TEST)` carve-out: no existing test compiles a
+     * generated uds_init.c under UNIT_TEST=1.
+     *
+     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2) /
+     *               SEC-BUILD-MODE-01 (build-mode derivation)
      */
-#if defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && \
-    !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY
+#if EDS_BUILD_IS_PRODUCTION
     {
         /* Production gate: refuse to start if keys or TRNG are missing. */
         if (uds_security_algo_keys_are_placeholder()) {
@@ -461,7 +475,7 @@ uds_status_t uds_generated_init(
             return UDS_STATUS_ERR_CONDITIONS_NOT_MET;
         }
     }
-#endif /* !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY */
+#endif /* EDS_BUILD_IS_PRODUCTION */
 
     /* ── Step 8: UDS server ────────────────────────────────────────────────
      *

--- a/examples/basic_ecu_freertos/CMakeLists.txt
+++ b/examples/basic_ecu_freertos/CMakeLists.txt
@@ -57,16 +57,6 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 # Required parameters
 # ---------------------------------------------------------------------------
 
-# [SEC-BUILD-MODE-01 / issue #84] FreeRTOS has no Kconfig of its own, so
-# without this option CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY is never defined for
-# a FreeRTOS build and EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h)
-# falls through to its PRODUCTION default on every build, including CI.
-# Mirrors Zephyr Kconfig's own `default y` for the same symbol: ON here
-# means "development / CI build, placeholder keys explicitly permitted."
-# Flip to OFF (-DEDS_PLACEHOLDER_KEYS_ONLY=OFF) to declare a production
-# build — this is what makes the CRIT-4 #error and the Step 7.1 runtime
-# guard in generated/uds_init.c reachable on FreeRTOS for the first time.
-option(EDS_PLACEHOLDER_KEYS_ONLY "Allow placeholder AES-128 security keys (DEVELOPMENT ONLY)" ON)
 
 if(NOT DEFINED EDS_PLATFORM)
     set(EDS_PLATFORM "freertos")
@@ -91,6 +81,11 @@ endif()
 # Repo root (two levels up from this file)
 # ---------------------------------------------------------------------------
 set(DIAG_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+
+# [SEC-BUILD-MODE-01 / issue #84] shared FreeRTOS build-mode option -- see
+# cmake/eds_build_mode.cmake for why this is centralized rather than
+# declared per-example (same lesson as cmake/eds_service_sources.cmake).
+include(${DIAG_ROOT}/cmake/eds_build_mode.cmake)
 
 # ---------------------------------------------------------------------------
 # Board-specific compiler flags
@@ -244,7 +239,7 @@ target_compile_definitions(eds_freertos PRIVATE
     # defined-and-1-or-0 signal Zephyr's Kconfig already gives it. The
     # $<BOOL:...> generator expression emits 1 when EDS_PLACEHOLDER_KEYS_ONLY
     # is ON, 0 when OFF -- production is declared with
-    # -DEDS_PLACEHOLDER_KEYS_ONLY=OFF (see the option() above).
+    # -DEDS_PLACEHOLDER_KEYS_ONLY=OFF (see cmake/eds_build_mode.cmake).
     CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=$<BOOL:${EDS_PLACEHOLDER_KEYS_ONLY}>
     # Suppress the uds_msg_buf_t _Static_assert: the FreeRTOS example
     # never allocates uds_msg_buf_t on the stack (module-level statics

--- a/examples/basic_ecu_freertos/CMakeLists.txt
+++ b/examples/basic_ecu_freertos/CMakeLists.txt
@@ -57,6 +57,17 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 # Required parameters
 # ---------------------------------------------------------------------------
 
+# [SEC-BUILD-MODE-01 / issue #84] FreeRTOS has no Kconfig of its own, so
+# without this option CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY is never defined for
+# a FreeRTOS build and EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h)
+# falls through to its PRODUCTION default on every build, including CI.
+# Mirrors Zephyr Kconfig's own `default y` for the same symbol: ON here
+# means "development / CI build, placeholder keys explicitly permitted."
+# Flip to OFF (-DEDS_PLACEHOLDER_KEYS_ONLY=OFF) to declare a production
+# build — this is what makes the CRIT-4 #error and the Step 7.1 runtime
+# guard in generated/uds_init.c reachable on FreeRTOS for the first time.
+option(EDS_PLACEHOLDER_KEYS_ONLY "Allow placeholder AES-128 security keys (DEVELOPMENT ONLY)" ON)
+
 if(NOT DEFINED EDS_PLATFORM)
     set(EDS_PLATFORM "freertos")
 endif()
@@ -229,8 +240,12 @@ target_include_directories(eds_freertos PRIVATE
 
 target_compile_definitions(eds_freertos PRIVATE
     EDS_PLATFORM_FREERTOS=1
-    # Disable placeholder key compile-time gate for CI/development builds
-    # (production prj sets CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=n)
+    # [SEC-BUILD-MODE-01 / issue #84] Give EDS_BUILD_IS_PRODUCTION the same
+    # defined-and-1-or-0 signal Zephyr's Kconfig already gives it. The
+    # $<BOOL:...> generator expression emits 1 when EDS_PLACEHOLDER_KEYS_ONLY
+    # is ON, 0 when OFF -- production is declared with
+    # -DEDS_PLACEHOLDER_KEYS_ONLY=OFF (see the option() above).
+    CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=$<BOOL:${EDS_PLACEHOLDER_KEYS_ONLY}>
     # Suppress the uds_msg_buf_t _Static_assert: the FreeRTOS example
     # never allocates uds_msg_buf_t on the stack (module-level statics
     # in freertos_platform_api.c own those buffers).

--- a/examples/basic_ecu_freertos/generated/uds_init.c
+++ b/examples/basic_ecu_freertos/generated/uds_init.c
@@ -442,10 +442,24 @@ uds_status_t uds_generated_init(
      *   uds_security_algo_set_level_key(0x01U, otp_key_level1_16bytes);
      *   uds_security_algo_set_level_key(0x03U, otp_key_level2_16bytes);
      *
-     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2)
+     * BUILD-MODE DERIVATION [SEC-BUILD-MODE-01 / issue #84]: this guard used
+     * to test `defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY`
+     * directly. Zephyr's generated autoconf.h omits the Kconfig symbol
+     * entirely (rather than emitting 0) when the bool is set to `n`, so that
+     * idiom silently never fired on a real Zephyr production build, and
+     * never fired on FreeRTOS at all (FreeRTOS never defined the symbol).
+     * It now consumes EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h),
+     * the single shared build-mode primitive the CRIT-4 #error in
+     * uds_security_algo.c also derives from, so the two cannot drift apart
+     * again. No `#include` change needed here — this file already includes
+     * uds_security_algo.h. Unlike the CRIT-4 site, this guard needs no
+     * `!defined(UNIT_TEST)` carve-out: no existing test compiles a
+     * generated uds_init.c under UNIT_TEST=1.
+     *
+     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2) /
+     *               SEC-BUILD-MODE-01 (build-mode derivation)
      */
-#if defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && \
-    !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY
+#if EDS_BUILD_IS_PRODUCTION
     {
         /* Production gate: refuse to start if keys or TRNG are missing. */
         if (uds_security_algo_keys_are_placeholder()) {
@@ -461,7 +475,7 @@ uds_status_t uds_generated_init(
             return UDS_STATUS_ERR_CONDITIONS_NOT_MET;
         }
     }
-#endif /* !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY */
+#endif /* EDS_BUILD_IS_PRODUCTION */
 
     /* ── Step 8: UDS server ────────────────────────────────────────────────
      *

--- a/examples/bms_ecu/generated/uds_init.c
+++ b/examples/bms_ecu/generated/uds_init.c
@@ -470,10 +470,24 @@ uds_status_t uds_generated_init(
      *   uds_security_algo_set_level_key(0x01U, otp_key_level1_16bytes);
      *   uds_security_algo_set_level_key(0x03U, otp_key_level2_16bytes);
      *
-     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2)
+     * BUILD-MODE DERIVATION [SEC-BUILD-MODE-01 / issue #84]: this guard used
+     * to test `defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY`
+     * directly. Zephyr's generated autoconf.h omits the Kconfig symbol
+     * entirely (rather than emitting 0) when the bool is set to `n`, so that
+     * idiom silently never fired on a real Zephyr production build, and
+     * never fired on FreeRTOS at all (FreeRTOS never defined the symbol).
+     * It now consumes EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h),
+     * the single shared build-mode primitive the CRIT-4 #error in
+     * uds_security_algo.c also derives from, so the two cannot drift apart
+     * again. No `#include` change needed here — this file already includes
+     * uds_security_algo.h. Unlike the CRIT-4 site, this guard needs no
+     * `!defined(UNIT_TEST)` carve-out: no existing test compiles a
+     * generated uds_init.c under UNIT_TEST=1.
+     *
+     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2) /
+     *               SEC-BUILD-MODE-01 (build-mode derivation)
      */
-#if defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && \
-    !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY
+#if EDS_BUILD_IS_PRODUCTION
     {
         /* Production gate: refuse to start if keys or TRNG are missing. */
         if (uds_security_algo_keys_are_placeholder()) {
@@ -489,7 +503,7 @@ uds_status_t uds_generated_init(
             return UDS_STATUS_ERR_CONDITIONS_NOT_MET;
         }
     }
-#endif /* !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY */
+#endif /* EDS_BUILD_IS_PRODUCTION */
 
     /* ── Step 8: UDS server ────────────────────────────────────────────────
      *

--- a/examples/motor_controller_ecu/generated/uds_init.c
+++ b/examples/motor_controller_ecu/generated/uds_init.c
@@ -470,10 +470,24 @@ uds_status_t uds_generated_init(
      *   uds_security_algo_set_level_key(0x01U, otp_key_level1_16bytes);
      *   uds_security_algo_set_level_key(0x03U, otp_key_level2_16bytes);
      *
-     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2)
+     * BUILD-MODE DERIVATION [SEC-BUILD-MODE-01 / issue #84]: this guard used
+     * to test `defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY`
+     * directly. Zephyr's generated autoconf.h omits the Kconfig symbol
+     * entirely (rather than emitting 0) when the bool is set to `n`, so that
+     * idiom silently never fired on a real Zephyr production build, and
+     * never fired on FreeRTOS at all (FreeRTOS never defined the symbol).
+     * It now consumes EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h),
+     * the single shared build-mode primitive the CRIT-4 #error in
+     * uds_security_algo.c also derives from, so the two cannot drift apart
+     * again. No `#include` change needed here — this file already includes
+     * uds_security_algo.h. Unlike the CRIT-4 site, this guard needs no
+     * `!defined(UNIT_TEST)` carve-out: no existing test compiles a
+     * generated uds_init.c under UNIT_TEST=1.
+     *
+     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2) /
+     *               SEC-BUILD-MODE-01 (build-mode derivation)
      */
-#if defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && \
-    !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY
+#if EDS_BUILD_IS_PRODUCTION
     {
         /* Production gate: refuse to start if keys or TRNG are missing. */
         if (uds_security_algo_keys_are_placeholder()) {
@@ -489,7 +503,7 @@ uds_status_t uds_generated_init(
             return UDS_STATUS_ERR_CONDITIONS_NOT_MET;
         }
     }
-#endif /* !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY */
+#endif /* EDS_BUILD_IS_PRODUCTION */
 
     /* ── Step 8: UDS server ────────────────────────────────────────────────
      *

--- a/examples/robot_joint_controller_ecu/generated/uds_init.c
+++ b/examples/robot_joint_controller_ecu/generated/uds_init.c
@@ -469,10 +469,24 @@ uds_status_t uds_generated_init(
      *   uds_security_algo_set_level_key(0x01U, otp_key_level1_16bytes);
      *   uds_security_algo_set_level_key(0x03U, otp_key_level2_16bytes);
      *
-     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2)
+     * BUILD-MODE DERIVATION [SEC-BUILD-MODE-01 / issue #84]: this guard used
+     * to test `defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY`
+     * directly. Zephyr's generated autoconf.h omits the Kconfig symbol
+     * entirely (rather than emitting 0) when the bool is set to `n`, so that
+     * idiom silently never fired on a real Zephyr production build, and
+     * never fired on FreeRTOS at all (FreeRTOS never defined the symbol).
+     * It now consumes EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h),
+     * the single shared build-mode primitive the CRIT-4 #error in
+     * uds_security_algo.c also derives from, so the two cannot drift apart
+     * again. No `#include` change needed here — this file already includes
+     * uds_security_algo.h. Unlike the CRIT-4 site, this guard needs no
+     * `!defined(UNIT_TEST)` carve-out: no existing test compiles a
+     * generated uds_init.c under UNIT_TEST=1.
+     *
+     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2) /
+     *               SEC-BUILD-MODE-01 (build-mode derivation)
      */
-#if defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && \
-    !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY
+#if EDS_BUILD_IS_PRODUCTION
     {
         /* Production gate: refuse to start if keys or TRNG are missing. */
         if (uds_security_algo_keys_are_placeholder()) {
@@ -488,7 +502,7 @@ uds_status_t uds_generated_init(
             return UDS_STATUS_ERR_CONDITIONS_NOT_MET;
         }
     }
-#endif /* !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY */
+#endif /* EDS_BUILD_IS_PRODUCTION */
 
     /* ── Step 8: UDS server ────────────────────────────────────────────────
      *

--- a/examples/safeboot_ecu/generated/uds_init.c
+++ b/examples/safeboot_ecu/generated/uds_init.c
@@ -466,10 +466,24 @@ uds_status_t uds_generated_init(
      *   uds_security_algo_set_level_key(0x01U, otp_key_level1_16bytes);
      *   uds_security_algo_set_level_key(0x03U, otp_key_level2_16bytes);
      *
-     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2)
+     * BUILD-MODE DERIVATION [SEC-BUILD-MODE-01 / issue #84]: this guard used
+     * to test `defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY`
+     * directly. Zephyr's generated autoconf.h omits the Kconfig symbol
+     * entirely (rather than emitting 0) when the bool is set to `n`, so that
+     * idiom silently never fired on a real Zephyr production build, and
+     * never fired on FreeRTOS at all (FreeRTOS never defined the symbol).
+     * It now consumes EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h),
+     * the single shared build-mode primitive the CRIT-4 #error in
+     * uds_security_algo.c also derives from, so the two cannot drift apart
+     * again. No `#include` change needed here — this file already includes
+     * uds_security_algo.h. Unlike the CRIT-4 site, this guard needs no
+     * `!defined(UNIT_TEST)` carve-out: no existing test compiles a
+     * generated uds_init.c under UNIT_TEST=1.
+     *
+     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2) /
+     *               SEC-BUILD-MODE-01 (build-mode derivation)
      */
-#if defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && \
-    !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY
+#if EDS_BUILD_IS_PRODUCTION
     {
         /* Production gate: refuse to start if keys or TRNG are missing. */
         if (uds_security_algo_keys_are_placeholder()) {
@@ -485,7 +499,7 @@ uds_status_t uds_generated_init(
             return UDS_STATUS_ERR_CONDITIONS_NOT_MET;
         }
     }
-#endif /* !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY */
+#endif /* EDS_BUILD_IS_PRODUCTION */
 
     /* ── Step 8: UDS server ────────────────────────────────────────────────
      *

--- a/examples/safeboot_freertos_ecu/CMakeLists.txt
+++ b/examples/safeboot_freertos_ecu/CMakeLists.txt
@@ -77,6 +77,17 @@ set(CMAKE_C_EXTENSIONS        OFF)
 # Required parameters
 # ---------------------------------------------------------------------------
 
+# [SEC-BUILD-MODE-01 / issue #84] FreeRTOS has no Kconfig of its own, so
+# without this option CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY is never defined for
+# a FreeRTOS build and EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h)
+# falls through to its PRODUCTION default on every build, including CI.
+# Mirrors Zephyr Kconfig's own `default y` for the same symbol: ON here
+# means "development / CI build, placeholder keys explicitly permitted."
+# Flip to OFF (-DEDS_PLACEHOLDER_KEYS_ONLY=OFF) to declare a production
+# build — this is what makes the CRIT-4 #error and the Step 7.1 runtime
+# guard in generated/uds_init.c reachable on FreeRTOS for the first time.
+option(EDS_PLACEHOLDER_KEYS_ONLY "Allow placeholder AES-128 security keys (DEVELOPMENT ONLY)" ON)
+
 if(NOT DEFINED FREERTOS_DIR)
     message(FATAL_ERROR "FREERTOS_DIR must point to FreeRTOS-Kernel directory")
 endif()
@@ -238,6 +249,12 @@ target_include_directories(eds_safeboot_freertos PRIVATE
 target_compile_definitions(eds_safeboot_freertos PRIVATE
     EDS_PLATFORM_FREERTOS=1
     EDS_MSG_BUF_MAX_STACK_BYTES=8192
+    # [SEC-BUILD-MODE-01 / issue #84] Give EDS_BUILD_IS_PRODUCTION the same
+    # defined-and-1-or-0 signal Zephyr's Kconfig already gives it. The
+    # $<BOOL:...> generator expression emits 1 when EDS_PLACEHOLDER_KEYS_ONLY
+    # is ON, 0 when OFF -- production is declared with
+    # -DEDS_PLACEHOLDER_KEYS_ONLY=OFF (see the option() above).
+    CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=$<BOOL:${EDS_PLACEHOLDER_KEYS_ONLY}>
 )
 
 # ---------------------------------------------------------------------------

--- a/examples/safeboot_freertos_ecu/CMakeLists.txt
+++ b/examples/safeboot_freertos_ecu/CMakeLists.txt
@@ -77,16 +77,6 @@ set(CMAKE_C_EXTENSIONS        OFF)
 # Required parameters
 # ---------------------------------------------------------------------------
 
-# [SEC-BUILD-MODE-01 / issue #84] FreeRTOS has no Kconfig of its own, so
-# without this option CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY is never defined for
-# a FreeRTOS build and EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h)
-# falls through to its PRODUCTION default on every build, including CI.
-# Mirrors Zephyr Kconfig's own `default y` for the same symbol: ON here
-# means "development / CI build, placeholder keys explicitly permitted."
-# Flip to OFF (-DEDS_PLACEHOLDER_KEYS_ONLY=OFF) to declare a production
-# build — this is what makes the CRIT-4 #error and the Step 7.1 runtime
-# guard in generated/uds_init.c reachable on FreeRTOS for the first time.
-option(EDS_PLACEHOLDER_KEYS_ONLY "Allow placeholder AES-128 security keys (DEVELOPMENT ONLY)" ON)
 
 if(NOT DEFINED FREERTOS_DIR)
     message(FATAL_ERROR "FREERTOS_DIR must point to FreeRTOS-Kernel directory")
@@ -137,6 +127,11 @@ endif()
 # ---------------------------------------------------------------------------
 
 set(DIAG_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+
+# [SEC-BUILD-MODE-01 / issue #84] shared FreeRTOS build-mode option -- see
+# cmake/eds_build_mode.cmake for why this is centralized rather than
+# declared per-example (same lesson as cmake/eds_service_sources.cmake).
+include(${DIAG_ROOT}/cmake/eds_build_mode.cmake)
 
 # ---------------------------------------------------------------------------
 # FreeRTOS kernel sources
@@ -253,7 +248,7 @@ target_compile_definitions(eds_safeboot_freertos PRIVATE
     # defined-and-1-or-0 signal Zephyr's Kconfig already gives it. The
     # $<BOOL:...> generator expression emits 1 when EDS_PLACEHOLDER_KEYS_ONLY
     # is ON, 0 when OFF -- production is declared with
-    # -DEDS_PLACEHOLDER_KEYS_ONLY=OFF (see the option() above).
+    # -DEDS_PLACEHOLDER_KEYS_ONLY=OFF (see cmake/eds_build_mode.cmake).
     CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=$<BOOL:${EDS_PLACEHOLDER_KEYS_ONLY}>
 )
 

--- a/examples/safeboot_freertos_ecu/generated/uds_init.c
+++ b/examples/safeboot_freertos_ecu/generated/uds_init.c
@@ -466,10 +466,24 @@ uds_status_t uds_generated_init(
      *   uds_security_algo_set_level_key(0x01U, otp_key_level1_16bytes);
      *   uds_security_algo_set_level_key(0x03U, otp_key_level2_16bytes);
      *
-     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2)
+     * BUILD-MODE DERIVATION [SEC-BUILD-MODE-01 / issue #84]: this guard used
+     * to test `defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY`
+     * directly. Zephyr's generated autoconf.h omits the Kconfig symbol
+     * entirely (rather than emitting 0) when the bool is set to `n`, so that
+     * idiom silently never fired on a real Zephyr production build, and
+     * never fired on FreeRTOS at all (FreeRTOS never defined the symbol).
+     * It now consumes EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h),
+     * the single shared build-mode primitive the CRIT-4 #error in
+     * uds_security_algo.c also derives from, so the two cannot drift apart
+     * again. No `#include` change needed here — this file already includes
+     * uds_security_algo.h. Unlike the CRIT-4 site, this guard needs no
+     * `!defined(UNIT_TEST)` carve-out: no existing test compiles a
+     * generated uds_init.c under UNIT_TEST=1.
+     *
+     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2) /
+     *               SEC-BUILD-MODE-01 (build-mode derivation)
      */
-#if defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && \
-    !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY
+#if EDS_BUILD_IS_PRODUCTION
     {
         /* Production gate: refuse to start if keys or TRNG are missing. */
         if (uds_security_algo_keys_are_placeholder()) {
@@ -485,7 +499,7 @@ uds_status_t uds_generated_init(
             return UDS_STATUS_ERR_CONDITIONS_NOT_MET;
         }
     }
-#endif /* !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY */
+#endif /* EDS_BUILD_IS_PRODUCTION */
 
     /* ── Step 8: UDS server ────────────────────────────────────────────────
      *

--- a/examples/sensor_ecu/generated/uds_init.c
+++ b/examples/sensor_ecu/generated/uds_init.c
@@ -460,10 +460,24 @@ uds_status_t uds_generated_init(
      *   uds_security_algo_set_level_key(0x01U, otp_key_level1_16bytes);
      *   uds_security_algo_set_level_key(0x03U, otp_key_level2_16bytes);
      *
-     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2)
+     * BUILD-MODE DERIVATION [SEC-BUILD-MODE-01 / issue #84]: this guard used
+     * to test `defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY`
+     * directly. Zephyr's generated autoconf.h omits the Kconfig symbol
+     * entirely (rather than emitting 0) when the bool is set to `n`, so that
+     * idiom silently never fired on a real Zephyr production build, and
+     * never fired on FreeRTOS at all (FreeRTOS never defined the symbol).
+     * It now consumes EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h),
+     * the single shared build-mode primitive the CRIT-4 #error in
+     * uds_security_algo.c also derives from, so the two cannot drift apart
+     * again. No `#include` change needed here — this file already includes
+     * uds_security_algo.h. Unlike the CRIT-4 site, this guard needs no
+     * `!defined(UNIT_TEST)` carve-out: no existing test compiles a
+     * generated uds_init.c under UNIT_TEST=1.
+     *
+     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2) /
+     *               SEC-BUILD-MODE-01 (build-mode derivation)
      */
-#if defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && \
-    !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY
+#if EDS_BUILD_IS_PRODUCTION
     {
         /* Production gate: refuse to start if keys or TRNG are missing. */
         if (uds_security_algo_keys_are_placeholder()) {
@@ -479,7 +493,7 @@ uds_status_t uds_generated_init(
             return UDS_STATUS_ERR_CONDITIONS_NOT_MET;
         }
     }
-#endif /* !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY */
+#endif /* EDS_BUILD_IS_PRODUCTION */
 
     /* ── Step 8: UDS server ────────────────────────────────────────────────
      *

--- a/examples/sensor_ecu_freertos/CMakeLists.txt
+++ b/examples/sensor_ecu_freertos/CMakeLists.txt
@@ -64,6 +64,17 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 # Required parameters
 # ---------------------------------------------------------------------------
 
+# [SEC-BUILD-MODE-01 / issue #84] FreeRTOS has no Kconfig of its own, so
+# without this option CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY is never defined for
+# a FreeRTOS build and EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h)
+# falls through to its PRODUCTION default on every build, including CI.
+# Mirrors Zephyr Kconfig's own `default y` for the same symbol: ON here
+# means "development / CI build, placeholder keys explicitly permitted."
+# Flip to OFF (-DEDS_PLACEHOLDER_KEYS_ONLY=OFF) to declare a production
+# build — this is what makes the CRIT-4 #error and the Step 7.1 runtime
+# guard in generated/uds_init.c reachable on FreeRTOS for the first time.
+option(EDS_PLACEHOLDER_KEYS_ONLY "Allow placeholder AES-128 security keys (DEVELOPMENT ONLY)" ON)
+
 if(NOT DEFINED EDS_PLATFORM)
     set(EDS_PLATFORM "freertos")
 endif()
@@ -229,6 +240,12 @@ target_include_directories(eds_sensor_freertos PRIVATE
 
 target_compile_definitions(eds_sensor_freertos PRIVATE
     EDS_PLATFORM_FREERTOS=1
+    # [SEC-BUILD-MODE-01 / issue #84] Give EDS_BUILD_IS_PRODUCTION the same
+    # defined-and-1-or-0 signal Zephyr's Kconfig already gives it. The
+    # $<BOOL:...> generator expression emits 1 when EDS_PLACEHOLDER_KEYS_ONLY
+    # is ON, 0 when OFF -- production is declared with
+    # -DEDS_PLACEHOLDER_KEYS_ONLY=OFF (see the option() above).
+    CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=$<BOOL:${EDS_PLACEHOLDER_KEYS_ONLY}>
     # Suppress the uds_msg_buf_t _Static_assert: the FreeRTOS example
     # never allocates uds_msg_buf_t on the stack.
     EDS_MSG_BUF_MAX_STACK_BYTES=8192

--- a/examples/sensor_ecu_freertos/CMakeLists.txt
+++ b/examples/sensor_ecu_freertos/CMakeLists.txt
@@ -64,16 +64,6 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 # Required parameters
 # ---------------------------------------------------------------------------
 
-# [SEC-BUILD-MODE-01 / issue #84] FreeRTOS has no Kconfig of its own, so
-# without this option CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY is never defined for
-# a FreeRTOS build and EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h)
-# falls through to its PRODUCTION default on every build, including CI.
-# Mirrors Zephyr Kconfig's own `default y` for the same symbol: ON here
-# means "development / CI build, placeholder keys explicitly permitted."
-# Flip to OFF (-DEDS_PLACEHOLDER_KEYS_ONLY=OFF) to declare a production
-# build — this is what makes the CRIT-4 #error and the Step 7.1 runtime
-# guard in generated/uds_init.c reachable on FreeRTOS for the first time.
-option(EDS_PLACEHOLDER_KEYS_ONLY "Allow placeholder AES-128 security keys (DEVELOPMENT ONLY)" ON)
 
 if(NOT DEFINED EDS_PLATFORM)
     set(EDS_PLATFORM "freertos")
@@ -98,6 +88,11 @@ endif()
 # ---------------------------------------------------------------------------
 
 set(DIAG_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+
+# [SEC-BUILD-MODE-01 / issue #84] shared FreeRTOS build-mode option -- see
+# cmake/eds_build_mode.cmake for why this is centralized rather than
+# declared per-example (same lesson as cmake/eds_service_sources.cmake).
+include(${DIAG_ROOT}/cmake/eds_build_mode.cmake)
 
 # ---------------------------------------------------------------------------
 # Board-specific compiler flags
@@ -244,7 +239,7 @@ target_compile_definitions(eds_sensor_freertos PRIVATE
     # defined-and-1-or-0 signal Zephyr's Kconfig already gives it. The
     # $<BOOL:...> generator expression emits 1 when EDS_PLACEHOLDER_KEYS_ONLY
     # is ON, 0 when OFF -- production is declared with
-    # -DEDS_PLACEHOLDER_KEYS_ONLY=OFF (see the option() above).
+    # -DEDS_PLACEHOLDER_KEYS_ONLY=OFF (see cmake/eds_build_mode.cmake).
     CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=$<BOOL:${EDS_PLACEHOLDER_KEYS_ONLY}>
     # Suppress the uds_msg_buf_t _Static_assert: the FreeRTOS example
     # never allocates uds_msg_buf_t on the stack.

--- a/examples/sensor_ecu_freertos/generated/uds_init.c
+++ b/examples/sensor_ecu_freertos/generated/uds_init.c
@@ -416,10 +416,24 @@ uds_status_t uds_generated_init(
      *   uds_security_algo_set_level_key(0x01U, otp_key_level1_16bytes);
      *   uds_security_algo_set_level_key(0x03U, otp_key_level2_16bytes);
      *
-     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2)
+     * BUILD-MODE DERIVATION [SEC-BUILD-MODE-01 / issue #84]: this guard used
+     * to test `defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY`
+     * directly. Zephyr's generated autoconf.h omits the Kconfig symbol
+     * entirely (rather than emitting 0) when the bool is set to `n`, so that
+     * idiom silently never fired on a real Zephyr production build, and
+     * never fired on FreeRTOS at all (FreeRTOS never defined the symbol).
+     * It now consumes EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h),
+     * the single shared build-mode primitive the CRIT-4 #error in
+     * uds_security_algo.c also derives from, so the two cannot drift apart
+     * again. No `#include` change needed here — this file already includes
+     * uds_security_algo.h. Unlike the CRIT-4 site, this guard needs no
+     * `!defined(UNIT_TEST)` carve-out: no existing test compiles a
+     * generated uds_init.c under UNIT_TEST=1.
+     *
+     * TRACEABILITY: SEC-KEY-GATE-01 (CRIT-4) / SEC-TRNG-GATE-01 (HIGH-2) /
+     *               SEC-BUILD-MODE-01 (build-mode derivation)
      */
-#if defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && \
-    !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY
+#if EDS_BUILD_IS_PRODUCTION
     {
         /* Production gate: refuse to start if keys or TRNG are missing. */
         if (uds_security_algo_keys_are_placeholder()) {
@@ -435,7 +449,7 @@ uds_status_t uds_generated_init(
             return UDS_STATUS_ERR_CONDITIONS_NOT_MET;
         }
     }
-#endif /* !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY */
+#endif /* EDS_BUILD_IS_PRODUCTION */
 
     /* ── Step 8: UDS server ────────────────────────────────────────────────
      *

--- a/scripts/verify_build_mode_macro.sh
+++ b/scripts/verify_build_mode_macro.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Xaloqi EDS
+# scripts/verify_build_mode_macro.sh
+#
+# PURPOSE: Permanent regression probe for EDS_BUILD_IS_PRODUCTION
+#          (core/uds_security_algo.h, SEC-BUILD-MODE-01 / issue #84).
+#
+#          Compiles tests/probe_eds_build_is_production.c (a preprocessor-
+#          only probe, never linked) under every build-mode -D combination
+#          this codebase can present, and checks that EDS_BUILD_IS_PRODUCTION
+#          resolves to the expected 0 (development) or 1 (production) value
+#          in each case. A triggered #error in that file always fails the
+#          gcc invocation regardless of warning/optimization flags, so this
+#          is a reliable oracle for a compile-time-only macro that has no
+#          runtime value to assert against directly.
+#
+#          This is the automated form of the truth table used to catch and
+#          fix issue #84: the OLD `defined(X) && !X` idiom silently did
+#          nothing on a real Zephyr production build (case 2) and left every
+#          FreeRTOS build unprotected (case 4, before examples/*_freertos/
+#          CMakeLists.txt started defining CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY
+#          itself). Every case below must keep resolving correctly, forever.
+#
+# USAGE:
+#   bash scripts/verify_build_mode_macro.sh
+#
+# EXIT CODES:
+#   0  All cases resolved to their expected value.
+#   1  One or more cases resolved incorrectly, or failed to compile at all.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PROBE_SRC="${ROOT}/tests/probe_eds_build_is_production.c"
+OBJ="$(mktemp -u /tmp/eds_build_mode_probe.XXXXXX.o)"
+
+trap 'rm -f "${OBJ}"' EXIT
+
+if [[ ! -f "${PROBE_SRC}" ]]; then
+    echo "ERROR: ${PROBE_SRC} not found."
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Each entry: "label|expected(0|1)|extra -D flags (space-separated, may be empty)"
+# Mirrors the truth table in the #84 fix design / EDS_BUILD_IS_PRODUCTION's
+# own doc comment.
+# ---------------------------------------------------------------------------
+CASES=(
+    "Zephyr dev (CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=1)|0|-DCONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=1"
+    "Zephyr production (symbol omitted)|1|"
+    "FreeRTOS dev, new CMake default (EDS_PLATFORM_FREERTOS + CONFIG=1)|0|-DEDS_PLATFORM_FREERTOS=1 -DCONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=1"
+    "FreeRTOS with nothing wired (regression safety net)|1|-DEDS_PLATFORM_FREERTOS=1"
+    "host unit-test / harness build (UNIT_TEST=1)|0|-DUNIT_TEST=1"
+    "forced production test binary (UNIT_TEST=1, CONFIG=0)|1|-DUNIT_TEST=1 -DCONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0"
+    "explicit override escape hatch (EDS_BUILD_IS_PRODUCTION=1 wins)|1|-DCONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=1 -DEDS_BUILD_IS_PRODUCTION=1"
+)
+
+PASS=0
+FAIL=0
+
+echo ""
+echo "================================================================"
+echo "  Xaloqi EDS — EDS_BUILD_IS_PRODUCTION build-mode macro probe"
+echo "================================================================"
+echo ""
+
+for entry in "${CASES[@]}"; do
+    IFS='|' read -r label expected extra_flags <<< "${entry}"
+
+    # shellcheck disable=SC2086
+    build_out=$(gcc -I"${ROOT}/core" ${extra_flags} -c "${PROBE_SRC}" -o "${OBJ}" 2>&1) && build_rc=0 || build_rc=$?
+
+    if [[ ${build_rc} -eq 0 ]]; then
+        printf "  %-70s  BUILD_FAIL (no #error fired)\n" "${label}"
+        FAIL=$((FAIL + 1))
+        continue
+    fi
+
+    if echo "${build_out}" | grep -q "EDS_BUILD_IS_PRODUCTION_PROBE_RESULT_${expected}"; then
+        printf "  %-70s  PASS (== %s)\n" "${label}" "${expected}"
+        PASS=$((PASS + 1))
+    else
+        got="?"
+        if echo "${build_out}" | grep -q "EDS_BUILD_IS_PRODUCTION_PROBE_RESULT_0"; then got="0"; fi
+        if echo "${build_out}" | grep -q "EDS_BUILD_IS_PRODUCTION_PROBE_RESULT_1"; then got="1"; fi
+        printf "  %-70s  FAIL (expected %s, got %s)\n" "${label}" "${expected}" "${got}"
+        echo "${build_out}" | sed 's/^/      /'
+        FAIL=$((FAIL + 1))
+    fi
+done
+
+echo ""
+echo "================================================================"
+echo "  Build-mode macro probe: ${PASS} passed, ${FAIL} failed (of ${#CASES[@]})"
+echo "================================================================"
+echo ""
+
+if [[ ${FAIL} -ne 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tests/probe_eds_build_is_production.c
+++ b/tests/probe_eds_build_is_production.c
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2026 Xaloqi
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: tests/probe_eds_build_is_production.c
+ *
+ * PURPOSE: Preprocessor-only probe that proves EDS_BUILD_IS_PRODUCTION
+ *          (core/uds_security_algo.h, SEC-BUILD-MODE-01) resolves to the
+ *          correct value for every build-mode signal combination this
+ *          codebase can present, across platforms.
+ *
+ * This file is never linked or run — it is compiled with -c under a set of
+ * -D combinations by scripts/verify_build_mode_macro.sh, and the value of
+ * EDS_BUILD_IS_PRODUCTION is extracted from a deliberate #error. gcc always
+ * treats a triggered #error as a hard failure regardless of optimization or
+ * warning flags, which makes this a reliable, permanent regression probe
+ * for a compile-time-only macro that has no runtime representation to
+ * assert against.
+ *
+ * TRACEABILITY: SEC-BUILD-MODE-01 / issue #84
+ * ============================================================================= */
+
+#include "uds_security_algo.h"
+
+#if EDS_BUILD_IS_PRODUCTION
+#error "EDS_BUILD_IS_PRODUCTION_PROBE_RESULT_1"
+#else
+#error "EDS_BUILD_IS_PRODUCTION_PROBE_RESULT_0"
+#endif


### PR DESCRIPTION
Closes #84.

## Unification design

Two independently-authored copies of "is this a production build?" existed in this codebase and both got it wrong the same way:

- the CRIT-4 placeholder-key `#error` in `core/uds_security_algo.c`
- the Step 7.1 runtime guard generated into every `examples/*/generated/uds_init.c` (`tools/templates/uds_init.c.j2`, private EDS-toolchain repo)

Both used `defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) && !CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY`. Zephyr's generated `autoconf.h` emits `#define CONFIG_X 1` for a Kconfig bool set to `y`, and **omits the symbol entirely** for `n` — it never emits `#define CONFIG_X 0`. On a real Zephyr **production** build (the bool set to `n`, exactly what the docs told integrators to do), `defined(CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY)` was `FALSE`, so both gates silently did nothing in precisely the configuration they exist to protect.

Fix: derive "is this production?" from one shared primitive, `EDS_BUILD_IS_PRODUCTION` (`core/uds_security_algo.h`, `[SEC-BUILD-MODE-01]`), and have every gate reference it instead of re-deriving the same logic. One definition cannot drift from itself — that's the actual root-cause fix, not just a polarity flip on the two existing call sites.

- **CRIT-4** (`core/uds_security_algo.c`): `#if EDS_BUILD_IS_PRODUCTION && !defined(UNIT_TEST)`. The `!defined(UNIT_TEST)` carve-out is preserved from the original gate — it was never part of the #84 bug. It lets a host test force `EDS_BUILD_IS_PRODUCTION=1` to exercise a *different* gate's production behaviour (`test_trng_fail_closed.c` forces `-DCONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0` to reach `ALGO_ENTROPY_FAIL_CLOSED`'s fail-closed path) without also tripping the placeholder-key `#error` against a test binary that was never going to have real OEM keys. Also corrected a stale comment claiming the gate does byte-pattern detection of the key array bytes — verified no such preprocessor mechanism exists anywhere in the codebase; the gate is actually an unconditional compile failure once production is declared.
- **`ALGO_ENTROPY_FAIL_CLOSED`** (`[SEC-TRNG-FAILCLOSED-01]`) is now a plain alias: `#define ALGO_ENTROPY_FAIL_CLOSED EDS_BUILD_IS_PRODUCTION`. Name kept as-is (already used throughout comments, `test_trng_fail_closed.c`, `SECURITY.md`) to avoid unrelated churn.

## The FreeRTOS landmine, and how it's fixed

FreeRTOS has no Kconfig of its own. Verified by grep across all 4 FreeRTOS examples (`basic_ecu_freertos`, `basic_ecu_doip_freertos`, `sensor_ecu_freertos`, `safeboot_freertos_ecu`): none of them ever defined `CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY` anywhere — not in `CMakeLists.txt`, not via codegen. `basic_ecu_freertos/CMakeLists.txt` even had a comment claiming otherwise ("production prj sets CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=n") that described an intention never implemented.

Under the **old** idiom this meant FreeRTOS was *always* unprotected by both gates — a second instance of the same #84 bug, not a regression introduced here. Under a **naive** fail-closed-by-default fix, FreeRTOS would have flipped to the opposite failure mode: every FreeRTOS build, including all CI jobs, would hit the CRIT-4 `#error` and the Step 7.1 runtime refusal unconditionally, with no way to declare itself a development build.

Fix: all 4 FreeRTOS example `CMakeLists.txt` files now expose:
```cmake
option(EDS_PLACEHOLDER_KEYS_ONLY "Allow placeholder AES-128 security keys (DEVELOPMENT ONLY)" ON)
...
target_compile_definitions(<target> PRIVATE
    CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=$<BOOL:${EDS_PLACEHOLDER_KEYS_ONLY}>
)
```
Default `ON` (development), mirroring Zephyr Kconfig's own `default y`. This gives FreeRTOS the exact same defined-and-1-or-0 signal Zephyr's Kconfig always gave, so it's handled entirely by `EDS_BUILD_IS_PRODUCTION`'s first branch. Verified with a real ARM cross-compile (see below) — the default build still succeeds, and flipping `-DEDS_PLACEHOLDER_KEYS_ONLY=OFF` now makes the build fail with `SEC-KEY-GATE-01`, proving the gate is reachable on FreeRTOS for the first time.

## Retroactively closes a latent gap in the already-merged PR #85

`ALGO_ENTROPY_FAIL_CLOSED` (PR #85, corrected in #90) already had the right fail-closed-by-default polarity. But because FreeRTOS never defined the Kconfig symbol, a real FreeRTOS build has **always** silently resolved `ALGO_ENTROPY_FAIL_CLOSED` to `1` (production/fail-closed) — with no supported way to opt into the development LFSR fallback. This has not broken CI: the `freertos-qemu` job is build-only (compiles, links, checks the ELF exists) and never exercises a live SecurityAccess request, so this was a real, live, CI-invisible latent gap on `main` today. This PR closes it via the same `-DEDS_PLACEHOLDER_KEYS_ONLY` CMake option, since `ALGO_ENTROPY_FAIL_CLOSED` and the CRIT-4 gate now share one derivation.

## Breaking change

Any FreeRTOS build, and any Zephyr production build that was silently bypassing the CRIT-4 key gate and/or the TRNG fail-closed gate before this fix, will now correctly refuse to **compile** (CRIT-4, if placeholder keys are still present) or **initialise** (Step 7.1 runtime guard) unless it explicitly declares itself a development build (`CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=y` on Zephyr, `-DEDS_PLACEHOLDER_KEYS_ONLY=ON` on FreeRTOS — both are the default, so CI and existing dev workflows are unaffected). This is the intended remediation, but it is a real behaviour change for anyone unknowingly relying on the previously-broken, silently-inert gates. See `CHANGELOG.md` and `SECURITY.md` for the full corrected dev-vs-production tables.

## Verification evidence

### 1. Macro-selection probe (`scripts/verify_build_mode_macro.sh`, wired into `build_tests.sh`)

Permanent regression test (`tests/probe_eds_build_is_production.c`, a preprocessor-only probe) proving `EDS_BUILD_IS_PRODUCTION` resolves correctly for every documented case:

```
================================================================
  Xaloqi EDS — EDS_BUILD_IS_PRODUCTION build-mode macro probe
================================================================

  Zephyr dev (CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=1)                        PASS (== 0)
  Zephyr production (symbol omitted)                                      PASS (== 1)
  FreeRTOS dev, new CMake default (EDS_PLATFORM_FREERTOS + CONFIG=1)      PASS (== 0)
  FreeRTOS with nothing wired (regression safety net)                     PASS (== 1)
  host unit-test / harness build (UNIT_TEST=1)                            PASS (== 0)
  forced production test binary (UNIT_TEST=1, CONFIG=0)                   PASS (== 1)
  explicit override escape hatch (EDS_BUILD_IS_PRODUCTION=1 wins)         PASS (== 1)

================================================================
  Build-mode macro probe: 7 passed, 0 failed (of 7)
================================================================
```

### 2. CRIT-4 negative compile test (wired into `build_tests.sh`)

```
================================================================
  [SEC-KEY-GATE-01] CRIT-4 negative compile test
================================================================

  PASS: production build (CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0, no UNIT_TEST)
        correctly FAILS to compile, citing SEC-KEY-GATE-01.
  PASS: default dev-mode compile (-DUNIT_TEST=1, no Kconfig symbol)
        still succeeds (regression guard).
```

Confirmed empirically before this fix (baseline `main`) the same negative-compile command **succeeded** (the bug) — i.e. this is a genuine before/after proof, not just a post-hoc assertion.

### 3. FreeRTOS CMake fix — real ARM cross-compile

Toolchain: `arm-none-eabi-gcc` 14.2.1, `cmake`, `ninja`, `FreeRTOS-Kernel` cloned fresh from GitHub. Ran the actual `freertos-qemu` CI job's `cmake`/`ninja` invocation for `basic_ecu_freertos` (the only FreeRTOS example with a CI job today — `basic_ecu_doip_freertos`, `sensor_ecu_freertos`, `safeboot_freertos_ecu` have no CI job at all currently, confirmed no matching job names in `ci.yml`).

- **Default (dev-mode) build**: configures and links successfully, `eds_freertos.elf` produced. (One unrelated `-Wno-error=incompatible-pointer-types` override was needed purely because this sandbox's `arm-none-eabi-gcc` 14.2.1 is newer than CI's pinned Ubuntu 22.04 apt package and defaults an existing, pre-existing, unrelated type-mismatch warning in `platform/freertos/freertos_platform_api.c` to a hard error — not something this PR touches or introduces; noted separately below.)
- **`-DEDS_PLACEHOLDER_KEYS_ONLY=OFF`**: build now fails:
  ```
  core/uds_security_algo.c:129:2: error: #error "[SEC-KEY-GATE-01] Production build declared (EDS_BUILD_IS_PRODUCTION=1) ..."
  ```
  Proving the gate is reachable on FreeRTOS for the first time.
- CMake **configure** (generator-expression resolution) verified for the other 3 FreeRTOS examples — `CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=1` correctly appears in each one's `build.ninja` `DEFINES` line by default.

### 4. Full existing gate suite

```
bash build_tests.sh          -> 43/43 passed (+ items 1 and 2 above, also green)
bash build_harness.sh --run  -> 68/68 passed
cmake -S tests -B build && cmake --build build -j4 && ctest --test-dir build
                              -> 100% tests passed, 43/43
```
Zephyr SDK / `native_sim` not available in this sandbox (no `ZEPHYR_BASE`, no zephyr-sdk installed) — the Zephyr dev/production macro-resolution cases are covered directly by the preprocessor probe in item 1 instead.

## Scope note: what this PR does NOT include

- **`tools/templates/uds_init.c.j2` (private EDS-toolchain repo)**: the sandbox this PR was prepared in blocks git operations (branch/commit/push) against that repo from an EDS worktree ("a worktree-isolated agent's git operations must target its own worktree"). The Step 7.1 template fix is prepared and verified (see companion note) but not yet committed there — tracked as a follow-up, cross-linked once opened.
- **Regenerating the 12 `examples/*/generated/uds_init.c` files**: attempted, but the private toolchain repo's *current* `tools/templates/uds_init.c.j2` has drifted from what actually produced today's committed generated output, in ways unrelated to this fix (an ISO 26262 citation wording change affecting all 12 files, and an entire additional CommunicationControl/`ControlDTCSetting` init step present in the current template but absent from 4 of the 12 committed files — `ardep_ecu`, `bms_ecu`, `motor_controller_ecu`, `sensor_ecu_freertos`). Per this task's own regeneration safeguard, committing regenerated output through a template with unrelated, unreviewed drift was not done. This needs the toolchain repo maintainer to either regenerate from a pinned revision that matches today's committed output, or accept the unrelated drift as a separate, intentional update. Not done silently or guessed at.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
