### PR TITLE
docs: make proprietary-firmware linking rights explicit in README and COMMERCIAL_NOTICE

### DIFF
--- a/COMMERCIAL_NOTICE.md
+++ b/COMMERCIAL_NOTICE.md
@@ -95,6 +95,14 @@ A commercial license grants you the right to use Xaloqi EDS in one
 proprietary project per seat, ship binary firmware to your customers,
 and keep your firmware source code private.
 
+**Linking, explicitly:** the commercial license permits you to statically
+or dynamically link the GPL-licensed runtime stack (`core/`, `transport/`,
+`config/`, `platform/`) into proprietary, closed-source ECU firmware and
+distribute the resulting binary to your OEM or end customer — with no
+GPL source-disclosure obligation for your own firmware code. See
+`LICENSE_COMMERCIAL.txt` §5 ("GPL v2 Runtime and Commercial License
+Relationship") for the full terms.
+
 Full license terms: `LICENSE_COMMERCIAL.txt` in this repository.
 
 ---

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ EDS is dual-licensed. The runtime stack is GPL v2 and the whole thing builds and
 
 **In short:** clone this repo and you can build, run, and study the full stack and every example for free. A [Developer license](COMMERCIAL_NOTICE.md) adds the generator templates (regenerate from your own YAML) and the right to ship proprietary firmware. Full boundary: [COMMERCIAL_NOTICE.md](COMMERCIAL_NOTICE.md).
 
+**On linking, explicitly:** a commercial license permits you to statically or dynamically link the GPL-licensed runtime stack (`core/`, `transport/`, `config/`, `platform/`) into closed-source ECU firmware and distribute the resulting binary to your OEM or end customer — with no GPL source-disclosure obligation for your own firmware code. Full terms: `LICENSE_COMMERCIAL.txt` §5 ("GPL v2 Runtime and Commercial License Relationship").
+
 ---
 
 ## 60-second walkthrough


### PR DESCRIPTION
## What

Adds one explicit paragraph to `README.md` (Open-core section) and `COMMERCIAL_NOTICE.md` (How to get a commercial license section) that:

- names the four GPL v2-licensed directories a licensee would link against: `core/`, `transport/`, `config/`, `platform/`
- states plainly that a commercial license permits static or dynamic linking into proprietary/closed-source ECU firmware and distribution of the resulting binary to the OEM/end customer, with **no GPL source-disclosure obligation** for the licensee's own firmware code
- points to `LICENSE_COMMERCIAL.txt` §5 ("GPL v2 Runtime and Commercial License Relationship") for the full terms

## Why

An ambiguity in where this reads clearly, not in what's granted: `LICENSE_COMMERCIAL.txt` §5 already states that a commercial license is NOT subject to GPL v2 and supersedes it for that licensee — but a reader skimming README.md or COMMERCIAL_NOTICE.md for "can I statically link this into closed-source firmware and ship the binary without GPL disclosure" had to infer the answer rather than read it stated outright. This closes that gap.

## Scope

**Docs-only. No change to actual license terms, no new legal language.** Both new paragraphs restate what §5 already grants, in the two docs a prospective licensee is most likely to read first, and cite §5 as the source of truth. `LICENSE_COMMERCIAL.txt` itself is untouched.

## Verification

`bash build_tests.sh` — 43/43 unit tests pass, plus the 7/7 build-mode macro probe and the negative-compile gate. Expected no-op since only Markdown/text docs changed; confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)