### PR TITLE
fix: bump README.md version badge to v1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Xaloqi Embedded Diagnostics Suite
 
 [![CI](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml/badge.svg)](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-v1.10.1-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.10.1)
+[![Version](https://img.shields.io/badge/version-v1.11.0-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.11.0)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](LICENSE)
 [![Zephyr](https://img.shields.io/badge/Zephyr-v3.7%2B-brightgreen)](https://zephyrproject.org)
 


### PR DESCRIPTION
The shields.io version badge in README.md was never bumped as part of the v1.11.0 release prep — `check_release_docs.py`'s badge check couldn't catch it pre-tag (its ground truth is the current git tag, so a stale badge and an unbumped badge look identical until the tag moves). Found via `xaloqi-knowledge/scripts/check_versions.py` during the release's close-the-loop step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)