### PR TITLE
chore(release): v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+## [1.11.0] — 2026-08-29
+
 ### Security
 
 - **BREAKING: unified build-mode detection closes a silent bypass of both the

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 > repo. Community users cloning the public repo can ignore this file.
 
 **Product:** Xaloqi EDS (Xaloqi Embedded Diagnostic Suite)  
-**Version:** v1.10.1  
+**Version:** v1.11.0  
 **Support:** contact@xaloqi.com
 
 ---
@@ -50,7 +50,7 @@ cd EDS
 Verify you are on the correct version:
 
 ```bash
-git checkout v1.10.1
+git checkout v1.11.0
 ```
 
 ---
@@ -59,10 +59,10 @@ git checkout v1.10.1
 
 ```bash
 # From the EDS repo root:
-unzip -o /path/to/xaloqi-eds-developer-v1.10.1.zip
+unzip -o /path/to/xaloqi-eds-developer-v1.11.0.zip
 
 # Or for Professional:
-unzip -o /path/to/xaloqi-eds-professional-v1.10.1.zip
+unzip -o /path/to/xaloqi-eds-professional-v1.11.0.zip
 ```
 
 The `-o` flag overwrites existing files without prompting — required when updating an existing installation.
@@ -75,7 +75,7 @@ The `-o` flag overwrites existing files without prompting — required when upda
 >
 > ```bash
 > rm -f tools/templates tools/testgen.py tools/_license.py harness
-> unzip -o /path/to/xaloqi-eds-developer-v1.10.1.zip
+> unzip -o /path/to/xaloqi-eds-developer-v1.11.0.zip
 > ```
 
 This extracts the toolchain files directly into the repo tree. No separate directory. After extraction you will have:
@@ -185,7 +185,7 @@ Expected output:
 
 ```
 ========================================================================
-  Xaloqi EDS — Code Generator v1.10.1
+  Xaloqi EDS — Code Generator v1.11.0
 ========================================================================
   Config   : examples/bms_ecu/diagnostics_config.yaml
   ...

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ For the full FreeRTOS integration guide (callbacks, NVM, reset, production porti
 ### Run the test suite
 
 ```bash
-# 42 Unity unit tests (host-native, no Zephyr SDK needed)
+# 43 Unity unit tests (host-native, no Zephyr SDK needed)
 bash build_tests.sh
 
 # 68 harness integration tests (Professional tier — requires harness/ sources)
@@ -306,7 +306,7 @@ Step 5  Data length correct?     → NRC 0x13 incorrectMessageLengthOrInvalidFor
 | `ide/vscode-extension/` | YAML validation, hover docs, Run Codegen command *(Developer/Professional tier)* |
 | `examples/` | basic\_ecu · basic\_ecu\_doip · basic\_ecu\_freertos · basic\_ecu\_doip\_freertos · sensor\_ecu · sensor\_ecu\_freertos · safeboot\_ecu · safeboot\_freertos\_ecu · robot\_joint\_controller\_ecu · bms\_ecu · motor\_controller\_ecu · ardep\_ecu · each with its own `generated/` subfolder |
 | `gui/` | React/TypeScript configurator + live dashboard *(Developer/Professional tier)* |
-| `tests/` | 42 Unity unit tests, harness, Python integration tests |
+| `tests/` | 43 Unity unit tests, harness, Python integration tests |
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -220,7 +220,7 @@ embedded-diagnostics-suite/
 │   └── mocks/                  # Zephyr port mock + NVM mock for host builds
 │
 └── scripts/
-    ├── build_tests.sh          # Runs all 42 unit test modules
+    ├── build_tests.sh          # Runs all 43 unit test modules
     └── build_harness.sh        # Runs all 68 harness tests
 ```
 
@@ -591,7 +591,7 @@ The first five examples ship with committed generated output (DID handlers, safe
 
 | Job | What it validates |
 |---|---|
-| `unit-tests` | All 42 Unity unit test modules (host-native, no Zephyr SDK) |
+| `unit-tests` | All 43 Unity unit test modules (host-native, no Zephyr SDK) |
 | `integration-tests` | Generated pytest suite in simulator mode |
 | `firmware-integration-tests` | pytest + per-routine tests against compiled firmware |
 | `static-analysis` | GCC `-fanalyzer` + MISRA cppcheck (zero errors) |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -6,7 +6,7 @@
 - Zephyr workspace with EDS checked out
 - A minimal ECU firmware built and running in the simulator
 - UDS service 0x22 (ReadDataByIdentifier) responding to requests
-- All 42 unit tests passing
+- All 43 unit tests passing
 
 **No prior Zephyr knowledge assumed.**
 
@@ -518,7 +518,7 @@ Run the integration tests in a second terminal to send traffic while it's runnin
 | `west build -b nucleo_h743zi2 examples/basic_ecu` | Cross-compile for STM32 Nucleo-H743ZI2 |
 | `west build -b mr_canhubk3 examples/basic_ecu -- -DEXTRA_CONF_FILE=boards/mr_canhubk3/mr_canhubk3.conf -DDTC_OVERLAY_FILE=boards/mr_canhubk3/mr_canhubk3.overlay` | Cross-compile for NXP MR-CANHUBK3 (S32K344) |
 | `west flash` | Flash to connected hardware |
-| `bash build_tests.sh` | Run 42 unit tests |
+| `bash build_tests.sh` | Run 43 unit tests |
 | `pytest tests/integration/ -v` | Run Python integration tests |
 | `cd gui && npm ci && npm start` | Start GUI configurator |
 | `python3 tools/testgen.py --config CONFIG --out OUT` | Generate pytest test suite |

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -1,7 +1,7 @@
 # Testing Strategy — Xaloqi EDS
 
 **Version:** v1.10.1  
-**Status:** 42/42 unit test modules passing. 68/68 harness tests passing. 13/13 CI jobs green. FreeRTOS, SafeBoot (Zephyr + FreeRTOS), DoIP, and sensor examples all covered.
+**Status:** 43/43 unit test modules passing. 68/68 harness tests passing. 21/21 CI jobs green. FreeRTOS, SafeBoot (Zephyr + FreeRTOS), DoIP, and sensor examples all covered.
 
 ---
 
@@ -105,7 +105,7 @@ bash scripts/build_tests.sh
 # Expected: 42 tests, 0 failures
 ```
 
-### Coverage — 42 unit test modules
+### Coverage — 43 unit test modules
 
 **UDS Core (4 modules)**
 
@@ -424,7 +424,7 @@ All 8 jobs must pass before a PR can be merged.
 
 Added in v1.3.0. Builds `examples/basic_ecu_freertos` with `-DEDS_PLATFORM=freertos`
 targeting QEMU ARM Cortex-M4. Downloads FreeRTOS-Kernel from GitHub, runs codegen,
-builds the ELF, and verifies it exists. The same 42 unit tests run against the FreeRTOS
+builds the ELF, and verifies it exists. The same 43 unit tests run against the FreeRTOS
 platform HAL (they mock the platform layer and are platform-independent).
 
 ### SafeBoot CI job (within `unit-tests`)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -210,7 +210,7 @@ platform/
 tools/              codegen.py, testgen.py, mcp_server.py, 17 Jinja2 templates
 examples/           12 ECU examples — each with diagnostics_config.yaml + generated/
 gui/                React/TypeScript configurator and live dashboard
-tests/              42 Unity unit tests, Python integration tests, harness (68 tests)
+tests/              43 Unity unit tests, Python integration tests, harness (68 tests)
 ide/vscode-extension/  YAML validation, hover docs, Run Codegen command
 
 ## Requirements

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -100,7 +100,7 @@ except ImportError:
     print("ERROR: Jinja2 is required.  pip install jinja2", file=sys.stderr)
     sys.exit(2)
 
-__version__ = "1.10.1"
+__version__ = "1.11.0"
 
 # =============================================================================
 # Constants


### PR DESCRIPTION
Release prep for v1.11.0: CHANGELOG roll, version bumps (codegen.py, INSTALL.md), and a docs-sweep pass fixing stale 42→43 unit-test-count and 13/13→21/21 CI-job-count mentions found by `check_release_docs.py` (the count grew to 43 during this cycle's SEC-TRNG work but wasn't swept everywhere).

Part of the v1.11.0 release — see xaloqi-knowledge/ops/release-runbook.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)