### PR TITLE
fix: eds_on_isotp_rx_complete() callback signature mismatch (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`freertos_platform_api.c`'s ISO-TP RX-complete callback had the wrong
+  signature.** (#96) `eds_on_isotp_rx_complete()`'s `length` parameter was
+  `uint16_t`, but `transport/isotp.h`'s `isotp_rx_complete_cb` typedef
+  declares it `uint32_t` — a function-pointer type mismatch at the
+  `isotp_process_rx_frame()` call site. CI's pinned `gcc-arm-none-eabi`
+  (~10.3.1) only warned; a real `arm-none-eabi-gcc` 14.2.1 cross-compile
+  rejects it outright with `-Wincompatible-pointer-types`, which is how this
+  was found — verifying #84's FreeRTOS fix stopped a full link one object
+  short. Widened the parameter to `uint32_t` to match the typedef exactly;
+  `s_poll_req_buf.length` (`uint16_t`) is unaffected — the existing
+  `UDS_MAX_PAYLOAD_LEN` (4095) bounds check already rejects anything that
+  wouldn't fit before the narrowing assignment, now made explicit. Verified
+  with a full real cross-compile + link of both FreeRTOS examples that use
+  this file (`basic_ecu_freertos`, `safeboot_freertos_ecu`) — both now reach
+  a complete `.elf`, and the fixed function compiles with zero warnings
+  even under `-Wconversion -Wsign-conversion`, stricter than this build
+  actually enforces.
+
+### Fixed
+
 - **All 12 example ECUs regenerated from the current codegen template,
   closing long-standing drift.** (EDS-toolchain#50) Two of the four
   examples added at "Initial public release" — `ardep_ecu`, `bms_ecu`,

--- a/platform/freertos/freertos_platform_api.c
+++ b/platform/freertos/freertos_platform_api.c
@@ -497,10 +497,21 @@ static uds_msg_buf_t s_poll_resp_buf;
  *
  * Runs in the context of the UDS poll task. s_poll_req_buf and s_poll_resp_buf
  * are module-level statics — no concurrent access from other tasks or ISRs.
+ *
+ * [#96 FIX] `length` widened from uint16_t to uint32_t to match
+ * isotp_rx_complete_cb's typedef (transport/isotp.h) exactly. The narrower
+ * parameter made this a function-pointer signature mismatch at the
+ * isotp_process_rx_frame() call site below — a real
+ * -Wincompatible-pointer-types error on GCC 14+, silently downgraded to a
+ * warning by the older gcc-arm-none-eabi CI is pinned to
+ * (cmake/toolchain/arm-none-eabi.cmake), which is why it was never caught.
+ * s_poll_req_buf.length (uint16_t) is unaffected: the existing
+ * UDS_MAX_PAYLOAD_LEN (4095) bounds check below already rejects anything
+ * that wouldn't fit before the narrowing assignment, now made explicit.
  */
 static void eds_on_isotp_rx_complete(
     const uint8_t *data,
-    uint16_t       length,
+    uint32_t       length,
     void          *arg)
 {
     uds_server_ctx_t *srv = (uds_server_ctx_t *)arg;
@@ -512,14 +523,14 @@ static void eds_on_isotp_rx_complete(
         return;
     }
 
-    if ((length == (uint16_t)0U) || (length > (uint16_t)UDS_MAX_PAYLOAD_LEN)) {
+    if ((length == (uint32_t)0U) || (length > (uint32_t)UDS_MAX_PAYLOAD_LEN)) {
         return;
     }
 
-    for (i = (uint16_t)0U; i < length; i++) {
+    for (i = (uint16_t)0U; i < (uint16_t)length; i++) {
         s_poll_req_buf.data[i] = data[i];
     }
-    s_poll_req_buf.length  = length;
+    s_poll_req_buf.length  = (uint16_t)length;
     s_poll_resp_buf.length = (uint16_t)0U;
 
     status = uds_server_process_request(srv, &s_poll_req_buf, &s_poll_resp_buf);


### PR DESCRIPTION
Closes #96.

## The bug

`eds_on_isotp_rx_complete()`'s `length` parameter was `uint16_t`, but `transport/isotp.h`'s `isotp_rx_complete_cb` typedef declares it `uint32_t` — a function-pointer type mismatch at the `isotp_process_rx_frame()` call site. CI's pinned `gcc-arm-none-eabi` (~10.3.1) only warns on this; a real `arm-none-eabi-gcc` 14.2.1 cross-compile rejects it outright with `-Wincompatible-pointer-types`, which is how this was found — verifying #84's FreeRTOS build stopped one object short of a full link because of it.

## The fix

Widened the parameter to `uint32_t` to match the typedef exactly. `s_poll_req_buf.length` (`uint16_t`) is unaffected: the existing `UDS_MAX_PAYLOAD_LEN` (4095) bounds check already rejects anything that wouldn't fit before the narrowing assignment to that field, which is now an explicit cast rather than implicit.

Only one call site of this callback type exists in the whole codebase — grepped `isotp_rx_complete_cb` / `isotp_process_rx_frame` across `transport/`, `platform/`, `core/`. The Zephyr platform doesn't define an equivalent callback, so no other file needed this fix.

## Verification

Full real cross-compile + link (`arm-none-eabi-gcc` 14.2.1 + a freshly cloned `FreeRTOS-Kernel`) of both FreeRTOS examples that reference this file: `basic_ecu_freertos` and `safeboot_freertos_ecu`. **Both now reach a complete `.elf`** (previously stopped at 53/54 objects). The fixed function compiles with zero warnings, checked also under `-Wconversion -Wsign-conversion`, stricter than this build's own `-Wall -Wextra` actually enforces.

Full existing gate suite re-verified unaffected: `build_tests.sh` (43/43), `build_harness.sh --run` (68/68), `cmake`/`ctest` (43/43) — none of which compile `platform/freertos/` (host tests use mocks instead), so the FreeRTOS cross-compile above is the real verification for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)