### PR TITLE
fix: regenerate all 12 example ECUs, closing template drift (EDS-toolchain#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **All 12 example ECUs regenerated from the current codegen template,
+  closing long-standing drift.** (EDS-toolchain#50) Two of the four
+  examples added at "Initial public release" — `ardep_ecu`, `bms_ecu`,
+  `motor_controller_ecu`, `sensor_ecu_freertos` — carried committed
+  `generated/` output that predated two real template fixes made months
+  earlier and never propagated: an ISO 26262 citation correction
+  (`§9.4.3` → `:2018 §7.4.12`, present in the other 8 examples already)
+  and `uds_comm_control_init()` Step 5.8, without which every SID 0x28
+  (CommunicationControl) and 0x85 (ControlDTCSetting) request on those 4
+  ECUs returned NRC 0x22 (`conditionsNotCorrect`) — a real functional
+  bug, not just stale documentation. Also picked up `UDS_STACK_VERSION`
+  catching up from a stale `1.0.0`/`1.6.0` to the current `1.7.0` on the
+  same 4 examples (the ECU's own version, e.g. `ARDEP_IOController
+  v1.0.0`, is unaffected — that's a separate field). The other 8
+  examples only picked up the ISO citation fix (they already had
+  CommunicationControl). Regenerated with the license-check bypass
+  (`XALOQI_LICENSE_SKIP=1`) and diffed every file in every example
+  against what was committed before touching anything — confirmed the
+  only differences anywhere are the two fixes above, the expected
+  per-generation timestamp, and the version bump; no DID/routine/safety
+  wrapper logic changed for any example. None of the 4 affected examples
+  are built by any CI job today (only `basic_ecu`, `basic_ecu_doip`,
+  `basic_ecu_freertos`, and `safeboot_freertos_ecu` are) — verified
+  correctness with a full host-side link of each against the real stack
+  instead (zero undefined references besides the expected missing
+  `main()`, which these init-sequence files don't define).
+
 ### Documentation
 
 - **Stale CI job-count comments corrected.** (#91) `.github/workflows/ci.yml`'s

--- a/examples/ardep_ecu/generated/did_handlers.c
+++ b/examples/ardep_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/ardep_ecu/generated/did_handlers.h
+++ b/examples/ardep_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/ardep_ecu/generated/did_safety_wrappers.c
+++ b/examples/ardep_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/ardep_ecu/generated/did_safety_wrappers.h
+++ b/examples/ardep_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/ardep_ecu/generated/generated_config.h
+++ b/examples/ardep_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "ARDEP_IOController"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-05-20T07:21:48Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:45Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/ardep_ecu/generated/routine_handlers.c
+++ b/examples/ardep_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: ARDEP_IOController  v1.0.0  Generated: 2026-05-20T07:21:48Z
+// ECU: ARDEP_IOController  v1.0.0  Generated: 2026-08-29T11:04:45Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/ardep_ecu/generated/routine_handlers.h
+++ b/examples/ardep_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: ARDEP_IOController  v1.0.0  Generated: 2026-05-20T07:21:48Z
+// ECU: ARDEP_IOController  v1.0.0  Generated: 2026-08-29T11:04:45Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/ardep_ecu/generated/safety_config.h
+++ b/examples/ardep_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.0.0"
+#define UDS_STACK_VERSION "1.7.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/ardep_ecu/generated/uds_init.c
+++ b/examples/ardep_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -21,7 +21,7 @@
  *
  *          Initialisation sequence (order is mandatory — do not reorder):
  *            1.  uds_safety_init()                — safety check engine (REQ-SAFE-005)
- *            1.1 uds_safety_self_test()           — ISO 26262-6 §9.4.3 pre-start self-test
+ *            1.1 uds_safety_self_test()           — ISO 26262-6:2018 §7.4.12 (safety mechanism — pre-start verification)
  *            2.  did_database_init()              — DID storage table
  *            3.  dtc_database_init()              — DTC storage table
  *            3.5 dtc_mirror_init()                — DTC NVM mirror module (REQ-DTC-NVM-01)
@@ -31,6 +31,7 @@
  *            5.5 dtc_mirror_load()                — restore DTC status from NVM (REQ-DTC-NVM-01)
  *            5.6 routine_handlers_register_all()  — populate routine table
  *            5.7 (flash ops — caller registers if DFU required)
+ *            5.8 uds_comm_control_init()          — SID 0x28 + 0x85 state machine
  *            6.  uds_session_init()               — session state machine
  *            7.  uds_security_init()              — seed/key state machine
  *            7.1 Production key + TRNG guard      — SEC-KEY-GATE-01 / SEC-TRNG-GATE-01
@@ -55,6 +56,7 @@
 #include "uds_security.h"
 #include "uds_security_algo.h"
 #include "uds_safety.h"
+#include "uds_comm_control.h"
 #include "uds_types.h"
 #include "services.h"
 #include "did_handlers.h"
@@ -141,7 +143,7 @@ uds_status_t uds_generated_init(
 
     /* ── Step 1.1: Safety module self-test ────────────────────────────────────────
      *
-     * [CRIT-2 FIX] ISO 26262-6 §9.4.3 requires a software component pre-start
+     * [CRIT-2 FIX] ISO 26262-6:2018 §7.4.12 (safety mechanisms) requires a pre-start
      * self-test for ASIL-B modules.  uds_safety_self_test() exercises each
      * safety check category (NULL ptr, request length, DTC status mask,
      * session validation) with known-good and known-bad inputs to confirm
@@ -158,7 +160,7 @@ uds_status_t uds_generated_init(
      * any database init, so the DID table is empty and no DTC is registered.
      * This is the state the self-test expects and was designed to run in.
      *
-     * TRACEABILITY: ISO 26262-6 §9.4.3 (REQ-SAFE-SELFTEST-01)
+     * TRACEABILITY: ISO 26262-6:2018 §7.4.12 (REQ-SAFE-SELFTEST-01)
      */
     {
         uds_safety_result_t self_test_rc = uds_safety_self_test();
@@ -474,6 +476,48 @@ uds_status_t uds_generated_init(
      * Then regenerate: python3 tools/codegen.py --config <yaml> --out generated/
      *                                            --safety-wrappers --asil-level B
      */
+    /* ── Step 5.8: Communication control + DTC setting state machine ──────
+     *
+     * Initialises the module that backs SID 0x28 (CommunicationControl) and
+     * SID 0x85 (ControlDTCSetting).  Without this call s_initialized is false
+     * and both services return NRC 0x22 (conditionsNotCorrect).
+     *
+     * Platform callbacks are OPTIONAL.  Passing NULL means:
+     *   - 0x28 responses succeed and the mode is tracked in software
+     *     (s_comm_mode), but no CAN filter is adjusted by the stack itself.
+     *   - 0x85 responses succeed and the flag is tracked (s_dtc_setting),
+     *     but no hardware DTC-storage gate is applied by the stack.
+     *
+     * OEM INTEGRATION: to wire real hardware behaviour, register callbacks
+     * before (or instead of) calling uds_generated_init():
+     *
+     *   static uds_status_t my_comm_cb(uds_comm_mode_t mode, uint8_t type) {
+     *       // adjust CAN filter — e.g. Zephyr: can_add_rx_filter / can_detach
+     *       return UDS_STATUS_OK;
+     *   }
+     *   static uds_status_t my_dtc_cb(uds_dtc_setting_mode_t mode) {
+     *       // gate DTC storage in the application
+     *       return UDS_STATUS_OK;
+     *   }
+     *   static const uds_comm_control_cfg_t k_comm_cfg = {
+     *       .comm_cb = my_comm_cb, .dtc_cb = my_dtc_cb };
+     *   uds_comm_control_init(&k_comm_cfg);
+     *   uds_generated_init(...);   // do NOT call uds_generated_init if
+     *                              // you already initialised comm_control
+     *
+     * TRACEABILITY: REQ-COMM-001, REQ-DTC-SET-001
+     */
+    {
+        static const uds_comm_control_cfg_t k_comm_cfg = {
+            .comm_cb = NULL,   /* OEM: wire platform CAN-filter callback here */
+            .dtc_cb  = NULL,   /* OEM: wire DTC-enable/disable callback here  */
+        };
+        status = uds_comm_control_init(&k_comm_cfg);
+        if (status != UDS_STATUS_OK) {
+            return status;
+        }
+    }
+
     /* ── Step 6: Session layer ─────────────────────────────────────────────
      *
      * Starts in UDS_SESSION_DEFAULT. S3server timer armed.

--- a/examples/ardep_ecu/generated/uds_init.h
+++ b/examples/ardep_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/basic_ecu/generated/did_handlers.c
+++ b/examples/basic_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-06-23T19:16:13Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/basic_ecu/generated/did_handlers.h
+++ b/examples/basic_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-06-23T19:16:13Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/basic_ecu/generated/did_safety_wrappers.c
+++ b/examples/basic_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-06-23T19:16:13Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/basic_ecu/generated/did_safety_wrappers.h
+++ b/examples/basic_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-06-23T19:16:13Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/basic_ecu/generated/generated_config.h
+++ b/examples/basic_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-06-23T19:16:13Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "BasicECU"
 #define GEN_ECU_VERSION         "0.1.0"
-#define GEN_GENERATED_TIMESTAMP "2026-06-23T19:16:13Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:45Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/basic_ecu/generated/routine_handlers.c
+++ b/examples/basic_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU  v0.1.0  Generated: 2026-06-23T19:16:13Z
+// ECU: BasicECU  v0.1.0  Generated: 2026-08-29T11:04:45Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/basic_ecu/generated/routine_handlers.h
+++ b/examples/basic_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU  v0.1.0  Generated: 2026-06-23T19:16:13Z
+// ECU: BasicECU  v0.1.0  Generated: 2026-08-29T11:04:45Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/basic_ecu/generated/safety_config.h
+++ b/examples/basic_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-06-23T19:16:13Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/basic_ecu/generated/uds_init.c
+++ b/examples/basic_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-06-23T19:16:13Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -21,7 +21,7 @@
  *
  *          Initialisation sequence (order is mandatory — do not reorder):
  *            1.  uds_safety_init()                — safety check engine (REQ-SAFE-005)
- *            1.1 uds_safety_self_test()           — ISO 26262-6 §9.4.3 pre-start self-test
+ *            1.1 uds_safety_self_test()           — ISO 26262-6:2018 §7.4.12 (safety mechanism — pre-start verification)
  *            2.  did_database_init()              — DID storage table
  *            3.  dtc_database_init()              — DTC storage table
  *            3.5 dtc_mirror_init()                — DTC NVM mirror module (REQ-DTC-NVM-01)
@@ -143,7 +143,7 @@ uds_status_t uds_generated_init(
 
     /* ── Step 1.1: Safety module self-test ────────────────────────────────────────
      *
-     * [CRIT-2 FIX] ISO 26262-6 §9.4.3 requires a software component pre-start
+     * [CRIT-2 FIX] ISO 26262-6:2018 §7.4.12 (safety mechanisms) requires a pre-start
      * self-test for ASIL-B modules.  uds_safety_self_test() exercises each
      * safety check category (NULL ptr, request length, DTC status mask,
      * session validation) with known-good and known-bad inputs to confirm
@@ -160,7 +160,7 @@ uds_status_t uds_generated_init(
      * any database init, so the DID table is empty and no DTC is registered.
      * This is the state the self-test expects and was designed to run in.
      *
-     * TRACEABILITY: ISO 26262-6 §9.4.3 (REQ-SAFE-SELFTEST-01)
+     * TRACEABILITY: ISO 26262-6:2018 §7.4.12 (REQ-SAFE-SELFTEST-01)
      */
     {
         uds_safety_result_t self_test_rc = uds_safety_self_test();

--- a/examples/basic_ecu/generated/uds_init.h
+++ b/examples/basic_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-06-23T19:16:13Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/basic_ecu_doip/generated/did_handlers.c
+++ b/examples/basic_ecu_doip/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-06-23T19:16:13Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/basic_ecu_doip/generated/did_handlers.h
+++ b/examples/basic_ecu_doip/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-06-23T19:16:13Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/basic_ecu_doip/generated/did_safety_wrappers.c
+++ b/examples/basic_ecu_doip/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-06-23T19:16:13Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/basic_ecu_doip/generated/did_safety_wrappers.h
+++ b/examples/basic_ecu_doip/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-06-23T19:16:13Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/basic_ecu_doip/generated/generated_config.h
+++ b/examples/basic_ecu_doip/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-06-23T19:16:13Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "BasicECU_DoIP"
 #define GEN_ECU_VERSION         "1.6.0"
-#define GEN_GENERATED_TIMESTAMP "2026-06-23T19:16:13Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:45Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/basic_ecu_doip/generated/routine_handlers.c
+++ b/examples/basic_ecu_doip/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU_DoIP  v1.6.0  Generated: 2026-06-23T19:16:13Z
+// ECU: BasicECU_DoIP  v1.6.0  Generated: 2026-08-29T11:04:45Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/basic_ecu_doip/generated/routine_handlers.h
+++ b/examples/basic_ecu_doip/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU_DoIP  v1.6.0  Generated: 2026-06-23T19:16:13Z
+// ECU: BasicECU_DoIP  v1.6.0  Generated: 2026-08-29T11:04:45Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/basic_ecu_doip/generated/safety_config.h
+++ b/examples/basic_ecu_doip/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-06-23T19:16:13Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/basic_ecu_doip/generated/uds_init.c
+++ b/examples/basic_ecu_doip/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-06-23T19:16:13Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -21,7 +21,7 @@
  *
  *          Initialisation sequence (order is mandatory — do not reorder):
  *            1.  uds_safety_init()                — safety check engine (REQ-SAFE-005)
- *            1.1 uds_safety_self_test()           — ISO 26262-6 §9.4.3 pre-start self-test
+ *            1.1 uds_safety_self_test()           — ISO 26262-6:2018 §7.4.12 (safety mechanism — pre-start verification)
  *            2.  did_database_init()              — DID storage table
  *            3.  dtc_database_init()              — DTC storage table
  *            3.5 dtc_mirror_init()                — DTC NVM mirror module (REQ-DTC-NVM-01)
@@ -143,7 +143,7 @@ uds_status_t uds_generated_init(
 
     /* ── Step 1.1: Safety module self-test ────────────────────────────────────────
      *
-     * [CRIT-2 FIX] ISO 26262-6 §9.4.3 requires a software component pre-start
+     * [CRIT-2 FIX] ISO 26262-6:2018 §7.4.12 (safety mechanisms) requires a pre-start
      * self-test for ASIL-B modules.  uds_safety_self_test() exercises each
      * safety check category (NULL ptr, request length, DTC status mask,
      * session validation) with known-good and known-bad inputs to confirm
@@ -160,7 +160,7 @@ uds_status_t uds_generated_init(
      * any database init, so the DID table is empty and no DTC is registered.
      * This is the state the self-test expects and was designed to run in.
      *
-     * TRACEABILITY: ISO 26262-6 §9.4.3 (REQ-SAFE-SELFTEST-01)
+     * TRACEABILITY: ISO 26262-6:2018 §7.4.12 (REQ-SAFE-SELFTEST-01)
      */
     {
         uds_safety_result_t self_test_rc = uds_safety_self_test();

--- a/examples/basic_ecu_doip/generated/uds_init.h
+++ b/examples/basic_ecu_doip/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-06-23T19:16:13Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/basic_ecu_doip_freertos/generated/did_handlers.c
+++ b/examples/basic_ecu_doip_freertos/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/basic_ecu_doip_freertos/generated/did_handlers.h
+++ b/examples/basic_ecu_doip_freertos/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/basic_ecu_doip_freertos/generated/did_safety_wrappers.c
+++ b/examples/basic_ecu_doip_freertos/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/basic_ecu_doip_freertos/generated/did_safety_wrappers.h
+++ b/examples/basic_ecu_doip_freertos/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/basic_ecu_doip_freertos/generated/generated_config.h
+++ b/examples/basic_ecu_doip_freertos/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "BasicECU_DoIP_FreeRTOS"
 #define GEN_ECU_VERSION         "1.6.0"
-#define GEN_GENERATED_TIMESTAMP "2026-06-23T19:16:14Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:45Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/basic_ecu_doip_freertos/generated/routine_handlers.c
+++ b/examples/basic_ecu_doip_freertos/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU_DoIP_FreeRTOS  v1.6.0  Generated: 2026-06-23T19:16:14Z
+// ECU: BasicECU_DoIP_FreeRTOS  v1.6.0  Generated: 2026-08-29T11:04:45Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/basic_ecu_doip_freertos/generated/routine_handlers.h
+++ b/examples/basic_ecu_doip_freertos/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU_DoIP_FreeRTOS  v1.6.0  Generated: 2026-06-23T19:16:14Z
+// ECU: BasicECU_DoIP_FreeRTOS  v1.6.0  Generated: 2026-08-29T11:04:45Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/basic_ecu_doip_freertos/generated/safety_config.h
+++ b/examples/basic_ecu_doip_freertos/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/basic_ecu_doip_freertos/generated/uds_init.c
+++ b/examples/basic_ecu_doip_freertos/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -21,7 +21,7 @@
  *
  *          Initialisation sequence (order is mandatory — do not reorder):
  *            1.  uds_safety_init()                — safety check engine (REQ-SAFE-005)
- *            1.1 uds_safety_self_test()           — ISO 26262-6 §9.4.3 pre-start self-test
+ *            1.1 uds_safety_self_test()           — ISO 26262-6:2018 §7.4.12 (safety mechanism — pre-start verification)
  *            2.  did_database_init()              — DID storage table
  *            3.  dtc_database_init()              — DTC storage table
  *            3.5 dtc_mirror_init()                — DTC NVM mirror module (REQ-DTC-NVM-01)
@@ -143,7 +143,7 @@ uds_status_t uds_generated_init(
 
     /* ── Step 1.1: Safety module self-test ────────────────────────────────────────
      *
-     * [CRIT-2 FIX] ISO 26262-6 §9.4.3 requires a software component pre-start
+     * [CRIT-2 FIX] ISO 26262-6:2018 §7.4.12 (safety mechanisms) requires a pre-start
      * self-test for ASIL-B modules.  uds_safety_self_test() exercises each
      * safety check category (NULL ptr, request length, DTC status mask,
      * session validation) with known-good and known-bad inputs to confirm
@@ -160,7 +160,7 @@ uds_status_t uds_generated_init(
      * any database init, so the DID table is empty and no DTC is registered.
      * This is the state the self-test expects and was designed to run in.
      *
-     * TRACEABILITY: ISO 26262-6 §9.4.3 (REQ-SAFE-SELFTEST-01)
+     * TRACEABILITY: ISO 26262-6:2018 §7.4.12 (REQ-SAFE-SELFTEST-01)
      */
     {
         uds_safety_result_t self_test_rc = uds_safety_self_test();

--- a/examples/basic_ecu_doip_freertos/generated/uds_init.h
+++ b/examples/basic_ecu_doip_freertos/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/basic_ecu_freertos/generated/did_handlers.c
+++ b/examples/basic_ecu_freertos/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/basic_ecu_freertos/generated/did_handlers.h
+++ b/examples/basic_ecu_freertos/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/basic_ecu_freertos/generated/did_safety_wrappers.c
+++ b/examples/basic_ecu_freertos/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/basic_ecu_freertos/generated/did_safety_wrappers.h
+++ b/examples/basic_ecu_freertos/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/basic_ecu_freertos/generated/generated_config.h
+++ b/examples/basic_ecu_freertos/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "BasicECU"
 #define GEN_ECU_VERSION         "0.1.0"
-#define GEN_GENERATED_TIMESTAMP "2026-06-23T19:16:14Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:45Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/basic_ecu_freertos/generated/routine_handlers.c
+++ b/examples/basic_ecu_freertos/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU  v0.1.0  Generated: 2026-06-23T19:16:14Z
+// ECU: BasicECU  v0.1.0  Generated: 2026-08-29T11:04:45Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/basic_ecu_freertos/generated/routine_handlers.h
+++ b/examples/basic_ecu_freertos/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU  v0.1.0  Generated: 2026-06-23T19:16:14Z
+// ECU: BasicECU  v0.1.0  Generated: 2026-08-29T11:04:45Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/basic_ecu_freertos/generated/safety_config.h
+++ b/examples/basic_ecu_freertos/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/basic_ecu_freertos/generated/uds_init.c
+++ b/examples/basic_ecu_freertos/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -21,7 +21,7 @@
  *
  *          Initialisation sequence (order is mandatory — do not reorder):
  *            1.  uds_safety_init()                — safety check engine (REQ-SAFE-005)
- *            1.1 uds_safety_self_test()           — ISO 26262-6 §9.4.3 pre-start self-test
+ *            1.1 uds_safety_self_test()           — ISO 26262-6:2018 §7.4.12 (safety mechanism — pre-start verification)
  *            2.  did_database_init()              — DID storage table
  *            3.  dtc_database_init()              — DTC storage table
  *            3.5 dtc_mirror_init()                — DTC NVM mirror module (REQ-DTC-NVM-01)
@@ -143,7 +143,7 @@ uds_status_t uds_generated_init(
 
     /* ── Step 1.1: Safety module self-test ────────────────────────────────────────
      *
-     * [CRIT-2 FIX] ISO 26262-6 §9.4.3 requires a software component pre-start
+     * [CRIT-2 FIX] ISO 26262-6:2018 §7.4.12 (safety mechanisms) requires a pre-start
      * self-test for ASIL-B modules.  uds_safety_self_test() exercises each
      * safety check category (NULL ptr, request length, DTC status mask,
      * session validation) with known-good and known-bad inputs to confirm
@@ -160,7 +160,7 @@ uds_status_t uds_generated_init(
      * any database init, so the DID table is empty and no DTC is registered.
      * This is the state the self-test expects and was designed to run in.
      *
-     * TRACEABILITY: ISO 26262-6 §9.4.3 (REQ-SAFE-SELFTEST-01)
+     * TRACEABILITY: ISO 26262-6:2018 §7.4.12 (REQ-SAFE-SELFTEST-01)
      */
     {
         uds_safety_result_t self_test_rc = uds_safety_self_test();

--- a/examples/basic_ecu_freertos/generated/uds_init.h
+++ b/examples/basic_ecu_freertos/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/bms_ecu/generated/did_handlers.c
+++ b/examples/bms_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/bms_ecu/generated/did_handlers.h
+++ b/examples/bms_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/bms_ecu/generated/did_safety_wrappers.c
+++ b/examples/bms_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/bms_ecu/generated/did_safety_wrappers.h
+++ b/examples/bms_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/bms_ecu/generated/generated_config.h
+++ b/examples/bms_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "BMS_MainController"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-05-20T07:21:48Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:45Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/bms_ecu/generated/routine_handlers.c
+++ b/examples/bms_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: BMS_MainController  v1.0.0  Generated: 2026-05-20T07:21:48Z
+// ECU: BMS_MainController  v1.0.0  Generated: 2026-08-29T11:04:45Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/bms_ecu/generated/routine_handlers.h
+++ b/examples/bms_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: BMS_MainController  v1.0.0  Generated: 2026-05-20T07:21:48Z
+// ECU: BMS_MainController  v1.0.0  Generated: 2026-08-29T11:04:45Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/bms_ecu/generated/safety_config.h
+++ b/examples/bms_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.0.0"
+#define UDS_STACK_VERSION "1.7.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/bms_ecu/generated/uds_init.c
+++ b/examples/bms_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -21,7 +21,7 @@
  *
  *          Initialisation sequence (order is mandatory — do not reorder):
  *            1.  uds_safety_init()                — safety check engine (REQ-SAFE-005)
- *            1.1 uds_safety_self_test()           — ISO 26262-6 §9.4.3 pre-start self-test
+ *            1.1 uds_safety_self_test()           — ISO 26262-6:2018 §7.4.12 (safety mechanism — pre-start verification)
  *            2.  did_database_init()              — DID storage table
  *            3.  dtc_database_init()              — DTC storage table
  *            3.5 dtc_mirror_init()                — DTC NVM mirror module (REQ-DTC-NVM-01)
@@ -31,6 +31,7 @@
  *            5.5 dtc_mirror_load()                — restore DTC status from NVM (REQ-DTC-NVM-01)
  *            5.6 routine_handlers_register_all()  — populate routine table
  *            5.7 (flash ops — caller registers if DFU required)
+ *            5.8 uds_comm_control_init()          — SID 0x28 + 0x85 state machine
  *            6.  uds_session_init()               — session state machine
  *            7.  uds_security_init()              — seed/key state machine
  *            7.1 Production key + TRNG guard      — SEC-KEY-GATE-01 / SEC-TRNG-GATE-01
@@ -55,6 +56,7 @@
 #include "uds_security.h"
 #include "uds_security_algo.h"
 #include "uds_safety.h"
+#include "uds_comm_control.h"
 #include "uds_types.h"
 #include "services.h"
 #include "did_handlers.h"
@@ -141,7 +143,7 @@ uds_status_t uds_generated_init(
 
     /* ── Step 1.1: Safety module self-test ────────────────────────────────────────
      *
-     * [CRIT-2 FIX] ISO 26262-6 §9.4.3 requires a software component pre-start
+     * [CRIT-2 FIX] ISO 26262-6:2018 §7.4.12 (safety mechanisms) requires a pre-start
      * self-test for ASIL-B modules.  uds_safety_self_test() exercises each
      * safety check category (NULL ptr, request length, DTC status mask,
      * session validation) with known-good and known-bad inputs to confirm
@@ -158,7 +160,7 @@ uds_status_t uds_generated_init(
      * any database init, so the DID table is empty and no DTC is registered.
      * This is the state the self-test expects and was designed to run in.
      *
-     * TRACEABILITY: ISO 26262-6 §9.4.3 (REQ-SAFE-SELFTEST-01)
+     * TRACEABILITY: ISO 26262-6:2018 §7.4.12 (REQ-SAFE-SELFTEST-01)
      */
     {
         uds_safety_result_t self_test_rc = uds_safety_self_test();
@@ -393,6 +395,48 @@ uds_status_t uds_generated_init(
      * Then regenerate: python3 tools/codegen.py --config <yaml> --out generated/
      *                                            --safety-wrappers --asil-level B
      */
+    /* ── Step 5.8: Communication control + DTC setting state machine ──────
+     *
+     * Initialises the module that backs SID 0x28 (CommunicationControl) and
+     * SID 0x85 (ControlDTCSetting).  Without this call s_initialized is false
+     * and both services return NRC 0x22 (conditionsNotCorrect).
+     *
+     * Platform callbacks are OPTIONAL.  Passing NULL means:
+     *   - 0x28 responses succeed and the mode is tracked in software
+     *     (s_comm_mode), but no CAN filter is adjusted by the stack itself.
+     *   - 0x85 responses succeed and the flag is tracked (s_dtc_setting),
+     *     but no hardware DTC-storage gate is applied by the stack.
+     *
+     * OEM INTEGRATION: to wire real hardware behaviour, register callbacks
+     * before (or instead of) calling uds_generated_init():
+     *
+     *   static uds_status_t my_comm_cb(uds_comm_mode_t mode, uint8_t type) {
+     *       // adjust CAN filter — e.g. Zephyr: can_add_rx_filter / can_detach
+     *       return UDS_STATUS_OK;
+     *   }
+     *   static uds_status_t my_dtc_cb(uds_dtc_setting_mode_t mode) {
+     *       // gate DTC storage in the application
+     *       return UDS_STATUS_OK;
+     *   }
+     *   static const uds_comm_control_cfg_t k_comm_cfg = {
+     *       .comm_cb = my_comm_cb, .dtc_cb = my_dtc_cb };
+     *   uds_comm_control_init(&k_comm_cfg);
+     *   uds_generated_init(...);   // do NOT call uds_generated_init if
+     *                              // you already initialised comm_control
+     *
+     * TRACEABILITY: REQ-COMM-001, REQ-DTC-SET-001
+     */
+    {
+        static const uds_comm_control_cfg_t k_comm_cfg = {
+            .comm_cb = NULL,   /* OEM: wire platform CAN-filter callback here */
+            .dtc_cb  = NULL,   /* OEM: wire DTC-enable/disable callback here  */
+        };
+        status = uds_comm_control_init(&k_comm_cfg);
+        if (status != UDS_STATUS_OK) {
+            return status;
+        }
+    }
+
     /* ── Step 6: Session layer ─────────────────────────────────────────────
      *
      * Starts in UDS_SESSION_DEFAULT. S3server timer armed.

--- a/examples/bms_ecu/generated/uds_init.h
+++ b/examples/bms_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/motor_controller_ecu/generated/did_handlers.c
+++ b/examples/motor_controller_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/motor_controller_ecu/generated/did_handlers.h
+++ b/examples/motor_controller_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/motor_controller_ecu/generated/did_safety_wrappers.c
+++ b/examples/motor_controller_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/motor_controller_ecu/generated/did_safety_wrappers.h
+++ b/examples/motor_controller_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/motor_controller_ecu/generated/generated_config.h
+++ b/examples/motor_controller_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "MotorController_Inverter"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-05-20T07:21:48Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:45Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/motor_controller_ecu/generated/routine_handlers.c
+++ b/examples/motor_controller_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: MotorController_Inverter  v1.0.0  Generated: 2026-05-20T07:21:48Z
+// ECU: MotorController_Inverter  v1.0.0  Generated: 2026-08-29T11:04:45Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/motor_controller_ecu/generated/routine_handlers.h
+++ b/examples/motor_controller_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: MotorController_Inverter  v1.0.0  Generated: 2026-05-20T07:21:48Z
+// ECU: MotorController_Inverter  v1.0.0  Generated: 2026-08-29T11:04:45Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/motor_controller_ecu/generated/safety_config.h
+++ b/examples/motor_controller_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.0.0"
+#define UDS_STACK_VERSION "1.7.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/motor_controller_ecu/generated/uds_init.c
+++ b/examples/motor_controller_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -21,7 +21,7 @@
  *
  *          Initialisation sequence (order is mandatory — do not reorder):
  *            1.  uds_safety_init()                — safety check engine (REQ-SAFE-005)
- *            1.1 uds_safety_self_test()           — ISO 26262-6 §9.4.3 pre-start self-test
+ *            1.1 uds_safety_self_test()           — ISO 26262-6:2018 §7.4.12 (safety mechanism — pre-start verification)
  *            2.  did_database_init()              — DID storage table
  *            3.  dtc_database_init()              — DTC storage table
  *            3.5 dtc_mirror_init()                — DTC NVM mirror module (REQ-DTC-NVM-01)
@@ -31,6 +31,7 @@
  *            5.5 dtc_mirror_load()                — restore DTC status from NVM (REQ-DTC-NVM-01)
  *            5.6 routine_handlers_register_all()  — populate routine table
  *            5.7 (flash ops — caller registers if DFU required)
+ *            5.8 uds_comm_control_init()          — SID 0x28 + 0x85 state machine
  *            6.  uds_session_init()               — session state machine
  *            7.  uds_security_init()              — seed/key state machine
  *            7.1 Production key + TRNG guard      — SEC-KEY-GATE-01 / SEC-TRNG-GATE-01
@@ -55,6 +56,7 @@
 #include "uds_security.h"
 #include "uds_security_algo.h"
 #include "uds_safety.h"
+#include "uds_comm_control.h"
 #include "uds_types.h"
 #include "services.h"
 #include "did_handlers.h"
@@ -141,7 +143,7 @@ uds_status_t uds_generated_init(
 
     /* ── Step 1.1: Safety module self-test ────────────────────────────────────────
      *
-     * [CRIT-2 FIX] ISO 26262-6 §9.4.3 requires a software component pre-start
+     * [CRIT-2 FIX] ISO 26262-6:2018 §7.4.12 (safety mechanisms) requires a pre-start
      * self-test for ASIL-B modules.  uds_safety_self_test() exercises each
      * safety check category (NULL ptr, request length, DTC status mask,
      * session validation) with known-good and known-bad inputs to confirm
@@ -158,7 +160,7 @@ uds_status_t uds_generated_init(
      * any database init, so the DID table is empty and no DTC is registered.
      * This is the state the self-test expects and was designed to run in.
      *
-     * TRACEABILITY: ISO 26262-6 §9.4.3 (REQ-SAFE-SELFTEST-01)
+     * TRACEABILITY: ISO 26262-6:2018 §7.4.12 (REQ-SAFE-SELFTEST-01)
      */
     {
         uds_safety_result_t self_test_rc = uds_safety_self_test();
@@ -393,6 +395,48 @@ uds_status_t uds_generated_init(
      * Then regenerate: python3 tools/codegen.py --config <yaml> --out generated/
      *                                            --safety-wrappers --asil-level B
      */
+    /* ── Step 5.8: Communication control + DTC setting state machine ──────
+     *
+     * Initialises the module that backs SID 0x28 (CommunicationControl) and
+     * SID 0x85 (ControlDTCSetting).  Without this call s_initialized is false
+     * and both services return NRC 0x22 (conditionsNotCorrect).
+     *
+     * Platform callbacks are OPTIONAL.  Passing NULL means:
+     *   - 0x28 responses succeed and the mode is tracked in software
+     *     (s_comm_mode), but no CAN filter is adjusted by the stack itself.
+     *   - 0x85 responses succeed and the flag is tracked (s_dtc_setting),
+     *     but no hardware DTC-storage gate is applied by the stack.
+     *
+     * OEM INTEGRATION: to wire real hardware behaviour, register callbacks
+     * before (or instead of) calling uds_generated_init():
+     *
+     *   static uds_status_t my_comm_cb(uds_comm_mode_t mode, uint8_t type) {
+     *       // adjust CAN filter — e.g. Zephyr: can_add_rx_filter / can_detach
+     *       return UDS_STATUS_OK;
+     *   }
+     *   static uds_status_t my_dtc_cb(uds_dtc_setting_mode_t mode) {
+     *       // gate DTC storage in the application
+     *       return UDS_STATUS_OK;
+     *   }
+     *   static const uds_comm_control_cfg_t k_comm_cfg = {
+     *       .comm_cb = my_comm_cb, .dtc_cb = my_dtc_cb };
+     *   uds_comm_control_init(&k_comm_cfg);
+     *   uds_generated_init(...);   // do NOT call uds_generated_init if
+     *                              // you already initialised comm_control
+     *
+     * TRACEABILITY: REQ-COMM-001, REQ-DTC-SET-001
+     */
+    {
+        static const uds_comm_control_cfg_t k_comm_cfg = {
+            .comm_cb = NULL,   /* OEM: wire platform CAN-filter callback here */
+            .dtc_cb  = NULL,   /* OEM: wire DTC-enable/disable callback here  */
+        };
+        status = uds_comm_control_init(&k_comm_cfg);
+        if (status != UDS_STATUS_OK) {
+            return status;
+        }
+    }
+
     /* ── Step 6: Session layer ─────────────────────────────────────────────
      *
      * Starts in UDS_SESSION_DEFAULT. S3server timer armed.

--- a/examples/motor_controller_ecu/generated/uds_init.h
+++ b/examples/motor_controller_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:48Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/robot_joint_controller_ecu/generated/did_handlers.c
+++ b/examples/robot_joint_controller_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/robot_joint_controller_ecu/generated/did_handlers.h
+++ b/examples/robot_joint_controller_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/robot_joint_controller_ecu/generated/did_safety_wrappers.c
+++ b/examples/robot_joint_controller_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/robot_joint_controller_ecu/generated/did_safety_wrappers.h
+++ b/examples/robot_joint_controller_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/robot_joint_controller_ecu/generated/generated_config.h
+++ b/examples/robot_joint_controller_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "RobotJointController"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-06-23T19:16:15Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:45Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/robot_joint_controller_ecu/generated/routine_handlers.c
+++ b/examples/robot_joint_controller_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: RobotJointController  v1.0.0  Generated: 2026-06-23T19:16:15Z
+// ECU: RobotJointController  v1.0.0  Generated: 2026-08-29T11:04:45Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/robot_joint_controller_ecu/generated/routine_handlers.h
+++ b/examples/robot_joint_controller_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: RobotJointController  v1.0.0  Generated: 2026-06-23T19:16:15Z
+// ECU: RobotJointController  v1.0.0  Generated: 2026-08-29T11:04:45Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/robot_joint_controller_ecu/generated/safety_config.h
+++ b/examples/robot_joint_controller_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/robot_joint_controller_ecu/generated/uds_init.c
+++ b/examples/robot_joint_controller_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -21,7 +21,7 @@
  *
  *          Initialisation sequence (order is mandatory — do not reorder):
  *            1.  uds_safety_init()                — safety check engine (REQ-SAFE-005)
- *            1.1 uds_safety_self_test()           — ISO 26262-6 §9.4.3 pre-start self-test
+ *            1.1 uds_safety_self_test()           — ISO 26262-6:2018 §7.4.12 (safety mechanism — pre-start verification)
  *            2.  did_database_init()              — DID storage table
  *            3.  dtc_database_init()              — DTC storage table
  *            3.5 dtc_mirror_init()                — DTC NVM mirror module (REQ-DTC-NVM-01)
@@ -143,7 +143,7 @@ uds_status_t uds_generated_init(
 
     /* ── Step 1.1: Safety module self-test ────────────────────────────────────────
      *
-     * [CRIT-2 FIX] ISO 26262-6 §9.4.3 requires a software component pre-start
+     * [CRIT-2 FIX] ISO 26262-6:2018 §7.4.12 (safety mechanisms) requires a pre-start
      * self-test for ASIL-B modules.  uds_safety_self_test() exercises each
      * safety check category (NULL ptr, request length, DTC status mask,
      * session validation) with known-good and known-bad inputs to confirm
@@ -160,7 +160,7 @@ uds_status_t uds_generated_init(
      * any database init, so the DID table is empty and no DTC is registered.
      * This is the state the self-test expects and was designed to run in.
      *
-     * TRACEABILITY: ISO 26262-6 §9.4.3 (REQ-SAFE-SELFTEST-01)
+     * TRACEABILITY: ISO 26262-6:2018 §7.4.12 (REQ-SAFE-SELFTEST-01)
      */
     {
         uds_safety_result_t self_test_rc = uds_safety_self_test();

--- a/examples/robot_joint_controller_ecu/generated/uds_init.h
+++ b/examples/robot_joint_controller_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/safeboot_ecu/generated/did_handlers.c
+++ b/examples/safeboot_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/safeboot_ecu/generated/did_handlers.h
+++ b/examples/safeboot_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/safeboot_ecu/generated/did_safety_wrappers.c
+++ b/examples/safeboot_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/safeboot_ecu/generated/did_safety_wrappers.h
+++ b/examples/safeboot_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/safeboot_ecu/generated/generated_config.h
+++ b/examples/safeboot_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "SafeBootECU"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-06-23T19:16:15Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:45Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/safeboot_ecu/generated/routine_handlers.c
+++ b/examples/safeboot_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: SafeBootECU  v1.0.0  Generated: 2026-06-23T19:16:15Z
+// ECU: SafeBootECU  v1.0.0  Generated: 2026-08-29T11:04:45Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/safeboot_ecu/generated/routine_handlers.h
+++ b/examples/safeboot_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: SafeBootECU  v1.0.0  Generated: 2026-06-23T19:16:15Z
+// ECU: SafeBootECU  v1.0.0  Generated: 2026-08-29T11:04:45Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/safeboot_ecu/generated/safety_config.h
+++ b/examples/safeboot_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:45Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/safeboot_ecu/generated/uds_init.c
+++ b/examples/safeboot_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -21,7 +21,7 @@
  *
  *          Initialisation sequence (order is mandatory — do not reorder):
  *            1.  uds_safety_init()                — safety check engine (REQ-SAFE-005)
- *            1.1 uds_safety_self_test()           — ISO 26262-6 §9.4.3 pre-start self-test
+ *            1.1 uds_safety_self_test()           — ISO 26262-6:2018 §7.4.12 (safety mechanism — pre-start verification)
  *            2.  did_database_init()              — DID storage table
  *            3.  dtc_database_init()              — DTC storage table
  *            3.5 dtc_mirror_init()                — DTC NVM mirror module (REQ-DTC-NVM-01)
@@ -145,7 +145,7 @@ uds_status_t uds_generated_init(
 
     /* ── Step 1.1: Safety module self-test ────────────────────────────────────────
      *
-     * [CRIT-2 FIX] ISO 26262-6 §9.4.3 requires a software component pre-start
+     * [CRIT-2 FIX] ISO 26262-6:2018 §7.4.12 (safety mechanisms) requires a pre-start
      * self-test for ASIL-B modules.  uds_safety_self_test() exercises each
      * safety check category (NULL ptr, request length, DTC status mask,
      * session validation) with known-good and known-bad inputs to confirm
@@ -162,7 +162,7 @@ uds_status_t uds_generated_init(
      * any database init, so the DID table is empty and no DTC is registered.
      * This is the state the self-test expects and was designed to run in.
      *
-     * TRACEABILITY: ISO 26262-6 §9.4.3 (REQ-SAFE-SELFTEST-01)
+     * TRACEABILITY: ISO 26262-6:2018 §7.4.12 (REQ-SAFE-SELFTEST-01)
      */
     {
         uds_safety_result_t self_test_rc = uds_safety_self_test();

--- a/examples/safeboot_ecu/generated/uds_init.h
+++ b/examples/safeboot_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:45Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/safeboot_freertos_ecu/generated/did_handlers.c
+++ b/examples/safeboot_freertos_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootFreeRTOSECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:46Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/safeboot_freertos_ecu/generated/did_handlers.h
+++ b/examples/safeboot_freertos_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootFreeRTOSECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:46Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/safeboot_freertos_ecu/generated/did_safety_wrappers.c
+++ b/examples/safeboot_freertos_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootFreeRTOSECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:46Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/safeboot_freertos_ecu/generated/did_safety_wrappers.h
+++ b/examples/safeboot_freertos_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootFreeRTOSECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:46Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/safeboot_freertos_ecu/generated/generated_config.h
+++ b/examples/safeboot_freertos_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootFreeRTOSECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:46Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "SafeBootFreeRTOSECU"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-06-23T19:16:15Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:46Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/safeboot_freertos_ecu/generated/routine_handlers.c
+++ b/examples/safeboot_freertos_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: SafeBootFreeRTOSECU  v1.0.0  Generated: 2026-06-23T19:16:15Z
+// ECU: SafeBootFreeRTOSECU  v1.0.0  Generated: 2026-08-29T11:04:46Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/safeboot_freertos_ecu/generated/routine_handlers.h
+++ b/examples/safeboot_freertos_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: SafeBootFreeRTOSECU  v1.0.0  Generated: 2026-06-23T19:16:15Z
+// ECU: SafeBootFreeRTOSECU  v1.0.0  Generated: 2026-08-29T11:04:46Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/safeboot_freertos_ecu/generated/safety_config.h
+++ b/examples/safeboot_freertos_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootFreeRTOSECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:46Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/safeboot_freertos_ecu/generated/uds_init.c
+++ b/examples/safeboot_freertos_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootFreeRTOSECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:46Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -21,7 +21,7 @@
  *
  *          Initialisation sequence (order is mandatory — do not reorder):
  *            1.  uds_safety_init()                — safety check engine (REQ-SAFE-005)
- *            1.1 uds_safety_self_test()           — ISO 26262-6 §9.4.3 pre-start self-test
+ *            1.1 uds_safety_self_test()           — ISO 26262-6:2018 §7.4.12 (safety mechanism — pre-start verification)
  *            2.  did_database_init()              — DID storage table
  *            3.  dtc_database_init()              — DTC storage table
  *            3.5 dtc_mirror_init()                — DTC NVM mirror module (REQ-DTC-NVM-01)
@@ -145,7 +145,7 @@ uds_status_t uds_generated_init(
 
     /* ── Step 1.1: Safety module self-test ────────────────────────────────────────
      *
-     * [CRIT-2 FIX] ISO 26262-6 §9.4.3 requires a software component pre-start
+     * [CRIT-2 FIX] ISO 26262-6:2018 §7.4.12 (safety mechanisms) requires a pre-start
      * self-test for ASIL-B modules.  uds_safety_self_test() exercises each
      * safety check category (NULL ptr, request length, DTC status mask,
      * session validation) with known-good and known-bad inputs to confirm
@@ -162,7 +162,7 @@ uds_status_t uds_generated_init(
      * any database init, so the DID table is empty and no DTC is registered.
      * This is the state the self-test expects and was designed to run in.
      *
-     * TRACEABILITY: ISO 26262-6 §9.4.3 (REQ-SAFE-SELFTEST-01)
+     * TRACEABILITY: ISO 26262-6:2018 §7.4.12 (REQ-SAFE-SELFTEST-01)
      */
     {
         uds_safety_result_t self_test_rc = uds_safety_self_test();

--- a/examples/safeboot_freertos_ecu/generated/uds_init.h
+++ b/examples/safeboot_freertos_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootFreeRTOSECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:15Z
+ * Generated : 2026-08-29T11:04:46Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/sensor_ecu/generated/did_handlers.c
+++ b/examples/sensor_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:46Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/sensor_ecu/generated/did_handlers.h
+++ b/examples/sensor_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:46Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/sensor_ecu/generated/did_safety_wrappers.c
+++ b/examples/sensor_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:46Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/sensor_ecu/generated/did_safety_wrappers.h
+++ b/examples/sensor_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:46Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/sensor_ecu/generated/generated_config.h
+++ b/examples/sensor_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:46Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "SensorECU"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-06-23T19:16:14Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:46Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/sensor_ecu/generated/routine_handlers.c
+++ b/examples/sensor_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: SensorECU  v1.0.0  Generated: 2026-06-23T19:16:14Z
+// ECU: SensorECU  v1.0.0  Generated: 2026-08-29T11:04:46Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/sensor_ecu/generated/routine_handlers.h
+++ b/examples/sensor_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: SensorECU  v1.0.0  Generated: 2026-06-23T19:16:14Z
+// ECU: SensorECU  v1.0.0  Generated: 2026-08-29T11:04:46Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/sensor_ecu/generated/safety_config.h
+++ b/examples/sensor_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:46Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/sensor_ecu/generated/uds_init.c
+++ b/examples/sensor_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:46Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -21,7 +21,7 @@
  *
  *          Initialisation sequence (order is mandatory — do not reorder):
  *            1.  uds_safety_init()                — safety check engine (REQ-SAFE-005)
- *            1.1 uds_safety_self_test()           — ISO 26262-6 §9.4.3 pre-start self-test
+ *            1.1 uds_safety_self_test()           — ISO 26262-6:2018 §7.4.12 (safety mechanism — pre-start verification)
  *            2.  did_database_init()              — DID storage table
  *            3.  dtc_database_init()              — DTC storage table
  *            3.5 dtc_mirror_init()                — DTC NVM mirror module (REQ-DTC-NVM-01)
@@ -143,7 +143,7 @@ uds_status_t uds_generated_init(
 
     /* ── Step 1.1: Safety module self-test ────────────────────────────────────────
      *
-     * [CRIT-2 FIX] ISO 26262-6 §9.4.3 requires a software component pre-start
+     * [CRIT-2 FIX] ISO 26262-6:2018 §7.4.12 (safety mechanisms) requires a pre-start
      * self-test for ASIL-B modules.  uds_safety_self_test() exercises each
      * safety check category (NULL ptr, request length, DTC status mask,
      * session validation) with known-good and known-bad inputs to confirm
@@ -160,7 +160,7 @@ uds_status_t uds_generated_init(
      * any database init, so the DID table is empty and no DTC is registered.
      * This is the state the self-test expects and was designed to run in.
      *
-     * TRACEABILITY: ISO 26262-6 §9.4.3 (REQ-SAFE-SELFTEST-01)
+     * TRACEABILITY: ISO 26262-6:2018 §7.4.12 (REQ-SAFE-SELFTEST-01)
      */
     {
         uds_safety_result_t self_test_rc = uds_safety_self_test();

--- a/examples/sensor_ecu/generated/uds_init.h
+++ b/examples/sensor_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-06-23T19:16:14Z
+ * Generated : 2026-08-29T11:04:46Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/sensor_ecu_freertos/generated/did_handlers.c
+++ b/examples/sensor_ecu_freertos/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:49Z
+ * Generated : 2026-08-29T11:04:46Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/sensor_ecu_freertos/generated/did_handlers.h
+++ b/examples/sensor_ecu_freertos/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:49Z
+ * Generated : 2026-08-29T11:04:46Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/sensor_ecu_freertos/generated/did_safety_wrappers.c
+++ b/examples/sensor_ecu_freertos/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:49Z
+ * Generated : 2026-08-29T11:04:46Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/sensor_ecu_freertos/generated/did_safety_wrappers.h
+++ b/examples/sensor_ecu_freertos/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:49Z
+ * Generated : 2026-08-29T11:04:46Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/sensor_ecu_freertos/generated/generated_config.h
+++ b/examples/sensor_ecu_freertos/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:49Z
+ * Generated : 2026-08-29T11:04:46Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "SensorECU"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-05-20T07:21:49Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:46Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/sensor_ecu_freertos/generated/routine_handlers.c
+++ b/examples/sensor_ecu_freertos/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: SensorECU  v1.0.0  Generated: 2026-05-20T07:21:49Z
+// ECU: SensorECU  v1.0.0  Generated: 2026-08-29T11:04:46Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/sensor_ecu_freertos/generated/routine_handlers.h
+++ b/examples/sensor_ecu_freertos/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: SensorECU  v1.0.0  Generated: 2026-05-20T07:21:49Z
+// ECU: SensorECU  v1.0.0  Generated: 2026-08-29T11:04:46Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/sensor_ecu_freertos/generated/safety_config.h
+++ b/examples/sensor_ecu_freertos/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:49Z
+ * Generated : 2026-08-29T11:04:46Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.0.0"
+#define UDS_STACK_VERSION "1.7.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/sensor_ecu_freertos/generated/uds_init.c
+++ b/examples/sensor_ecu_freertos/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:49Z
+ * Generated : 2026-08-29T11:04:46Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -21,7 +21,7 @@
  *
  *          Initialisation sequence (order is mandatory — do not reorder):
  *            1.  uds_safety_init()                — safety check engine (REQ-SAFE-005)
- *            1.1 uds_safety_self_test()           — ISO 26262-6 §9.4.3 pre-start self-test
+ *            1.1 uds_safety_self_test()           — ISO 26262-6:2018 §7.4.12 (safety mechanism — pre-start verification)
  *            2.  did_database_init()              — DID storage table
  *            3.  dtc_database_init()              — DTC storage table
  *            3.5 dtc_mirror_init()                — DTC NVM mirror module (REQ-DTC-NVM-01)
@@ -31,6 +31,7 @@
  *            5.5 dtc_mirror_load()                — restore DTC status from NVM (REQ-DTC-NVM-01)
  *            5.6 routine_handlers_register_all()  — populate routine table
  *            5.7 (flash ops — caller registers if DFU required)
+ *            5.8 uds_comm_control_init()          — SID 0x28 + 0x85 state machine
  *            6.  uds_session_init()               — session state machine
  *            7.  uds_security_init()              — seed/key state machine
  *            7.1 Production key + TRNG guard      — SEC-KEY-GATE-01 / SEC-TRNG-GATE-01
@@ -55,6 +56,7 @@
 #include "uds_security.h"
 #include "uds_security_algo.h"
 #include "uds_safety.h"
+#include "uds_comm_control.h"
 #include "uds_types.h"
 #include "services.h"
 #include "did_handlers.h"
@@ -141,7 +143,7 @@ uds_status_t uds_generated_init(
 
     /* ── Step 1.1: Safety module self-test ────────────────────────────────────────
      *
-     * [CRIT-2 FIX] ISO 26262-6 §9.4.3 requires a software component pre-start
+     * [CRIT-2 FIX] ISO 26262-6:2018 §7.4.12 (safety mechanisms) requires a pre-start
      * self-test for ASIL-B modules.  uds_safety_self_test() exercises each
      * safety check category (NULL ptr, request length, DTC status mask,
      * session validation) with known-good and known-bad inputs to confirm
@@ -158,7 +160,7 @@ uds_status_t uds_generated_init(
      * any database init, so the DID table is empty and no DTC is registered.
      * This is the state the self-test expects and was designed to run in.
      *
-     * TRACEABILITY: ISO 26262-6 §9.4.3 (REQ-SAFE-SELFTEST-01)
+     * TRACEABILITY: ISO 26262-6:2018 §7.4.12 (REQ-SAFE-SELFTEST-01)
      */
     {
         uds_safety_result_t self_test_rc = uds_safety_self_test();
@@ -339,6 +341,48 @@ uds_status_t uds_generated_init(
      * Then regenerate: python3 tools/codegen.py --config <yaml> --out generated/
      *                                            --safety-wrappers --asil-level B
      */
+    /* ── Step 5.8: Communication control + DTC setting state machine ──────
+     *
+     * Initialises the module that backs SID 0x28 (CommunicationControl) and
+     * SID 0x85 (ControlDTCSetting).  Without this call s_initialized is false
+     * and both services return NRC 0x22 (conditionsNotCorrect).
+     *
+     * Platform callbacks are OPTIONAL.  Passing NULL means:
+     *   - 0x28 responses succeed and the mode is tracked in software
+     *     (s_comm_mode), but no CAN filter is adjusted by the stack itself.
+     *   - 0x85 responses succeed and the flag is tracked (s_dtc_setting),
+     *     but no hardware DTC-storage gate is applied by the stack.
+     *
+     * OEM INTEGRATION: to wire real hardware behaviour, register callbacks
+     * before (or instead of) calling uds_generated_init():
+     *
+     *   static uds_status_t my_comm_cb(uds_comm_mode_t mode, uint8_t type) {
+     *       // adjust CAN filter — e.g. Zephyr: can_add_rx_filter / can_detach
+     *       return UDS_STATUS_OK;
+     *   }
+     *   static uds_status_t my_dtc_cb(uds_dtc_setting_mode_t mode) {
+     *       // gate DTC storage in the application
+     *       return UDS_STATUS_OK;
+     *   }
+     *   static const uds_comm_control_cfg_t k_comm_cfg = {
+     *       .comm_cb = my_comm_cb, .dtc_cb = my_dtc_cb };
+     *   uds_comm_control_init(&k_comm_cfg);
+     *   uds_generated_init(...);   // do NOT call uds_generated_init if
+     *                              // you already initialised comm_control
+     *
+     * TRACEABILITY: REQ-COMM-001, REQ-DTC-SET-001
+     */
+    {
+        static const uds_comm_control_cfg_t k_comm_cfg = {
+            .comm_cb = NULL,   /* OEM: wire platform CAN-filter callback here */
+            .dtc_cb  = NULL,   /* OEM: wire DTC-enable/disable callback here  */
+        };
+        status = uds_comm_control_init(&k_comm_cfg);
+        if (status != UDS_STATUS_OK) {
+            return status;
+        }
+    }
+
     /* ── Step 6: Session layer ─────────────────────────────────────────────
      *
      * Starts in UDS_SESSION_DEFAULT. S3server timer armed.

--- a/examples/sensor_ecu_freertos/generated/uds_init.h
+++ b/examples/sensor_ecu_freertos/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-05-20T07:21:49Z
+ * Generated : 2026-08-29T11:04:46Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *


### PR DESCRIPTION
Closes the template/committed-output drift found while regenerating `uds_init.c` for #84.

## What had drifted

1. **All 12 examples**: an ISO 26262 citation correction (`§9.4.3` → `:2018 §7.4.12`) made in the private EDS-toolchain template months ago ([0204e13](https://github.com/Xaloqi/EDS-toolchain/commit/0204e1309315a1f65b34315649c2ace72482ac1f)) but never propagated here via a regeneration + commit.
2. **4 of 12** (`ardep_ecu`, `bms_ecu`, `motor_controller_ecu`, `sensor_ecu_freertos`): missing `uds_comm_control_init()` Step 5.8 entirely. This was added to the template as a **real bug fix** ([2feee84](https://github.com/Xaloqi/EDS-toolchain/commit/2feee84b9741351fc7ec75fbcea41b675c589bf5)): without it, every SID 0x28 (CommunicationControl) and 0x85 (ControlDTCSetting) request on these 4 ECUs returns NRC 0x22 (`conditionsNotCorrect`) — not just stale docs, a functional defect sitting in public example code.

I confirmed these 4 examples' own copies in EDS-toolchain are equally stale (a single "Add files via upload" commit each, never regenerated since) — they were added to the public repo from an already-outdated snapshot, never actually produced by the current template.

## How this was regenerated safely

Copied the current (already `#84`-fixed) toolchain template in locally — gitignored, never committed, per issue #67's "never symlink `tools/templates`" rule — and ran `XALOQI_LICENSE_SKIP=1 python3 tools/codegen.py` for all 12 examples.

**Diffed every file in every example against what was committed, before staging anything.** The only differences anywhere: the two fixes above, the expected per-generation timestamp, and a `UDS_STACK_VERSION` catch-up (`1.0.0`/`1.6.0` → `1.7.0`) on the same 4 stale examples — the ECU's own version (e.g. `ARDEP_IOController v1.0.0`) is a separate field and is unaffected. No DID handler, routine handler, or safety wrapper logic changed for any example.

## Verification

None of the 4 affected examples are built by any CI job today — verified (`grep -oE "examples/[a-z_]+" .github/workflows/ci.yml` only matches `basic_ecu`, `basic_ecu_doip`, `basic_ecu_freertos`, `safeboot_freertos_ecu`). Filed that gap separately as [#98](https://github.com/Xaloqi/EDS/issues/98) — out of scope here.

Verified the CommControl addition compiles and **links** correctly with a full host-side link of each of the 4 against the real stack (`uds_server.c`, `uds_comm_control.c`, all 19 service handlers, transport, config): zero undefined references besides the expected missing `main()`, which these init-sequence files don't define by design.

Full existing gate suite re-verified unaffected: `build_tests.sh` (43/43), `build_harness.sh --run` (68/68), `cmake`/`ctest` (43/43).

🤖 Generated with [Claude Code](https://claude.com/claude-code)