### PR TITLE
fix(doip): send NRC 0x14 instead of silently dropping 4085-4095 byte UDS responses

### DIFF
--- a/tests/unit_runnable/test_doip_server.c
+++ b/tests/unit_runnable/test_doip_server.c
@@ -41,6 +41,9 @@
  *     - test_doip_short_write_slow_but_progressing_succeeds (Issue #105 follow-up)
  *     - test_doip_short_write_stalled_peer_bounded_retry_gives_up (Issue #105 follow-up)
  *     - test_doip_max_pdu_size_boundary
+ *     - test_doip_oversized_response_returns_nrc_0x14 (Issue #108)
+ *     - test_doip_response_4084_bytes_still_sent_positive (Issue #108, boundary)
+ *     - test_doip_response_4085_bytes_triggers_nrc_0x14 (Issue #108, boundary)
  *     - test_doip_handle_unknown_payload_type_ignored
  *
  * FRAMEWORK: Zephyr Ztest (shim used for host builds — see tests/runner/)
@@ -333,6 +336,42 @@ static uds_server_ctx_t *init_uds_server_with_large_response(void)
     return init_uds_server_with_ctx(&g_session_ctx_large_resp,
                                      &g_security_ctx_large_resp,
                                      &g_uds_ctx_large_resp,
+                                     table, 1U);
+}
+
+/* [Issue #108] Service handler with a caller-configurable response length,
+ * so the DoIP frame-budget boundary (in-budget / dead-zone) can be exercised
+ * at exact byte counts (4084, 4085, ~4090) rather than only the fixed 4000B
+ * used by the #105 short-write tests above. Filled with the same
+ * position-dependent byte pattern so a positive-response test can still
+ * verify byte-identical payload, not just framing. */
+static uint16_t g_variable_resp_len;
+
+static uds_status_t handler_variable_response(uds_server_ctx_t *ctx,
+                                               const uds_msg_buf_t *req,
+                                               uds_msg_buf_t *resp)
+{
+    (void)ctx;
+    (void)req;
+    for (uint16_t i = 0U; i < g_variable_resp_len; i++) {
+        resp->data[i] = (uint8_t)(i & 0xFFU);
+    }
+    resp->length = g_variable_resp_len;
+    return UDS_STATUS_OK;
+}
+
+static uds_session_ctx_t   g_session_ctx_var_resp;
+static uds_security_ctx_t  g_security_ctx_var_resp;
+static uds_server_ctx_t    g_uds_ctx_var_resp;
+
+static uds_server_ctx_t *init_uds_server_with_variable_response(void)
+{
+    static const uds_service_entry_t table[] = {
+        { 0x22U, handler_variable_response, false },
+    };
+    return init_uds_server_with_ctx(&g_session_ctx_var_resp,
+                                     &g_security_ctx_var_resp,
+                                     &g_uds_ctx_var_resp,
                                      table, 1U);
 }
 
@@ -1010,6 +1049,155 @@ ZTEST(doip_server_suite, test_doip_max_pdu_size_boundary)
                   "wrong NACK code for oversized PDU");
 }
 
+/* =========================================================================
+ * Tests — Issue #108: oversized *response* (4085-4095 bytes) must not be
+ * silently dropped. uds_msg_buf_t.data holds up to UDS_MAX_PAYLOAD_LEN
+ * (4095) bytes, but a DoIP frame can only carry up to
+ * DOIP_MAX_PDU_SIZE - DOIP_HEADER_LEN (4088) bytes of payload, of which 4
+ * are the response addressing header — so a dispatched positive response
+ * longer than 4084 bytes used to fall through every branch with nothing
+ * sent at all. The fix downgrades that case to a UDS negative response
+ * (NRC 0x14 RESPONSE_TOO_LONG), which always fits.
+ * ========================================================================= */
+
+/* Helper: locate the diagnostic-message response frame that follows the
+ * positive ack in the captured tx stream, and return its UDS payload
+ * pointer/length via out-params. Mirrors the offset logic already used by
+ * the #105 short-write tests above.
+ *
+ * Must return void: zassert_*() (see ztest_shim.h) expands to a bare
+ * `return;` on failure, which only compiles inside a void function. */
+static void find_diag_response_uds_payload(uint16_t *out_uds_len,
+                                            const uint8_t **out_uds_payload)
+{
+    uint32_t ack_payload_len = read_be32(&g_mock_tx_buf[4]);
+    size_t   resp_frame_off  = (size_t)DOIP_HEADER_LEN + (size_t)ack_payload_len;
+
+    zassert_true(resp_frame_off + DOIP_HEADER_LEN <= g_mock_tx_len,
+                 "response frame header missing from captured stream");
+
+    uint16_t resp_type = read_be16(&g_mock_tx_buf[resp_frame_off + 2U]);
+    zassert_equal(resp_type, (uint16_t)DOIP_PT_DIAGNOSTIC_MSG,
+                  "expected a DiagnosticMessage response frame after the ack");
+
+    uint32_t resp_payload_len = read_be32(&g_mock_tx_buf[resp_frame_off + 4U]);
+    size_t resp_total = resp_frame_off + (size_t)DOIP_HEADER_LEN + (size_t)resp_payload_len;
+    zassert_equal(resp_total, g_mock_tx_len,
+                  "captured byte stream is shorter/longer than the full frame");
+
+    /* resp_payload_len = 4 addressing bytes + UDS payload */
+    zassert_true(resp_payload_len >= 4U, "response frame payload too short to hold addressing");
+    *out_uds_len     = (uint16_t)(resp_payload_len - 4U);
+    *out_uds_payload = &g_mock_tx_buf[resp_frame_off + DOIP_HEADER_LEN + 4U];
+}
+
+ZTEST(doip_server_suite, test_doip_oversized_response_returns_nrc_0x14)
+{
+    /* A service handler response of ~4090 bytes — squarely in the 4085-4095
+     * dead zone — must now produce a DoIP frame carrying a UDS 0x7F
+     * negative response with NRC 0x14 (RESPONSE_TOO_LONG), not silence. */
+    setup_mock_platform();
+    uds_server_ctx_t *uds = init_uds_server_with_variable_response();
+    doip_server_state_t s = init_state(0xE400U);
+
+    uint8_t ra_payload[7];
+    build_routing_req_payload(ra_payload, 0x0E00U, 0x00U);
+    (void)doip_handle_frame(&s, uds, DOIP_PT_ROUTING_ACT_REQ, ra_payload, 7U);
+
+    memset(g_mock_tx_buf, 0, sizeof(g_mock_tx_buf));
+    g_mock_tx_len        = 0U;
+    g_variable_resp_len  = 4090U;
+
+    /* ReadDataByIdentifier (SID 0x22) — dispatched to handler_variable_response(). */
+    uint8_t diag_payload[7] = { 0x0E, 0x00, 0xE4, 0x00, 0x22, 0xF1, 0x90 };
+    uds_status_t rc = doip_handle_frame(&s, uds, DOIP_PT_DIAGNOSTIC_MSG,
+                                         diag_payload, 7U);
+    zassert_equal(rc, UDS_STATUS_OK, "handle_frame failed for oversized response");
+
+    uint16_t uds_len = 0U;
+    const uint8_t *uds_resp = NULL;
+    find_diag_response_uds_payload(&uds_len, &uds_resp);
+
+    zassert_equal(uds_len, 3U,
+                  "negative response PDU should be exactly 3 bytes (SID, 0x7F, orig SID, NRC)");
+    zassert_equal(uds_resp[0], (uint8_t)UDS_SID_NEGATIVE_RESPONSE, "expected 0x7F negative response SID");
+    zassert_equal(uds_resp[1], 0x22U, "negative response should echo original SID (0x22)");
+    zassert_equal(uds_resp[2], (uint8_t)UDS_NRC_RESPONSE_TOO_LONG,
+                  "expected NRC 0x14 RESPONSE_TOO_LONG for an oversized response");
+}
+
+ZTEST(doip_server_suite, test_doip_response_4084_bytes_still_sent_positive)
+{
+    /* Boundary regression: exactly 4084 bytes is still the largest response
+     * that fits (4084 + 4 addressing bytes == DOIP_MAX_PDU_SIZE - DOIP_HEADER_LEN
+     * == 4088), so it must still be sent as the normal, unmodified positive
+     * response — proving the new dead-zone branch didn't disturb the
+     * existing in-budget path. */
+    setup_mock_platform();
+    uds_server_ctx_t *uds = init_uds_server_with_variable_response();
+    doip_server_state_t s = init_state(0xE400U);
+
+    uint8_t ra_payload[7];
+    build_routing_req_payload(ra_payload, 0x0E00U, 0x00U);
+    (void)doip_handle_frame(&s, uds, DOIP_PT_ROUTING_ACT_REQ, ra_payload, 7U);
+
+    memset(g_mock_tx_buf, 0, sizeof(g_mock_tx_buf));
+    g_mock_tx_len        = 0U;
+    g_variable_resp_len  = 4084U;
+
+    uint8_t diag_payload[7] = { 0x0E, 0x00, 0xE4, 0x00, 0x22, 0xF1, 0x90 };
+    uds_status_t rc = doip_handle_frame(&s, uds, DOIP_PT_DIAGNOSTIC_MSG,
+                                         diag_payload, 7U);
+    zassert_equal(rc, UDS_STATUS_OK, "handle_frame failed at the 4084-byte boundary");
+
+    uint16_t uds_len = 0U;
+    const uint8_t *uds_resp = NULL;
+    find_diag_response_uds_payload(&uds_len, &uds_resp);
+
+    zassert_equal(uds_len, 4084U, "expected the full 4084-byte positive response, unmodified");
+    bool mismatch = false;
+    for (uint16_t i = 0U; i < 4084U; i++) {
+        if (uds_resp[i] != (uint8_t)(i & 0xFFU)) {
+            mismatch = true;
+            break;
+        }
+    }
+    zassert_false(mismatch, "4084-byte positive response payload must be byte-identical");
+}
+
+ZTEST(doip_server_suite, test_doip_response_4085_bytes_triggers_nrc_0x14)
+{
+    /* Boundary at the new edge: 4085 bytes is the first response length
+     * that no longer fits, and must trigger the NRC 0x14 downgrade path. */
+    setup_mock_platform();
+    uds_server_ctx_t *uds = init_uds_server_with_variable_response();
+    doip_server_state_t s = init_state(0xE400U);
+
+    uint8_t ra_payload[7];
+    build_routing_req_payload(ra_payload, 0x0E00U, 0x00U);
+    (void)doip_handle_frame(&s, uds, DOIP_PT_ROUTING_ACT_REQ, ra_payload, 7U);
+
+    memset(g_mock_tx_buf, 0, sizeof(g_mock_tx_buf));
+    g_mock_tx_len        = 0U;
+    g_variable_resp_len  = 4085U;
+
+    uint8_t diag_payload[7] = { 0x0E, 0x00, 0xE4, 0x00, 0x22, 0xF1, 0x90 };
+    uds_status_t rc = doip_handle_frame(&s, uds, DOIP_PT_DIAGNOSTIC_MSG,
+                                         diag_payload, 7U);
+    zassert_equal(rc, UDS_STATUS_OK, "handle_frame failed at the 4085-byte boundary");
+
+    uint16_t uds_len = 0U;
+    const uint8_t *uds_resp = NULL;
+    find_diag_response_uds_payload(&uds_len, &uds_resp);
+
+    zassert_equal(uds_len, 3U,
+                  "negative response PDU should be exactly 3 bytes (SID, 0x7F, orig SID, NRC)");
+    zassert_equal(uds_resp[0], (uint8_t)UDS_SID_NEGATIVE_RESPONSE, "expected 0x7F negative response SID");
+    zassert_equal(uds_resp[1], 0x22U, "negative response should echo original SID (0x22)");
+    zassert_equal(uds_resp[2], (uint8_t)UDS_NRC_RESPONSE_TOO_LONG,
+                  "expected NRC 0x14 RESPONSE_TOO_LONG at the 4085-byte boundary");
+}
+
 ZTEST(doip_server_suite, test_doip_handle_unknown_payload_type_ignored)
 {
     setup_mock_platform();
@@ -1101,6 +1289,9 @@ void run_all_tests(void)
     RUN_TEST(doip_server_suite__test_doip_short_write_slow_but_progressing_succeeds);
     RUN_TEST(doip_server_suite__test_doip_short_write_stalled_peer_bounded_retry_gives_up);
     RUN_TEST(doip_server_suite__test_doip_max_pdu_size_boundary);
+    RUN_TEST(doip_server_suite__test_doip_oversized_response_returns_nrc_0x14);
+    RUN_TEST(doip_server_suite__test_doip_response_4084_bytes_still_sent_positive);
+    RUN_TEST(doip_server_suite__test_doip_response_4085_bytes_triggers_nrc_0x14);
     RUN_TEST(doip_server_suite__test_doip_handle_unknown_payload_type_ignored);
     /* NULL-pointer guards */
     RUN_TEST(doip_server_suite__test_doip_server_init_null_guard);

--- a/transport/doip/doip_server.c
+++ b/transport/doip/doip_server.c
@@ -277,6 +277,12 @@ uds_status_t doip_handle_frame(doip_server_state_t *s,
         const uint8_t *uds_pdu = &payload[4];
         uint32_t uds_len   = payload_len - 4U;
 
+        /* [Issue #108] Capture the request's SID now, before req_buf/resp_buf
+         * are filled and (potentially) overwritten below — it is needed
+         * after dispatch to build a negative response if the dispatched
+         * response turns out too large to fit a DoIP frame. */
+        uint8_t original_sid = (uds_len >= 1U) ? uds_pdu[0] : 0U;
+
         /* Validate source matches activated tester */
         if (src_addr != s->tester_address) {
             (void)doip_send_diagnostic_negative_ack(s, DOIP_NACK_INVALID_SRC);
@@ -328,6 +334,44 @@ uds_status_t doip_handle_frame(doip_server_state_t *s,
             /* Encode DoIP Diagnostic Message response:
              * payload = our_logical_addr(2B) + tester_addr(2B) + UDS_resp(N) */
             uint32_t resp_payload_len = (uint32_t)resp_buf->length + 4U;
+
+            /* [Issue #108] The dispatched positive response does not fit
+             * this connection's DoIP frame budget (uds_msg_buf_t.data is
+             * sized up to UDS_MAX_PAYLOAD_LEN=4095 bytes, 11 bytes above
+             * what a DOIP_MAX_PDU_SIZE frame can carry after the 4-byte
+             * DoIP address header and DOIP_HEADER_LEN). The request's
+             * positive ack was already sent (ISO 13400-2 §9.5), so the
+             * tester is committed to waiting for a response frame here —
+             * dropping it silently just leaves the tester to time out on
+             * its own P2 timer. Downgrade to a UDS negative response
+             * (NRC 0x14 RESPONSE_TOO_LONG, ISO 14229-1) instead: it is
+             * always small (SID + 0x7F + original SID + NRC), so it is
+             * guaranteed to fit, and gives the tester a deterministic
+             * protocol-level rejection rather than silence.
+             *
+             * Deliberately NOT counted in ctx->negative_response_count: that
+             * counter lives in the UDS core (core/uds_server.c) and tracks
+             * outcomes of the *dispatch* itself (bad SID, access denied,
+             * handler error) — see uds_server_process_request(). Here,
+             * dispatch succeeded (dispatch_rc == UDS_STATUS_OK); the
+             * *transport* is what could not carry the result. Folding this
+             * in would blur two different failure classes behind one
+             * counter and would mean reaching into uds_server_ctx_t's
+             * internals from the transport layer, which this module
+             * otherwise never does (uds_ctx is always treated as opaque,
+             * passed only to uds_server_process_request()). */
+            if (resp_payload_len > (uint32_t)(DOIP_MAX_PDU_SIZE - DOIP_HEADER_LEN)) {
+                (void)uds_server_build_negative_response(original_sid,
+                                                          UDS_NRC_RESPONSE_TOO_LONG,
+                                                          resp_buf);
+                resp_payload_len = (uint32_t)resp_buf->length + 4U;
+            }
+            /* This guard now always holds once the downgrade above has run
+             * (the NRC PDU it builds is a fixed 3 bytes, well under budget);
+             * kept as an explicit, self-contained check anyway — rather than
+             * an `else`/unconditional fall-through — so this block's
+             * correctness never silently depends on that invariant holding
+             * elsewhere. */
             if (resp_payload_len <= (uint32_t)(DOIP_MAX_PDU_SIZE - DOIP_HEADER_LEN)) {
                 (void)doip_encode_header(s->tx_buf, DOIP_PT_DIAGNOSTIC_MSG,
                                          resp_payload_len);


### PR DESCRIPTION
Closes #108

## Bug

`doip_handle_frame()`'s `DOIP_PT_DIAGNOSTIC_MSG` case only sends the dispatched
UDS response if it fits the DoIP frame budget:

```c
uint32_t resp_payload_len = resp_buf->length + 4U; /* + 4B addressing header */
if (resp_payload_len <= DOIP_MAX_PDU_SIZE - DOIP_HEADER_LEN) {
    /* build + send frame */
}
```

`DOIP_MAX_PDU_SIZE - DOIP_HEADER_LEN` is 4088, so this only holds for
`resp_buf->length <= 4084`. But `uds_msg_buf_t.data` (the UDS core's
response buffer) is sized `UDS_MAX_PAYLOAD_LEN = 4095` — 11 bytes above that
ceiling. A service handler that legitimately fills the buffer to
4085-4095 bytes (e.g. ReadDataByIdentifier over several DIDs, or
ReadMemoryByAddress with a large size) makes the `if` false, and the
**entire send block is skipped**: no DoIP frame, not even a negative
response.

The positive ack for the *request* was already sent moments earlier
(ISO 13400-2 §9.5), so this isn't recoverable by NACKing the request —
the tester is simply left to time out on its own P2 timer instead of
getting a clean protocol-level rejection.

## Fix

When the dispatched response doesn't fit the frame budget, downgrade it
in place to a UDS negative response instead of dropping it:

```c
if (resp_payload_len > DOIP_MAX_PDU_SIZE - DOIP_HEADER_LEN) {
    uds_server_build_negative_response(original_sid, UDS_NRC_RESPONSE_TOO_LONG, resp_buf);
    resp_payload_len = resp_buf->length + 4U;
}
if (resp_payload_len <= DOIP_MAX_PDU_SIZE - DOIP_HEADER_LEN) {
    /* existing encode/send path, unchanged */
}
```

- Uses the existing `uds_server_build_negative_response()` builder to write a
  standard UDS `0x7F` PDU with `UDS_NRC_RESPONSE_TOO_LONG` (`0x14`,
  ISO 14229-1) — already used elsewhere in the codebase (e.g.
  `core/uds_services/service_0x22.c` for the same NRC on overflow).
- The original request's SID is captured (`original_sid`) right after the
  UDS PDU pointer is known, *before* `req_buf`/`resp_buf` are filled and
  potentially overwritten — needed to echo the correct SID in the negative
  response after dispatch has already reused those buffers.
- The NRC PDU is always exactly 3 bytes, so `resp_payload_len` after the
  downgrade is always well inside budget — the existing encode/send path
  (positive-response case) is untouched beyond adding this new branch
  ahead of it.

## `negative_response_count` — not incremented, and why

`uds_server_ctx_t.negative_response_count` (bumped in `core/uds_server.c` at
every existing NRC path, all inside `uds_server_process_request()`) tracks
outcomes of **dispatch** — bad SID, access denied, handler error. In this
bug, dispatch succeeds (`dispatch_rc == UDS_STATUS_OK`, real positive
response produced); it's the **transport** that can't carry the result.

I chose *not* to bump that counter from `doip_server.c`:
- It's a different failure class from what the counter otherwise means —
  folding transport-capacity failures into a UDS-dispatch-outcome counter
  would make it a worse signal for whoever monitors it (e.g. can't
  distinguish "security lockouts spiking" from "oversized reads keep
  happening").
- `doip_server.c` never reaches into `uds_server_ctx_t` internals today —
  it treats `uds_ctx` as opaque and only calls
  `uds_server_process_request()`. Bumping the field directly here would be
  the first exception to that.

Reasoning is captured as a code comment at the fix site, not just here, per
the task's ask not to silently skip the question either way.

## Tests

Extended `tests/unit_runnable/test_doip_server.c`, reusing the #105
large-response test scaffolding (`init_uds_server_with_large_response()` /
`handler_large_response()`) but with a new configurable-length variant
(`handler_variable_response()` / `init_uds_server_with_variable_response()`)
so exact boundary byte-counts can be tested:

- `test_doip_oversized_response_returns_nrc_0x14` — 4090-byte handler
  response (dead zone) now produces a DoIP frame carrying a UDS `0x7F`
  negative response with the correct original SID and NRC `0x14`, not
  silence.
- `test_doip_response_4084_bytes_still_sent_positive` — boundary
  regression: exactly 4084 bytes still sends the full, byte-identical
  positive response unchanged (proves the in-budget path wasn't touched).
- `test_doip_response_4085_bytes_triggers_nrc_0x14` — first byte over
  budget triggers the NRC 0x14 path.

To confirm these tests aren't vacuous, I temporarily mutated the fix's
boundary condition and reran — the new tests correctly flip to FAIL, then
back to PASS once reverted.

## Gates

- `bash build_tests.sh`: **43/43** host unit test modules pass (was 42
  modules before this PR added test coverage; all pass, 0 fail).
- `bash build_harness.sh --run`: not applicable — no `harness/` sources
  present in this checkout (gitignored commercial deliverable per
  CONTRIBUTING.md).
- `python3 misra_analysis.py --src-dirs transport/doip`: **0 findings**
  (GCC-only path — `cppcheck` isn't available in this sandbox, so the
  `--addon=misra` pass didn't run; GCC MISRA-relevant flags found 0
  issues).

## Heightened review (CONTRIBUTING.md)

`transport/doip/doip_server.c` is on the heightened-review list
(DoIP server, ISO 13400-2). Ran the `/code-review` skill against this diff
before opening the PR; addressed its findings (documented the
`negative_response_count` decision in-code, clarified the now-always-true
second budget check is intentionally kept explicit rather than collapsed).
Per CONTRIBUTING.md this file requires explicit human sign-off
(`Reviewed-by: <name>`) in the PR description in addition to CI — leaving
that for the maintainer at merge time, alongside the static analysis job
and full unit test suite already run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
