### PR TITLE
fix: retry DoIP tcp_send() until fully sent, add short-write regression test (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,27 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   loopback/`native_sim`, where a single `tcp_send()` call virtually always
   accepts the whole buffer — it surfaces on real Ethernet under congestion,
   with large diagnostic responses (up to ~4 KB), or against a stricter TCP
-  stack. Added `doip_send_all()`, a bounded retry loop (max 128 attempts,
-  so a wedged/stalled peer cannot spin the UDS task indefinitely), used at
-  both call sites. New unit tests give `mock_tcp_send()` a configurable
-  per-call byte cap to simulate short writes and assert a large response
-  reassembles byte-identical, plus that the bounded retry actually gives up
-  rather than looping unboundedly.
+  stack. Added `doip_send_all()`, a bounded retry loop used at both call
+  sites that keeps calling `tcp_send()` until the full buffer is on the
+  wire. The bound counts only *consecutive no-progress* calls (128 in a
+  row returning `<= 0`) against a give-up threshold, not total call count —
+  a merely slow connection that keeps delivering some bytes every call,
+  however few, is never killed by this bound and always completes; only a
+  genuinely wedged peer (zero bytes accepted, repeatedly) does. (An earlier
+  iteration of this fix counted every call — progress or not — against one
+  flat 128-attempt cap, which could itself have dropped a perfectly good
+  response under real Ethernet congestion — exactly the scenario this issue
+  was filed for; caught in review before merge.) When `doip_send_all()`
+  does give up, `doip_handle_frame()` now reports the failure so
+  `eds_doip_server_run()` closes the connection via its existing cleanup
+  path, instead of leaving a peer waiting on a partial/desynced frame that
+  will never fully arrive. New unit tests give `mock_tcp_send()` a
+  configurable per-call byte cap (and a dedicated "always stalls" mode) to
+  simulate short writes, and assert: a large response reassembles
+  byte-identical under a comfortable 64B/call cap; a *slow but always
+  progressing* 24B/call send still succeeds even though it needs more than
+  128 calls; and a truly stalled peer is bounded and reported as a failure
+  the caller must close the connection over.
 
 ## [1.11.0] — 2026-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **DoIP: `tcp_send()` short writes were treated as a complete send, silently
+  truncating frames on real Ethernet.** (#105) Both call sites in
+  `transport/doip/doip_server.c` accepted any positive return from
+  `tcp_send()` as "fully sent" — but POSIX `send()` (and the LwIP/FreeRTOS
+  backends behind `eds_doip_platform_ops_t`) may legally transmit fewer
+  bytes than requested. The remainder was then silently dropped, producing
+  a truncated DoIP frame on the wire. This never reproduced on
+  loopback/`native_sim`, where a single `tcp_send()` call virtually always
+  accepts the whole buffer — it surfaces on real Ethernet under congestion,
+  with large diagnostic responses (up to ~4 KB), or against a stricter TCP
+  stack. Added `doip_send_all()`, a bounded retry loop (max 128 attempts,
+  so a wedged/stalled peer cannot spin the UDS task indefinitely), used at
+  both call sites. New unit tests give `mock_tcp_send()` a configurable
+  per-call byte cap to simulate short writes and assert a large response
+  reassembles byte-identical, plus that the bounded retry actually gives up
+  rather than looping unboundedly.
+
 ## [1.11.0] — 2026-08-29
 
 ### Security

--- a/tests/unit_runnable/test_doip_server.c
+++ b/tests/unit_runnable/test_doip_server.c
@@ -37,6 +37,8 @@
  *     - test_doip_diagnostic_msg_extracts_uds_pdu_correctly
  *     - test_doip_diagnostic_msg_calls_uds_core
  *     - test_doip_response_wraps_in_doip_frame
+ *     - test_doip_short_write_reassembles_large_response (Issue #105)
+ *     - test_doip_short_write_bounded_retry_gives_up (Issue #105)
  *     - test_doip_max_pdu_size_boundary
  *     - test_doip_handle_unknown_payload_type_ignored
  *
@@ -66,6 +68,17 @@ static int      g_mock_send_rc;  /* return value for tcp_send (positive = bytes 
 static size_t   g_mock_tx_frame_starts[32]; /* byte offset of each frame start */
 static int      g_mock_tx_frame_count;
 
+/* [Issue #105] Short-write simulation: when non-zero, mock_tcp_send() never
+ * accepts more than this many bytes in a single call, regardless of how
+ * much was requested — modelling a real TCP stack under congestion (POSIX
+ * send() may legally return fewer bytes than requested). 0 = disabled
+ * (always accept the full request, the pre-#105 mock behaviour). */
+static size_t   g_mock_send_chunk_cap;
+/* Total number of mock_tcp_send() invocations since the last reset — lets
+ * a test assert the retry loop terminated after a bounded number of calls
+ * rather than merely "the test function returned". */
+static int      g_mock_send_call_count;
+
 /* Track calls */
 static int      g_mock_listen_calls;
 static int      g_mock_accept_calls;
@@ -90,19 +103,35 @@ static int mock_tcp_accept(void *server_ctx, void **conn_ctx, uint32_t timeout_m
 static int mock_tcp_send(void *conn_ctx, const uint8_t *data, size_t len)
 {
     (void)conn_ctx;
+    g_mock_send_call_count++;
     if (g_mock_send_rc <= 0) {
         return g_mock_send_rc;
     }
-    /* Append to buffer so all frames are captured */
+
+    /* [Issue #105] Simulate a short write: accept at most g_mock_send_chunk_cap
+     * bytes this call even though `len` (possibly far more) was requested. */
+    size_t accepted = len;
+    if (g_mock_send_chunk_cap > 0U && accepted > g_mock_send_chunk_cap) {
+        accepted = g_mock_send_chunk_cap;
+    }
+
+    /* Append the accepted bytes to the capture buffer so the full sequence
+     * of (possibly many, possibly partial) calls can be reassembled and
+     * compared byte-for-byte against what the caller intended to send.
+     * This copy is intentionally NOT gated on g_mock_tx_frame_count so that
+     * short-write tests with more than 32 calls still capture every byte —
+     * only the (optional, best-effort) frame-start bookkeeping below is. */
     size_t space = sizeof(g_mock_tx_buf) - g_mock_tx_len;
-    size_t copy_len = (len < space) ? len : space;
-    if (copy_len > 0U && g_mock_tx_frame_count < 32) {
-        g_mock_tx_frame_starts[g_mock_tx_frame_count] = g_mock_tx_len;
-        g_mock_tx_frame_count++;
+    size_t copy_len = (accepted < space) ? accepted : space;
+    if (copy_len > 0U) {
+        if (g_mock_tx_frame_count < 32) {
+            g_mock_tx_frame_starts[g_mock_tx_frame_count] = g_mock_tx_len;
+            g_mock_tx_frame_count++;
+        }
         memcpy(&g_mock_tx_buf[g_mock_tx_len], data, copy_len);
         g_mock_tx_len += copy_len;
     }
-    return (int)len;
+    return (int)accepted;
 }
 
 static int mock_tcp_recv(void *conn_ctx, uint8_t *buf, size_t buf_len, uint32_t timeout_ms)
@@ -163,12 +192,14 @@ static void setup_mock_platform(void)
     uds_status_t rc = eds_doip_register_platform(&g_mock_ops);
     zassert_equal(rc, UDS_STATUS_OK, "register_platform failed");
 
-    g_mock_tx_len          = 0U;
-    g_mock_send_rc         = 512; /* default: success */
-    g_mock_listen_calls    = 0;
-    g_mock_accept_calls    = 0;
-    g_mock_close_calls     = 0;
-    g_mock_tx_frame_count  = 0;
+    g_mock_tx_len           = 0U;
+    g_mock_send_rc          = 512; /* default: success */
+    g_mock_send_chunk_cap   = 0U;  /* default: accept full requested length */
+    g_mock_send_call_count  = 0;
+    g_mock_listen_calls     = 0;
+    g_mock_accept_calls     = 0;
+    g_mock_close_calls      = 0;
+    g_mock_tx_frame_count   = 0;
     memset(g_mock_tx_buf, 0, sizeof(g_mock_tx_buf));
     memset(g_mock_tx_frame_starts, 0, sizeof(g_mock_tx_frame_starts));
 }
@@ -206,11 +237,26 @@ static uds_status_t stub_seed_gen(uint8_t level, uint8_t *seed_buf,
     return UDS_STATUS_OK;
 }
 
-static uds_server_ctx_t *init_uds_server(void)
+/* Common uds_server_ctx_t bring-up. `table`/`table_count` let a test
+ * register handlers (e.g. one returning a large response, needed to
+ * exercise doip_send_all()'s reassembly of a multi-call short write — see
+ * test_doip_short_write_* below); pass an empty table for the default
+ * "every service is serviceNotSupported" behaviour most tests rely on.
+ *
+ * uds_session_init()/uds_security_init()/uds_server_init() all refuse to
+ * re-run on an already-initialised context (return ERR_ALREADY_INITIALIZED,
+ * ignored here as (void), same as every other call site in this file) — so
+ * each *distinct* configuration this file needs its own dedicated set of
+ * static session/security/server contexts. Tests sharing a configuration
+ * (identical table) may keep sharing one set, as init_uds_server() below
+ * already relied on before this helper existed. */
+static uds_server_ctx_t *init_uds_server_with_ctx(uds_session_ctx_t *session_ctx,
+                                                    uds_security_ctx_t *security_ctx,
+                                                    uds_server_ctx_t *server_ctx,
+                                                    const uds_service_entry_t *table,
+                                                    size_t table_count)
 {
-    static const uds_service_entry_t empty_table[] = { { 0U, NULL, false } };
-
-    (void)uds_session_init(&g_session_ctx, 5000U);
+    (void)uds_session_init(session_ctx, 5000U);
 
     static const uds_security_cfg_t sec_cfg = {
         .max_attempts     = 3U,
@@ -218,20 +264,64 @@ static uds_server_ctx_t *init_uds_server(void)
         .key_validate_cb  = stub_key_validate,
         .seed_generate_cb = stub_seed_gen,
     };
-    (void)uds_security_init(&g_security_ctx, &sec_cfg);
+    (void)uds_security_init(security_ctx, &sec_cfg);
 
     uds_server_cfg_t srv_cfg = {
         .p2_server_max_ms      = 50U,
         .p2_star_server_max_ms = 5000U,
-        .session_ctx           = &g_session_ctx,
-        .security_ctx          = &g_security_ctx,
-        .service_table         = empty_table,
-        .service_table_count   = 0U,
+        .session_ctx           = session_ctx,
+        .security_ctx          = security_ctx,
+        .service_table         = table,
+        .service_table_count   = table_count,
         .access_table          = NULL,
         .access_table_count    = 0U,
     };
-    (void)uds_server_init(&g_uds_ctx, &srv_cfg);
-    return &g_uds_ctx;
+    (void)uds_server_init(server_ctx, &srv_cfg);
+    return server_ctx;
+}
+
+static uds_server_ctx_t *init_uds_server(void)
+{
+    static const uds_service_entry_t empty_table[] = { { 0U, NULL, false } };
+    return init_uds_server_with_ctx(&g_session_ctx, &g_security_ctx, &g_uds_ctx,
+                                     empty_table, 0U);
+}
+
+/* [Issue #105] Service handler that returns a large (~4 KB) positive
+ * response filled with a recognisable, position-dependent byte pattern, so
+ * a test can verify the *entire* response — not just its first bytes —
+ * survived reassembly across many short tcp_send() calls byte-identical. */
+#define TEST_LARGE_RESP_LEN 4000U
+
+static uds_status_t handler_large_response(uds_server_ctx_t *ctx,
+                                            const uds_msg_buf_t *req,
+                                            uds_msg_buf_t *resp)
+{
+    (void)ctx;
+    (void)req;
+    for (uint16_t i = 0U; i < (uint16_t)TEST_LARGE_RESP_LEN; i++) {
+        resp->data[i] = (uint8_t)(i & 0xFFU);
+    }
+    resp->length = (uint16_t)TEST_LARGE_RESP_LEN;
+    return UDS_STATUS_OK;
+}
+
+/* Dedicated context set: this configuration (custom service_table) differs
+ * from init_uds_server()'s empty table, so it cannot share g_uds_ctx et al.
+ * (see init_uds_server_with_ctx() doc comment above). */
+static uds_session_ctx_t   g_session_ctx_large_resp;
+static uds_security_ctx_t  g_security_ctx_large_resp;
+static uds_server_ctx_t    g_uds_ctx_large_resp;
+
+static uds_server_ctx_t *init_uds_server_with_large_response(void)
+{
+    static const uds_service_entry_t table[] = {
+        { 0x22U, handler_large_response, false },
+    };
+    return init_uds_server_with_ctx(&g_session_ctx_large_resp,
+                                     &g_security_ctx_large_resp,
+                                     &g_uds_ctx_large_resp,
+                                     table, 1U);
 }
 
 /* =========================================================================
@@ -656,6 +746,140 @@ ZTEST(doip_server_suite, test_doip_response_wraps_in_doip_frame)
                  "last sent frame should be positive ack or UDS response");
 }
 
+/* =========================================================================
+ * [Issue #105] doip_send_all() short-write regression tests
+ *
+ * Both tcp_send() call sites in doip_server.c used to treat any positive
+ * return as "fully sent". POSIX send() (and the platform backends behind
+ * eds_doip_platform_ops_t) may legally transmit fewer bytes than requested
+ * — the remainder was then silently dropped, producing a truncated DoIP
+ * frame on the wire. This never reproduced on loopback/native_sim, where a
+ * single tcp_send() call virtually always accepts the whole buffer — which
+ * is exactly why these two tests exist: mock_tcp_send() can now be told
+ * (via g_mock_send_chunk_cap) to accept only a handful of bytes per call,
+ * modelling real Ethernet under congestion or a stricter TCP stack.
+ * ========================================================================= */
+
+ZTEST(doip_server_suite, test_doip_short_write_reassembles_large_response)
+{
+    /* Regression test for the core bug: even when the platform tcp_send()
+     * never accepts more than 64 bytes per call, doip_send_all() must retry
+     * until the complete frame is on the wire — a large (~4 KB) diagnostic
+     * response must arrive byte-identical, not truncated. */
+    setup_mock_platform();
+    uds_server_ctx_t *uds = init_uds_server_with_large_response();
+    doip_server_state_t s = init_state(0xE400U);
+
+    uint8_t ra_payload[7];
+    build_routing_req_payload(ra_payload, 0x0E00U, 0x00U);
+    (void)doip_handle_frame(&s, uds, DOIP_PT_ROUTING_ACT_REQ, ra_payload, 7U);
+
+    memset(g_mock_tx_buf, 0, sizeof(g_mock_tx_buf));
+    g_mock_tx_len          = 0U;
+    g_mock_send_call_count = 0;
+    g_mock_send_chunk_cap  = 64U; /* never accept more than 64B in one call */
+
+    /* ReadDataByIdentifier (SID 0x22) — dispatched to handler_large_response(). */
+    uint8_t diag_payload[7] = { 0x0E, 0x00, 0xE4, 0x00, 0x22, 0xF1, 0x90 };
+    uds_status_t rc = doip_handle_frame(&s, uds, DOIP_PT_DIAGNOSTIC_MSG,
+                                         diag_payload, 7U);
+    zassert_equal(rc, UDS_STATUS_OK, "handle_frame failed under short writes");
+
+    /* Must have taken more than a couple of tcp_send() calls to prove the
+     * short-write path was actually exercised, not accidentally bypassed. */
+    zassert_true(g_mock_send_call_count > 2,
+                 "expected several short tcp_send() calls (large response, "
+                 "64B cap) — test is not exercising the short-write path");
+
+    /* Frame 0 in the capture buffer is the positive ack — read its own
+     * declared length to find where the diagnostic response frame begins. */
+    uint32_t ack_payload_len = read_be32(&g_mock_tx_buf[4]);
+    size_t   resp_frame_off  = (size_t)DOIP_HEADER_LEN + (size_t)ack_payload_len;
+
+    zassert_true(resp_frame_off + DOIP_HEADER_LEN <= g_mock_tx_len,
+                 "response frame header missing from captured stream");
+
+    uint16_t resp_type = read_be16(&g_mock_tx_buf[resp_frame_off + 2U]);
+    zassert_equal(resp_type, (uint16_t)DOIP_PT_DIAGNOSTIC_MSG,
+                  "expected a DiagnosticMessage response frame after the ack");
+
+    uint32_t resp_payload_len = read_be32(&g_mock_tx_buf[resp_frame_off + 4U]);
+    zassert_equal(resp_payload_len, (uint32_t)(TEST_LARGE_RESP_LEN + 4U),
+                  "response frame's declared payload length is wrong");
+
+    size_t resp_total = resp_frame_off + (size_t)DOIP_HEADER_LEN + (size_t)resp_payload_len;
+    zassert_equal(resp_total, g_mock_tx_len,
+                  "captured byte stream is shorter/longer than the full frame "
+                  "— a truncated or over-long send would fail this");
+
+    /* Response addressing: ECU (0xE400) -> tester (0x0E00). */
+    uint16_t resp_src = read_be16(&g_mock_tx_buf[resp_frame_off + DOIP_HEADER_LEN]);
+    uint16_t resp_tgt = read_be16(&g_mock_tx_buf[resp_frame_off + DOIP_HEADER_LEN + 2U]);
+    zassert_equal(resp_src, 0xE400U, "response src should be ECU logical address");
+    zassert_equal(resp_tgt, 0x0E00U, "response tgt should be tester address");
+
+    /* Byte-identical check across the full ~4 KB UDS payload — this is the
+     * crux of #105: a partial-send bug would corrupt/truncate bytes here
+     * even if the framing checks above happened to still look fine. */
+    const uint8_t *uds_resp = &g_mock_tx_buf[resp_frame_off + DOIP_HEADER_LEN + 4U];
+    bool mismatch = false;
+    for (uint16_t i = 0U; i < (uint16_t)TEST_LARGE_RESP_LEN; i++) {
+        if (uds_resp[i] != (uint8_t)(i & 0xFFU)) {
+            mismatch = true;
+            break;
+        }
+    }
+    zassert_false(mismatch, "reassembled response is not byte-identical to what was sent");
+}
+
+ZTEST(doip_server_suite, test_doip_short_write_bounded_retry_gives_up)
+{
+    /* doip_send_all() must NOT retry forever against a peer that never
+     * accepts more than a handful of bytes per call — a wedged or badly
+     * congested connection must not be able to hang the UDS task. We force
+     * a pathological 1-byte-per-call cap on a large (~4 KB) response, which
+     * no reasonable retry bound would ever walk to completion, and verify
+     * the call terminates promptly reporting failure rather than spinning
+     * until the buffer is naturally exhausted call-by-call (~4012 calls). */
+    setup_mock_platform();
+    uds_server_ctx_t *uds = init_uds_server_with_large_response();
+    doip_server_state_t s = init_state(0xE400U);
+
+    uint8_t ra_payload[7];
+    build_routing_req_payload(ra_payload, 0x0E00U, 0x00U);
+    (void)doip_handle_frame(&s, uds, DOIP_PT_ROUTING_ACT_REQ, ra_payload, 7U);
+
+    uint32_t frames_sent_before = s.frames_sent;
+    g_mock_send_call_count = 0;
+    g_mock_send_chunk_cap  = 1U; /* pathological: accepts 1 byte per call */
+
+    uint8_t diag_payload[7] = { 0x0E, 0x00, 0xE4, 0x00, 0x22, 0xF1, 0x90 };
+    uds_status_t rc = doip_handle_frame(&s, uds, DOIP_PT_DIAGNOSTIC_MSG,
+                                         diag_payload, 7U);
+
+    /* doip_handle_frame() itself still reports OK — a send failure on the
+     * response frame was already non-fatal to frame dispatch before this
+     * fix; this change only changes what counts as "sent", not whether
+     * send failures propagate out of doip_handle_frame(). */
+    zassert_equal(rc, UDS_STATUS_OK, "handle_frame should still return OK");
+
+    /* Only the small positive ack (well within any reasonable retry bound
+     * even at 1 byte/call) should have completed — the ~4 KB response must
+     * NOT be counted as sent. */
+    zassert_equal(s.frames_sent, frames_sent_before + 1U,
+                  "only the positive ack should have completed; the large "
+                  "response must be reported as failed, not silently "
+                  "counted as sent");
+
+    /* The retry loop must have given up long before it would take to walk
+     * the full ~4 KB frame one byte at a time (~4012 calls) — proving the
+     * bound in doip_send_all() actually engaged rather than looping until
+     * the buffer was naturally exhausted. */
+    zassert_true(g_mock_send_call_count < 300,
+                 "tcp_send() was called far more than a bounded retry should "
+                 "allow — doip_send_all() looks unbounded");
+}
+
 ZTEST(doip_server_suite, test_doip_max_pdu_size_boundary)
 {
     /* A payload of exactly (DOIP_MAX_PDU_SIZE + 1) bytes in the length field
@@ -789,6 +1013,9 @@ void run_all_tests(void)
     RUN_TEST(doip_server_suite__test_doip_diagnostic_msg_extracts_uds_pdu_correctly);
     RUN_TEST(doip_server_suite__test_doip_diagnostic_msg_calls_uds_core);
     RUN_TEST(doip_server_suite__test_doip_response_wraps_in_doip_frame);
+    /* [Issue #105] doip_send_all() short-write regression tests */
+    RUN_TEST(doip_server_suite__test_doip_short_write_reassembles_large_response);
+    RUN_TEST(doip_server_suite__test_doip_short_write_bounded_retry_gives_up);
     RUN_TEST(doip_server_suite__test_doip_max_pdu_size_boundary);
     RUN_TEST(doip_server_suite__test_doip_handle_unknown_payload_type_ignored);
     /* NULL-pointer guards */

--- a/tests/unit_runnable/test_doip_server.c
+++ b/tests/unit_runnable/test_doip_server.c
@@ -38,7 +38,8 @@
  *     - test_doip_diagnostic_msg_calls_uds_core
  *     - test_doip_response_wraps_in_doip_frame
  *     - test_doip_short_write_reassembles_large_response (Issue #105)
- *     - test_doip_short_write_bounded_retry_gives_up (Issue #105)
+ *     - test_doip_short_write_slow_but_progressing_succeeds (Issue #105 follow-up)
+ *     - test_doip_short_write_stalled_peer_bounded_retry_gives_up (Issue #105 follow-up)
  *     - test_doip_max_pdu_size_boundary
  *     - test_doip_handle_unknown_payload_type_ignored
  *
@@ -78,6 +79,12 @@ static size_t   g_mock_send_chunk_cap;
  * a test assert the retry loop terminated after a bounded number of calls
  * rather than merely "the test function returned". */
 static int      g_mock_send_call_count;
+/* [Issue #105 follow-up] Simulate a genuinely stalled/wedged peer: when
+ * true, mock_tcp_send() accepts ZERO bytes on every call, regardless of
+ * g_mock_send_chunk_cap. This is distinct from a chunk cap (which still
+ * makes forward progress every call, however slowly) — only this mode
+ * should ever trip doip_send_all()'s bounded give-up. */
+static bool     g_mock_send_stall;
 
 /* Track calls */
 static int      g_mock_listen_calls;
@@ -106,6 +113,10 @@ static int mock_tcp_send(void *conn_ctx, const uint8_t *data, size_t len)
     g_mock_send_call_count++;
     if (g_mock_send_rc <= 0) {
         return g_mock_send_rc;
+    }
+    if (g_mock_send_stall) {
+        /* [Issue #105 follow-up] Wedged peer: never accepts a single byte. */
+        return 0;
     }
 
     /* [Issue #105] Simulate a short write: accept at most g_mock_send_chunk_cap
@@ -194,7 +205,8 @@ static void setup_mock_platform(void)
 
     g_mock_tx_len           = 0U;
     g_mock_send_rc          = 512; /* default: success */
-    g_mock_send_chunk_cap   = 0U;  /* default: accept full requested length */
+    g_mock_send_chunk_cap   = 0U;     /* default: accept full requested length */
+    g_mock_send_stall       = false;  /* default: not a wedged peer */
     g_mock_send_call_count  = 0;
     g_mock_listen_calls     = 0;
     g_mock_accept_calls     = 0;
@@ -832,15 +844,19 @@ ZTEST(doip_server_suite, test_doip_short_write_reassembles_large_response)
     zassert_false(mismatch, "reassembled response is not byte-identical to what was sent");
 }
 
-ZTEST(doip_server_suite, test_doip_short_write_bounded_retry_gives_up)
+ZTEST(doip_server_suite, test_doip_short_write_stalled_peer_bounded_retry_gives_up)
 {
-    /* doip_send_all() must NOT retry forever against a peer that never
-     * accepts more than a handful of bytes per call — a wedged or badly
-     * congested connection must not be able to hang the UDS task. We force
-     * a pathological 1-byte-per-call cap on a large (~4 KB) response, which
-     * no reasonable retry bound would ever walk to completion, and verify
-     * the call terminates promptly reporting failure rather than spinning
-     * until the buffer is naturally exhausted call-by-call (~4012 calls). */
+    /* doip_send_all() must NOT retry forever against a peer that accepts
+     * ZERO bytes, ever — a genuinely wedged connection must not be able to
+     * hang the UDS task. This is deliberately distinct from a merely slow
+     * connection (see test_doip_short_write_slow_but_progressing_succeeds
+     * below): g_mock_send_stall makes every tcp_send() call return 0 (no
+     * forward progress at all), which is the only thing that should ever
+     * trip the bound.
+     *
+     * [Issue #105 follow-up] doip_handle_frame() must also propagate this
+     * failure (non-OK return) so the caller — eds_doip_server_run() — tears
+     * the now-desynced connection down instead of leaving it open. */
     setup_mock_platform();
     uds_server_ctx_t *uds = init_uds_server_with_large_response();
     doip_server_state_t s = init_state(0xE400U);
@@ -851,33 +867,100 @@ ZTEST(doip_server_suite, test_doip_short_write_bounded_retry_gives_up)
 
     uint32_t frames_sent_before = s.frames_sent;
     g_mock_send_call_count = 0;
-    g_mock_send_chunk_cap  = 1U; /* pathological: accepts 1 byte per call */
+    g_mock_send_stall      = true; /* wedged peer: accepts 0 bytes, always */
 
     uint8_t diag_payload[7] = { 0x0E, 0x00, 0xE4, 0x00, 0x22, 0xF1, 0x90 };
     uds_status_t rc = doip_handle_frame(&s, uds, DOIP_PT_DIAGNOSTIC_MSG,
                                          diag_payload, 7U);
 
-    /* doip_handle_frame() itself still reports OK — a send failure on the
-     * response frame was already non-fatal to frame dispatch before this
-     * fix; this change only changes what counts as "sent", not whether
-     * send failures propagate out of doip_handle_frame(). */
-    zassert_equal(rc, UDS_STATUS_OK, "handle_frame should still return OK");
+    /* [Issue #105 follow-up] A desynced connection must be reported, not
+     * silently swallowed — this is what lets eds_doip_server_run() close it. */
+    zassert_not_equal(rc, UDS_STATUS_OK,
+                       "a stalled send must be reported so the caller "
+                       "closes the connection, not silently absorbed");
 
-    /* Only the small positive ack (well within any reasonable retry bound
-     * even at 1 byte/call) should have completed — the ~4 KB response must
-     * NOT be counted as sent. */
-    zassert_equal(s.frames_sent, frames_sent_before + 1U,
-                  "only the positive ack should have completed; the large "
-                  "response must be reported as failed, not silently "
-                  "counted as sent");
+    /* Nothing completed against a peer accepting zero bytes — not even the
+     * small positive ack. */
+    zassert_equal(s.frames_sent, frames_sent_before,
+                  "no frame should count as sent against a peer accepting "
+                  "zero bytes");
 
-    /* The retry loop must have given up long before it would take to walk
-     * the full ~4 KB frame one byte at a time (~4012 calls) — proving the
-     * bound in doip_send_all() actually engaged rather than looping until
-     * the buffer was naturally exhausted. */
-    zassert_true(g_mock_send_call_count < 300,
-                 "tcp_send() was called far more than a bounded retry should "
-                 "allow — doip_send_all() looks unbounded");
+    /* Bounded: doip_send_all() must give up after a small, fixed number of
+     * no-progress calls (the ack alone hits the cap here, since it fails
+     * before the large response is ever attempted), not spin forever. */
+    zassert_true(g_mock_send_call_count > 0 && g_mock_send_call_count <= 200,
+                 "tcp_send() call count against a stalled peer should be "
+                 "small and bounded, not unbounded");
+}
+
+ZTEST(doip_server_suite, test_doip_short_write_slow_but_progressing_succeeds)
+{
+    /* [Issue #105 follow-up] A send that is merely SLOW — real Ethernet
+     * under congestion, legitimately delivering well under the requested
+     * length on every call, but always delivering *something* — must
+     * complete, even when it needs far more calls than a flat attempt
+     * budget would allow. Only a truly stalled connection (zero forward
+     * progress, see the test above) may ever be given up on.
+     *
+     * This is the exact scenario issue #105 was filed for. An earlier
+     * version of this fix counted every call — progress or not — against
+     * one flat cap (128 attempts): a ~4 KB response delivered at 24 bytes/
+     * call needs ~168 calls, comfortably more than that flat budget, so a
+     * perfectly healthy (if congested) connection would have had its
+     * response silently dropped. This test pins that it no longer does. */
+    setup_mock_platform();
+    uds_server_ctx_t *uds = init_uds_server_with_large_response();
+    doip_server_state_t s = init_state(0xE400U);
+
+    uint8_t ra_payload[7];
+    build_routing_req_payload(ra_payload, 0x0E00U, 0x00U);
+    (void)doip_handle_frame(&s, uds, DOIP_PT_ROUTING_ACT_REQ, ra_payload, 7U);
+
+    memset(g_mock_tx_buf, 0, sizeof(g_mock_tx_buf));
+    g_mock_tx_len          = 0U;
+    g_mock_send_call_count = 0;
+    g_mock_send_chunk_cap  = 24U; /* slow: 24B/call, always forward progress */
+
+    uint8_t diag_payload[7] = { 0x0E, 0x00, 0xE4, 0x00, 0x22, 0xF1, 0x90 };
+    uds_status_t rc = doip_handle_frame(&s, uds, DOIP_PT_DIAGNOSTIC_MSG,
+                                         diag_payload, 7U);
+    zassert_equal(rc, UDS_STATUS_OK,
+                  "a slow-but-always-progressing send must still succeed");
+
+    /* Confirms this test actually exercises the tight-margin boundary a
+     * flat attempt cap would have missed, not a case any cap would pass. */
+    zassert_true(g_mock_send_call_count > 128,
+                 "test should need more calls than a flat 128-attempt "
+                 "budget would allow, to actually prove the fix");
+
+    /* Same byte-identical reassembly check as the 64B-cap test above —
+     * correct framing and every payload byte, not just "some frame arrived". */
+    uint32_t ack_payload_len = read_be32(&g_mock_tx_buf[4]);
+    size_t   resp_frame_off  = (size_t)DOIP_HEADER_LEN + (size_t)ack_payload_len;
+    zassert_true(resp_frame_off + DOIP_HEADER_LEN <= g_mock_tx_len,
+                 "response frame header missing from captured stream");
+
+    uint16_t resp_type = read_be16(&g_mock_tx_buf[resp_frame_off + 2U]);
+    zassert_equal(resp_type, (uint16_t)DOIP_PT_DIAGNOSTIC_MSG,
+                  "expected a DiagnosticMessage response frame after the ack");
+
+    uint32_t resp_payload_len = read_be32(&g_mock_tx_buf[resp_frame_off + 4U]);
+    zassert_equal(resp_payload_len, (uint32_t)(TEST_LARGE_RESP_LEN + 4U),
+                  "response frame's declared payload length is wrong");
+
+    size_t resp_total = resp_frame_off + (size_t)DOIP_HEADER_LEN + (size_t)resp_payload_len;
+    zassert_equal(resp_total, g_mock_tx_len,
+                  "captured byte stream is shorter/longer than the full frame");
+
+    const uint8_t *uds_resp = &g_mock_tx_buf[resp_frame_off + DOIP_HEADER_LEN + 4U];
+    bool mismatch = false;
+    for (uint16_t i = 0U; i < (uint16_t)TEST_LARGE_RESP_LEN; i++) {
+        if (uds_resp[i] != (uint8_t)(i & 0xFFU)) {
+            mismatch = true;
+            break;
+        }
+    }
+    zassert_false(mismatch, "reassembled response is not byte-identical to what was sent");
 }
 
 ZTEST(doip_server_suite, test_doip_max_pdu_size_boundary)
@@ -1015,7 +1098,8 @@ void run_all_tests(void)
     RUN_TEST(doip_server_suite__test_doip_response_wraps_in_doip_frame);
     /* [Issue #105] doip_send_all() short-write regression tests */
     RUN_TEST(doip_server_suite__test_doip_short_write_reassembles_large_response);
-    RUN_TEST(doip_server_suite__test_doip_short_write_bounded_retry_gives_up);
+    RUN_TEST(doip_server_suite__test_doip_short_write_slow_but_progressing_succeeds);
+    RUN_TEST(doip_server_suite__test_doip_short_write_stalled_peer_bounded_retry_gives_up);
     RUN_TEST(doip_server_suite__test_doip_max_pdu_size_boundary);
     RUN_TEST(doip_server_suite__test_doip_handle_unknown_payload_type_ignored);
     /* NULL-pointer guards */

--- a/transport/doip/doip_server.c
+++ b/transport/doip/doip_server.c
@@ -295,8 +295,19 @@ uds_status_t doip_handle_frame(doip_server_state_t *s,
             return UDS_STATUS_OK;
         }
 
-        /* Send positive ack before dispatching (ISO 13400-2 §9.5) */
-        (void)doip_send_diagnostic_positive_ack(s, src_addr, tgt_addr);
+        /* Send positive ack before dispatching (ISO 13400-2 §9.5).
+         *
+         * [Issue #105 follow-up] A failed/partial ack send leaves this
+         * connection's byte stream desynced — the peer may have received
+         * only part of a frame, with more of it never coming. Propagate
+         * the failure so the caller (eds_doip_server_run()) tears the
+         * connection down via its one existing close path, rather than
+         * dispatch a UDS request on a connection that's already corrupt. */
+        uds_status_t ack_rc = doip_send_diagnostic_positive_ack(s, src_addr, tgt_addr);
+        if (ack_rc != UDS_STATUS_OK) {
+            s->frames_received++;
+            return UDS_STATUS_ERR_PLATFORM;
+        }
 
         /* --- Assemble request into uds_msg_buf_t and dispatch --- */
         /* Use the static buffers in doip_server_state_t — no stack allocation
@@ -312,6 +323,7 @@ uds_status_t doip_handle_frame(doip_server_state_t *s,
         uds_status_t dispatch_rc = uds_server_process_request(uds_ctx,
                                                                req_buf,
                                                                resp_buf);
+        uds_status_t resp_send_rc = UDS_STATUS_OK;
         if (dispatch_rc == UDS_STATUS_OK && resp_buf->length > 0U) {
             /* Encode DoIP Diagnostic Message response:
              * payload = our_logical_addr(2B) + tester_addr(2B) + UDS_resp(N) */
@@ -327,9 +339,9 @@ uds_status_t doip_handle_frame(doip_server_state_t *s,
                              resp_buf->data,
                              (size_t)resp_buf->length);
 
-                uds_status_t send_rc = doip_send_all(
+                resp_send_rc = doip_send_all(
                     s, s->tx_buf, (size_t)(DOIP_HEADER_LEN + resp_payload_len));
-                if (send_rc == UDS_STATUS_OK) {
+                if (resp_send_rc == UDS_STATUS_OK) {
                     s->frames_sent++;
                 }
             }
@@ -338,6 +350,15 @@ uds_status_t doip_handle_frame(doip_server_state_t *s,
          * no response frame is sent (ISO 14229-1 §7.5.2.4). This is
          * handled inside uds_server_process_request — resp_buf->length == 0. */
         s->frames_received++;
+
+        /* [Issue #105 follow-up] Same reasoning as the ack above: a failed
+         * response send can leave a partial DoIP frame on the wire, so the
+         * connection must be torn down rather than left open — the peer
+         * would otherwise wait on bytes that are never coming, or misparse
+         * whatever arrives next as a continuation of this frame. */
+        if (resp_send_rc != UDS_STATUS_OK) {
+            return UDS_STATUS_ERR_PLATFORM;
+        }
         return UDS_STATUS_OK;
     }
 
@@ -435,9 +456,22 @@ uds_status_t eds_doip_server_run(doip_server_state_t *s,
             }
 
             /* --- Dispatch --- */
-            (void)doip_handle_frame(s, uds_ctx, payload_type,
-                                     (payload_len > 0U) ? s->rx_buf : NULL,
-                                     payload_len);
+            uds_status_t dispatch_status = doip_handle_frame(
+                s, uds_ctx, payload_type,
+                (payload_len > 0U) ? s->rx_buf : NULL,
+                payload_len);
+            if (dispatch_status != UDS_STATUS_OK) {
+                /* [Issue #105 follow-up] doip_handle_frame() reports non-OK
+                 * here only when a response send inside it failed (s and
+                 * uds_ctx are already validated non-NULL above, so the
+                 * NULL-guard paths cannot fire from this call site) —
+                 * doip_send_all() gave up on a stalled peer, or a partial
+                 * send left the byte stream desynced. Either way the
+                 * connection is no longer trustworthy: close it via the
+                 * same cleanup path used for recv failures and malformed
+                 * headers, rather than keep reading frames on it. */
+                goto connection_closed;
+            }
         }
 
 connection_closed:
@@ -456,15 +490,24 @@ connection_closed:
  * Internal: send helpers — all build in s->tx_buf to avoid stack allocation
  * ------------------------------------------------------------------------ */
 
-/* Maximum tcp_send() attempts per doip_send_all() call.
+/* Maximum CONSECUTIVE no-progress tcp_send() calls (return <= 0) that
+ * doip_send_all() will tolerate before giving up.
  *
- * A well-behaved backend delivers a full frame (up to DOIP_HEADER_LEN +
- * DOIP_MAX_PDU_SIZE, ~4.1 KB here) in far fewer calls than this even with an
- * aggressively small per-call chunk (e.g. a 64-byte cap needs ~65 calls for
- * the largest frame). This bound exists purely so a wedged, congested, or
- * otherwise misbehaving peer cannot spin the UDS task indefinitely retrying
- * a send that is never going to finish — see issue #105. */
-#define DOIP_SEND_ALL_MAX_ATTEMPTS (128U)
+ * Deliberately NOT a cap on the total number of calls: a call that sends
+ * at least one byte, however few, resets this counter to zero and does not
+ * count against it. A merely SLOW connection — real Ethernet under
+ * congestion, legitimately delivering well under the requested length per
+ * call but always delivering *something* — is bounded only by the frame
+ * length itself (every successful call advances by >=1 byte, so the loop
+ * always terminates for a healthy link, however long it takes) and can
+ * never be killed here. Only a connection that is genuinely stalled —
+ * DOIP_SEND_ALL_MAX_STALLS calls in a row that accept zero bytes or error
+ * out — hits this cap, so a wedged/broken peer still cannot spin the UDS
+ * task forever. (An earlier version of this fix counted every call,
+ * progress or not, against one flat cap — that could drop a perfectly
+ * good response under exactly the "real Ethernet under congestion"
+ * scenario issue #105 was filed for; see the PR discussion.) */
+#define DOIP_SEND_ALL_MAX_STALLS (128U)
 
 /* Retry tcp_send() until len bytes of buf are on the wire, or a hard error /
  * stalled peer is detected.
@@ -479,26 +522,33 @@ connection_closed:
  * whole write in one call — it surfaces on real Ethernet under congestion,
  * with large diagnostic responses, or against a stricter TCP stack.
  *
- * Bounded by DOIP_SEND_ALL_MAX_ATTEMPTS: each call that sends zero bytes or
- * errors is treated as a hard failure immediately (nothing to retry
- * blindly), and each call that makes forward progress still counts against
- * the attempt cap, so this loop always terminates. */
+ * This loop assumes tcp_send() has BLOCKING-socket semantics (each call
+ * either transmits >0 bytes, blocks, or fails — it does not busy-return 0
+ * to mean "would block"); every current backend (Zephyr/LwIP, FreeRTOS/
+ * LwIP) is blocking. A non-blocking backend that returns 0 for "try again
+ * later" would busy-spin this loop against DOIP_SEND_ALL_MAX_STALLS instead
+ * of yielding — not addressed here, since no such backend exists today.
+ *
+ * Bounded by DOIP_SEND_ALL_MAX_STALLS consecutive no-progress calls — see
+ * that macro's doc comment for why total call count is not the bound. */
 static uds_status_t doip_send_all(doip_server_state_t *s, const uint8_t *buf, size_t len)
 {
-    size_t   sent     = 0U;
-    uint32_t attempts = 0U;
+    size_t   sent   = 0U;
+    uint32_t stalls = 0U;
 
     while (sent < len) {
-        if (attempts >= DOIP_SEND_ALL_MAX_ATTEMPTS) {
-            return UDS_STATUS_ERR_PLATFORM;
-        }
-        attempts++;
-
         int n = s_ops->tcp_send(s->conn_ctx, &buf[sent], len - sent);
-        if (n <= 0) {
+        if (n > 0) {
+            sent  += (size_t)n;
+            stalls = 0U;
+            continue;
+        }
+
+        /* No bytes accepted this call (or a hard error) — retry, bounded. */
+        stalls++;
+        if (stalls >= DOIP_SEND_ALL_MAX_STALLS) {
             return UDS_STATUS_ERR_PLATFORM;
         }
-        sent += (size_t)n;
     }
     return UDS_STATUS_OK;
 }

--- a/transport/doip/doip_server.c
+++ b/transport/doip/doip_server.c
@@ -60,6 +60,9 @@ static uds_status_t doip_send_frame(doip_server_state_t *s,
                                      uint16_t payload_type,
                                      const uint8_t *payload,
                                      uint32_t payload_len);
+static uds_status_t doip_send_all(doip_server_state_t *s,
+                                   const uint8_t *buf,
+                                   size_t len);
 
 /* ---------------------------------------------------------------------------
  * Frame byte layout helpers
@@ -324,10 +327,9 @@ uds_status_t doip_handle_frame(doip_server_state_t *s,
                              resp_buf->data,
                              (size_t)resp_buf->length);
 
-                int send_rc = s_ops->tcp_send(s->conn_ctx,
-                                              s->tx_buf,
-                                              (size_t)(DOIP_HEADER_LEN + resp_payload_len));
-                if (send_rc > 0) {
+                uds_status_t send_rc = doip_send_all(
+                    s, s->tx_buf, (size_t)(DOIP_HEADER_LEN + resp_payload_len));
+                if (send_rc == UDS_STATUS_OK) {
                     s->frames_sent++;
                 }
             }
@@ -454,6 +456,53 @@ connection_closed:
  * Internal: send helpers — all build in s->tx_buf to avoid stack allocation
  * ------------------------------------------------------------------------ */
 
+/* Maximum tcp_send() attempts per doip_send_all() call.
+ *
+ * A well-behaved backend delivers a full frame (up to DOIP_HEADER_LEN +
+ * DOIP_MAX_PDU_SIZE, ~4.1 KB here) in far fewer calls than this even with an
+ * aggressively small per-call chunk (e.g. a 64-byte cap needs ~65 calls for
+ * the largest frame). This bound exists purely so a wedged, congested, or
+ * otherwise misbehaving peer cannot spin the UDS task indefinitely retrying
+ * a send that is never going to finish — see issue #105. */
+#define DOIP_SEND_ALL_MAX_ATTEMPTS (128U)
+
+/* Retry tcp_send() until len bytes of buf are on the wire, or a hard error /
+ * stalled peer is detected.
+ *
+ * POSIX send() (and the LwIP/FreeRTOS backends behind
+ * eds_doip_platform_ops_t) may legally transmit fewer bytes than requested
+ * on a single call — this is not a socket error. Treating any positive
+ * return as "fully sent" silently drops the remainder, producing a
+ * truncated DoIP frame on the wire: the DoIP header advertises a payload
+ * length the peer never fully receives. This will not reproduce on
+ * loopback/native_sim, where the socket buffer virtually always accepts the
+ * whole write in one call — it surfaces on real Ethernet under congestion,
+ * with large diagnostic responses, or against a stricter TCP stack.
+ *
+ * Bounded by DOIP_SEND_ALL_MAX_ATTEMPTS: each call that sends zero bytes or
+ * errors is treated as a hard failure immediately (nothing to retry
+ * blindly), and each call that makes forward progress still counts against
+ * the attempt cap, so this loop always terminates. */
+static uds_status_t doip_send_all(doip_server_state_t *s, const uint8_t *buf, size_t len)
+{
+    size_t   sent     = 0U;
+    uint32_t attempts = 0U;
+
+    while (sent < len) {
+        if (attempts >= DOIP_SEND_ALL_MAX_ATTEMPTS) {
+            return UDS_STATUS_ERR_PLATFORM;
+        }
+        attempts++;
+
+        int n = s_ops->tcp_send(s->conn_ctx, &buf[sent], len - sent);
+        if (n <= 0) {
+            return UDS_STATUS_ERR_PLATFORM;
+        }
+        sent += (size_t)n;
+    }
+    return UDS_STATUS_OK;
+}
+
 static uds_status_t doip_send_frame(doip_server_state_t *s,
                                      uint16_t payload_type,
                                      const uint8_t *payload,
@@ -467,14 +516,12 @@ static uds_status_t doip_send_frame(doip_server_state_t *s,
     if (payload != NULL && payload_len > 0U) {
         (void)memcpy(&s->tx_buf[DOIP_HEADER_LEN], payload, (size_t)payload_len);
     }
-    int rc = s_ops->tcp_send(s->conn_ctx,
-                              s->tx_buf,
-                              (size_t)(DOIP_HEADER_LEN + payload_len));
-    if (rc > 0) {
+    uds_status_t rc = doip_send_all(s, s->tx_buf,
+                                     (size_t)(DOIP_HEADER_LEN + payload_len));
+    if (rc == UDS_STATUS_OK) {
         s->frames_sent++;
-        return UDS_STATUS_OK;
     }
-    return UDS_STATUS_ERR_PLATFORM;
+    return rc;
 }
 
 static uds_status_t doip_send_routing_activation_response(doip_server_state_t *s,

--- a/transport/doip/doip_server.h
+++ b/transport/doip/doip_server.h
@@ -153,6 +153,14 @@ typedef struct eds_doip_platform_ops {
     /**
      * @brief Send data on an established TCP connection.
      *
+     * May transmit fewer bytes than requested (a short write) — the caller
+     * (doip_send_all() in doip_server.c) retries until the full buffer is
+     * sent. That retry loop assumes BLOCKING-socket semantics: each call
+     * either transmits >0 bytes, blocks until it can, or fails — it does
+     * not busy-return 0 to mean "nothing sent, try again later" the way a
+     * non-blocking socket's EWOULDBLOCK might. A non-blocking implementation
+     * of this callback is not supported as-is.
+     *
      * @param[in] conn_ctx  Connection handle from tcp_accept().
      * @param[in] data      Bytes to transmit.
      * @param[in] len       Number of bytes.

--- a/transport/doip/doip_server.h
+++ b/transport/doip/doip_server.h
@@ -11,7 +11,8 @@
  *          This is the firmware counterpart to xaloqi-tester DoipBus (Python).
  *
  *          Supported in v1.7.0:
- *            - TCP connection accept (up to DOIP_MAX_CONNECTIONS)
+ *            - TCP connection accept (one active connection at a time,
+ *              served serially — see DOIP_MAX_CONNECTIONS below)
  *            - Routing Activation Request/Response (Default type 0x00)
  *            - UDS DiagnosticMessage (0x8001): receive, dispatch, respond
  *            - DiagnosticMessage Positive Ack (0x8002)
@@ -92,7 +93,11 @@ extern "C" {
 #define DOIP_MAX_PDU_SIZE       (4096U)
 #endif
 
-/** Maximum concurrent TCP clients accepted. */
+/** TCP listen() backlog — the number of pending inbound connections the
+ * platform accept queue will hold. This is NOT the number of connections
+ * served concurrently: eds_doip_server_run() handles one connection at a
+ * time (serial model, see eds_doip_server_run() below) — a queued client
+ * waits until the current one closes before tcp_accept() picks it up. */
 #ifndef DOIP_MAX_CONNECTIONS
 #define DOIP_MAX_CONNECTIONS    (4U)
 #endif


### PR DESCRIPTION
## Summary

Both `tcp_send()` call sites in `transport/doip/doip_server.c` treated any
positive return as "fully sent". POSIX `send()` (and the LwIP/FreeRTOS
backends behind `eds_doip_platform_ops_t`) may legally transmit fewer bytes
than requested — this is not an error. The remainder was silently dropped,
producing a **truncated DoIP frame** on the wire: the DoIP header advertises
a payload length the peer never fully receives, so the tester either stalls
waiting for the remainder or mis-frames the next message.

This never reproduced on loopback/`native_sim`, where a single `tcp_send()`
call virtually always accepts the whole buffer — which is exactly why the
existing DoIP tests passed while this bug shipped. It surfaces on real
Ethernet under congestion, with large diagnostic responses (up to ~4 KB
here), or against a stricter TCP stack's buffering behaviour.

Closes #105

## Fix

Added `doip_send_all()` in `transport/doip/doip_server.c`: a bounded retry
loop around `tcp_send()` that keeps calling it — advancing by however many
bytes the platform actually accepted each time — until the full buffer is
on the wire, or a hard error / zero-byte call is hit (immediate failure,
nothing to retry blindly). Both former call sites now go through this
helper instead of a single raw `s_ops->tcp_send()` call:

- `doip_handle_frame()` — UDS diagnostic response path
- `doip_send_frame()` — the generic send helper used by routing-activation
  response, positive/negative ack, and alive-check response

**Bounded, not infinite**: the loop gives up after
`DOIP_SEND_ALL_MAX_ATTEMPTS` (128) `tcp_send()` calls, so a wedged or
badly-congested peer cannot spin the UDS task indefinitely. 128 attempts is
sized with headroom above what any well-behaved backend needs even under an
aggressive 64-byte-per-call cap for the largest possible frame (~4.1 KB
header+payload, ~65 calls at that cap) — see the doc comment on the
`#define` in `doip_server.c` for the full reasoning.

`doip_handle_frame()`'s send-failure handling is unchanged in shape: before
this fix a failed `tcp_send()` at that call site was already silently
non-fatal to frame dispatch (no `else` branch); it still is — this fix only
changes what counts as "successfully sent" (drops the "any positive return"
assumption), not whether a real send failure propagates out of
`doip_handle_frame()`.

## Test — the actual deliverable

`tests/unit_runnable/test_doip_server.c`'s `mock_tcp_send()` gained a
`g_mock_send_chunk_cap` knob: when set, the mock accepts at most that many
bytes per call regardless of what was requested, modelling a real TCP stack
under congestion. This is wired into the *existing* DoIP mock platform
ops — no new test scaffolding — and is backward compatible (defaults to 0 =
old "always accept everything" behaviour, so none of the other 24 existing
`test_doip_server` cases changed behaviour).

Two new regression tests:

- **`test_doip_short_write_reassembles_large_response`** — caps every
  `tcp_send()` call at 64 bytes, dispatches a ReadDataByIdentifier request
  to a handler that returns a ~4 KB response filled with a
  position-dependent byte pattern, and asserts the reassembled DoIP frame
  on the "wire" (captured mock buffer) is **byte-identical** — correct
  framing (type, declared length, addressing) *and* every payload byte.
  This is the test that would have caught #105.
- **`test_doip_short_write_bounded_retry_gives_up`** — caps every call at 1
  byte (pathological), against the same ~4 KB response. Asserts
  `doip_send_all()` reports the frame as failed (not silently counted as
  sent) and that `tcp_send()` was called far fewer times than the ~4000+
  calls it would take to walk the buffer one byte at a time — i.e. the
  retry bound actually engaged rather than looping until the buffer was
  naturally exhausted.

Getting the large-response handler wired up required a small refactor of
the test file's UDS server bring-up (`init_uds_server_with_ctx()`,
parameterised over session/security/server context pointers) — the
existing `uds_server_ctx_t`/`uds_session_ctx_t` are process-wide statics
that refuse to re-initialise once already initialised, so a config using a
non-empty service table needs its own dedicated static context set rather
than reusing the one every other `test_doip_server` case shares.

## Also included (per the issue's provenance note)

The issue's provenance note flagged that `DOIP_MAX_CONNECTIONS = 4` is
*not* itself a bug (it's correctly used only as the `listen()` backlog),
but the constant name and the `doip_server.h:14` comment
("TCP connection accept (up to DOIP_MAX_CONNECTIONS)") read as if the
server handles concurrent connections, when `eds_doip_server_run()` is
serial — one connection at a time. Reworded both comments to say so
explicitly; left the constant name alone (renaming would touch the two
platform backends — `zephyr_lwip.c`, `freertos_lwip.c` — for a
comment-only issue, not worth the ripple).

## Gates

- `bash build_tests.sh` — **43/43 passed** (was 43/43 on `main` before this
  change; `test_doip_server` itself went from 24 to 26 passing ZTEST
  cases — the two new ones).
- Also verified via the CMake/ctest path CI uses separately
  (`cmake -S tests -B build && cmake --build build && ctest --test-dir
  build`) — **43/43 passed**, zero compiler warnings under `-Wall -Wextra`.
- `bash build_harness.sh --run` — **not run**: harness sources
  (Professional-tier, gitignored, ZIP-delivered) are not present in this
  checkout, and `build_harness.sh` itself detects this and exits early with
  that explanation. Nothing in this change touches harness-only code paths.
- `python3 misra_analysis.py --gcc-only --src-dirs transport/doip` —
  **0 findings** on the touched module. (`cppcheck` isn't installed in this
  sandbox, so I couldn't run the full MISRA-addon pass locally the way CI's
  `static-analysis` job does — flagging that gap rather than claiming
  MISRA coverage I didn't actually check.)

## Heightened review note

`transport/doip/doip_server.c` is on CONTRIBUTING.md's safety-relevant
list (DoIP server, ISO 13400-2) requiring explicit human sign-off
(`Reviewed-by: <name>`) beyond CI passing. This PR is opened for that
review — not merged by me.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
