### PR TITLE
docs: fix stale CI job/test counts (#91) and seed-layout comment (#94)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,15 @@
 # =============================================================================
 # Xaloqi EDS — .github/workflows/ci.yml
 #
-# Community tier CI pipeline — 8 jobs covering the public GPL runtime stack.
+# Community tier CI pipeline covering the public GPL runtime stack.
 #
-# Jobs:
-#   1. unit-tests           — 42 host-side C unit tests (Unity framework)
-#   2. integration-tests    — pytest suite against basic_ecu generated output (simulator mode)
-#   3. static-analysis      — GCC -fanalyzer + MISRA C:2012 cppcheck (zero open violations)
-#   4. zephyr-native        — west build -b native_sim (basic_ecu, Zephyr v3.7)
-#   5. zephyr-stm32         — west build -b nucleo_h743zi (cross-compile, basic_ecu)
-#   6. freertos-qemu        — FreeRTOS ARM cross-compile (basic_ecu_freertos, QEMU M4)
-#   7. freertos-safeboot    — FreeRTOS OTA DFU compile (safeboot_freertos_ecu, QEMU M4, RAM stub)
-#   8. harness-tests        — build_harness.sh: MISRA-clean C build + 68 integration tests
+# [#91] The job count and per-job summary used to be hand-maintained here and
+# drifted badly (this comment once listed 8 jobs and 42 unit tests; the
+# actual counts had grown to 14 jobs / 43 unit tests, and the list itself was
+# missing 6 jobs entirely). Rather than re-introduce a number that will go
+# stale again the next time a job is added or split, the authoritative job
+# list is the `jobs:` block below — see its job names and `name:` fields
+# directly, or `gh workflow view ci.yml` / the Actions UI for the live list.
 #
 # Additional CI jobs (codegen examples, GUI, MCP server) run in the
 # private EDS-toolchain repo against the full Developer/Professional toolchain.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+### Documentation
+
+- **Stale CI job-count comments corrected.** (#91) `.github/workflows/ci.yml`'s
+  header comment said "8 jobs" and listed 8 by name — the actual count had
+  grown to 14 and the list was missing 6 jobs entirely. `CONTRIBUTING.md` said
+  "13 jobs" in one place and "10 CI jobs" in another, neither matching. All
+  three unit-test-count mentions in `CONTRIBUTING.md` still said "42" (now
+  43). Rather than replace one stale number with another that will drift the
+  next time a job is added or split, the job-count references now point at
+  `.github/workflows/ci.yml`'s `jobs:` block as the single authoritative
+  list instead of hardcoding a count.
+- **`uds_security_algo.h`'s ALGORITHM OVERVIEW comment corrected.** (#94) It
+  described seed byte 6 as holding `security_level`, a layout the
+  implementation no longer uses — domain separation is via a distinct AES
+  key per level, not a seed byte, freeing the full 16-bit sequence counter
+  across bytes 6-7. `UDS_ALGO_SEED_LEVEL_OFFSET` is noted as a
+  byte-compatible alias for `UDS_ALGO_SEED_SEQ_HI_OFFSET`, not a distinct
+  field — matching what `tests/unit_runnable/test_phase5_security_algo.c`'s
+  `tc031` already tests (fixed in #93's PR, #92).
+
 ### Security
 
 - **BREAKING: unified build-mode detection closes a silent bypass of both the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Bug reports, documentation improvements, and issue comments never require a CLA.
 - Changes that remove or weaken any step of the 5-step ASIL-B safety wrapper chain
 - Dynamic memory allocation (`malloc`, `free`) anywhere in the stack
 - Recursion in any safety-critical module
-- Changes that break the `native_sim` CI build or cause any of the 42 unit tests to fail
+- Changes that break the `native_sim` CI build or cause any unit test to fail (currently 43 — see build_tests.sh, which enforces its own count via an anti-drift check)
 - Hand-written changes to files under `generated/` — these are codegen output;
   fix the template in `tools/templates/` instead
 - External runtime dependencies not already present in the stack
@@ -126,7 +126,7 @@ python3 tools/codegen.py \
   --out generated/ \
   --safety-wrappers --asil-level B --test-gen
 
-# All 42 unit tests must pass
+# All unit tests must pass (currently 43)
 bash build_tests.sh
 
 # All 68 harness tests must pass
@@ -137,8 +137,10 @@ west build -b native_sim examples/basic_ecu \
   -- -DDTC_OVERLAY_FILE=boards/native_sim.overlay
 ```
 
-CI runs all 13 jobs automatically on pull requests. A PR will not be merged if
-any CI job is red.
+CI runs the full workflow automatically on pull requests — see
+`.github/workflows/ci.yml` for the current job list (it grows as coverage is
+added; don't hardcode a count here, it has drifted before — #91). A PR will
+not be merged if any CI job is red.
 
 ### 5. Pull request checklist
 
@@ -148,7 +150,7 @@ any CI job is red.
 - [ ] SPDX header on every new file
 - [ ] Unit test added or updated for the changed module
 - [ ] `generated/` files regenerated and committed if YAML or templates changed
-- [ ] All 42 unit tests pass locally (`bash build_tests.sh`)
+- [ ] All unit tests pass locally (`bash build_tests.sh`)
 - [ ] PR title follows format: `[fix|feat|docs|test|chore]: short description`
 
 ---
@@ -278,7 +280,7 @@ safety-relevant code.
 ### What it is not used for
 
 - Autonomous merge decisions — no AI output is merged without human sign-off
-- Bypassing CI — all commits, regardless of origin, must pass all 10 CI jobs
+- Bypassing CI — all commits, regardless of origin, must pass all CI jobs (see .github/workflows/ci.yml for the current list)
 - Architecture decisions — module boundaries, safety architecture, and API contracts
   are defined by the project maintainer
 
@@ -286,8 +288,10 @@ safety-relevant code.
 
 Every commit that touches the EDS codebase, regardless of how it was generated, must satisfy:
 
-1. **CI gate:** All 10 CI jobs green — unit tests, integration tests, static analysis,
-   Zephyr build, FreeRTOS build, DoIP integration, harness tests, robustness tests.
+1. **CI gate:** All CI jobs green — unit tests, CMake/CTest parity, integration
+   tests, static analysis, Zephyr builds (multiple board targets), FreeRTOS
+   builds, DoIP integration, SOVD codegen, robustness campaign, harness tests.
+   See `.github/workflows/ci.yml` for the current, authoritative list.
 2. **Human sign-off:** The committing engineer reads, understands, and takes
    responsibility for every line before it is staged. AI-generated output is a
    starting point, not a finished deliverable.

--- a/core/uds_security_algo.h
+++ b/core/uds_security_algo.h
@@ -18,8 +18,17 @@
  *   ───────────────
  *   The 8-byte seed is structured as:
  *     Byte 0..5 : 48-bit TRNG nonce (from hardware RNG)
- *     Byte 6    : security_level (embedded for domain separation)
+ *     Byte 6    : sequence_hi    (upper 8 bits of monotonic counter)
  *     Byte 7    : sequence_lo    (lower 8 bits of monotonic counter)
+ *
+ *   [#94] security_level is NOT embedded in the seed — domain separation
+ *   between levels comes entirely from using a different AES key per level
+ *   (see uds_security_algo_generate_seed() in uds_security_algo.c), which
+ *   frees the full 16-bit sequence counter across bytes 6-7. This corrects
+ *   an earlier version of this comment block, which described a layout
+ *   where byte 6 held security_level. UDS_ALGO_SEED_LEVEL_OFFSET (below)
+ *   is kept only as a byte-compatible alias for UDS_ALGO_SEED_SEQ_HI_OFFSET
+ *   — it does not name a distinct field.
  *
  *   KEY DERIVATION
  *   ─────────────────────────────────────────


### PR DESCRIPTION
Both found as byproducts of the #84/#88 work, filed separately to keep those PRs scoped.

## #91 — stale CI job/test counts

`.github/workflows/ci.yml`'s header comment said "8 jobs" and named 8 by number — the actual count had grown to 14, with 6 jobs missing from the list entirely (never updated when `zephyr-nxp-s32k`, `doip-integration`, `sovd-codegen`, `robustness-tests`, `harness-tests`, and `cmake-ctest-build` were added). `CONTRIBUTING.md` separately said "13 jobs" in one place and "10 CI jobs" in another, neither matching either. Found 3 more stale "42 unit tests" mentions while fixing this (now 43) beyond the one the issue named.

Rather than replace one stale number with another that will drift the next time a job is added or split, job-count references now point at `ci.yml`'s `jobs:` block as the single authoritative list instead of hardcoding a count that has already drifted twice.

## #94 — stale seed-layout comment

`uds_security_algo.h`'s ALGORITHM OVERVIEW comment described seed byte 6 as holding `security_level` — a layout the implementation deliberately abandoned (domain separation is via a distinct AES key per level, not a seed byte, per the `[P1-SEC]` comment in `uds_security_algo.c`). `UDS_ALGO_SEED_LEVEL_OFFSET` is now noted as a byte-compatible alias for `UDS_ALGO_SEED_SEQ_HI_OFFSET`, matching what `tc031` (fixed in [EDS#93](https://github.com/Xaloqi/EDS/pull/93)) already tests.

## Verification

Docs-only. `build_tests.sh` (43/43), `build_harness.sh --run` (68/68), `cmake`/`ctest` (43/43) all unaffected. Swept both edited files with `gcc -Wcomment` to confirm no nested-comment issue was introduced — the same MISRA Rule 3.1 trap that's bitten this repo twice already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)