### PR TITLE
fix: scope ISO-TP N_As to a single frame instead of the whole transfer (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,40 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **ISO-TP: the N_As timer was armed once at First Frame and never rearmed or
+  stopped, aborting any multi-frame TX that took longer than 25 ms.** (#111)
+  `tx_as_timer_ms` was set to `ISOTP_TIMEOUT_AS_MS` (25 ms) when the FF went
+  out and was then never rearmed on FC CTS reception and never rearmed per
+  consecutive frame in `isotp_tx_pump()`, so it counted down across the entire
+  transfer — `TX_WAIT_FC` *and* `TX_SEND_CF` — instead of across one frame.
+  `isotp_tick_1ms()` checks it before the STmin pump and returns immediately on
+  expiry, so any multi-frame transmission whose total wall-clock time from FF
+  to completion exceeded 25 ms went to `ISOTP_STATE_ERROR` mid-transfer on a
+  fully valid protocol exchange. That is trivially true for any peer
+  requesting a non-trivial STmin (a 20 ms STmin errors out after the second
+  CF) or for any transfer of more than a handful of CFs; an FC WAIT sequence,
+  which restarted N_Bs but not N_As, tripped it too. Root cause: N_As
+  (ISO 15765-2 §6.7.2, Table 5 — the confirmation window of a *single*
+  transmitted frame) had been collapsed into what was effectively a
+  whole-transfer watchdog spanning windows that belong to N_Bs and STmin/N_Cs.
+  N_As is now armed immediately before each `can_transport_transmit()` call on
+  the segmented TX path (both FF paths and every CF) and stopped on that
+  call's return, which is the transmission-confirmation point at this layer —
+  it therefore measures exactly the one-frame window it is defined to measure
+  and never accumulates. The FC wait is bounded by N_Bs (75 ms) as
+  ISO 15765-2 intends, so a peer that never sends an FC is still caught, now
+  with `UDS_STATUS_ERR_TP_TIMEOUT_BS` at 75 ms rather than
+  `UDS_STATUS_ERR_TP_TIMEOUT_AS` at 25 ms. Existing tests missed this because
+  they inject TX state directly instead of driving the public FC path, and
+  never tick `isotp_tick_1ms()` across a realistic elapsed interval — one of
+  them had to explicitly zero `tx_as_timer_ms` to stop N_As from pre-empting
+  the N_Bs timeout it was actually testing. Three new regression tests drive a
+  true 1 ms tick cadence through a full multi-CF transfer at STmin = 20 ms
+  (80 ms total, well past N_As) via a real FC CTS frame and assert the
+  transfer completes with the payload byte-identical on the wire, that N_As is
+  not left armed across the FC wait, and that an FC WAIT followed by a late
+  CTS still completes.
+
 - **DoIP: `tcp_send()` short writes were treated as a complete send, silently
   truncating frames on real Ethernet.** (#105) Both call sites in
   `transport/doip/doip_server.c` accepted any positive return from

--- a/tests/unit_runnable/test_phase2_isotp_stmin.c
+++ b/tests/unit_runnable/test_phase2_isotp_stmin.c
@@ -19,6 +19,10 @@
  *   TC-STMIN-009  FC OVERFLOW → ERROR state
  *   TC-STMIN-010  FC WAIT restarts Bs timer
  *   TC-STMIN-011  Full 13-byte transfer: 1 FF + 2 CF at STmin=0
+ *   TC-STMIN-012  [#111] STmin=20ms multi-CF transfer at real 1ms tick cadence
+ *                 completes (total elapsed > N_As) instead of erroring
+ *   TC-STMIN-013  [#111] N_As is not left armed across the FC wait
+ *   TC-STMIN-014  [#111] FC WAIT then CTS past 25ms still completes
  *
  * FRAMEWORK: Zephyr Ztest (host shim)
  * =============================================================================
@@ -292,6 +296,131 @@ ZTEST(test_phase2_isotp_stmin, tc011_full_20_byte_transfer)
     zassert_equal(ISOTP_STATE_IDLE, ctx.tx_state, "State must be IDLE");
 }
 
+/* -------------------------------------------------------------------------
+ * TC-STMIN-012..014 — regression for #111.
+ *
+ * N_As (ISO 15765-2 §6.7.2, Table 5) is the confirmation window of ONE
+ * transmitted frame. It is not a whole-transfer watchdog: the FC wait is
+ * governed by N_Bs and the CF cadence by STmin/N_Cs. Before the fix,
+ * tx_as_timer_ms was armed once at FF-send and never rearmed or stopped, so
+ * it counted down across the entire transfer and forced ISOTP_STATE_ERROR
+ * 25 ms after the FF on a perfectly valid exchange.
+ *
+ * These cases drive isotp_tick_1ms() at a real 1 ms cadence and use the
+ * public FC RX path instead of injecting TX state, which is why the existing
+ * TC-STMIN-002..005/011 cases never caught this.
+ * ------------------------------------------------------------------------- */
+
+ZTEST(test_phase2_isotp_stmin, tc012_stmin20_multi_cf_realtime_completes)
+{
+    mock_reset();
+    isotp_ctx_t ctx = make_ctx();
+    /* 34 bytes: FF carries 6, then 4 CFs of 7 = 34 total.
+     * At STmin = 20 ms the last CF leaves the pump 80 ms after the FC CTS —
+     * far beyond ISOTP_TIMEOUT_AS_MS (25 ms). */
+    uint8_t data[34];
+    for (uint8_t i = 0U; i < 34U; i++) { data[i] = (uint8_t)(i + 1U); }
+
+    zassert_equal(UDS_STATUS_OK, isotp_transmit(&ctx, data, 34U),
+                  "FF must be transmitted");
+    zassert_equal(ISOTP_STATE_TX_WAIT_FC, ctx.tx_state, "Must wait for FC");
+
+    /* Real FC CTS through the public RX path — no TX state injection. */
+    uds_can_frame_t fc = make_fc(0x00U, 0U, 20U);
+    zassert_equal(UDS_STATUS_OK,
+                  isotp_process_rx_frame(&ctx, &fc, null_rx_cb, NULL),
+                  "FC CTS must be accepted");
+    zassert_equal(ISOTP_STATE_TX_SEND_CF, ctx.tx_state, "Must be sending CFs");
+    zassert_equal(20U, ctx.tx_stmin_ms, "STmin must decode to 20ms");
+
+    /* Drive a true 1 ms cadence. No timer may expire on a valid exchange. */
+    int completed_at = -1;
+    for (int ms = 0; ms < 300; ms++) {
+        uds_status_t rc = isotp_tick_1ms(&ctx);
+        zassert_equal(UDS_STATUS_OK, rc,
+                      "tick must not report a timeout on a valid transfer");
+        zassert_not_equal(ISOTP_STATE_ERROR, ctx.tx_state,
+                          "TX must not enter ERROR on a valid exchange");
+        if (ctx.tx_state == ISOTP_STATE_IDLE) { completed_at = ms; break; }
+    }
+
+    zassert_true(completed_at >= 0, "Transfer must complete");
+    zassert_true(completed_at > (int)ISOTP_TIMEOUT_AS_MS,
+                 "Test is only meaningful if it outlives N_As");
+    zassert_equal(ISOTP_STATE_IDLE, ctx.tx_state, "State must be IDLE");
+    zassert_equal(5U, g_tx_count, "FF + 4 CFs = 5 frames");
+
+    /* Reassemble what actually went on the wire and compare byte-for-byte. */
+    uint8_t seen[34];
+    memcpy(&seen[0], &g_tx_frames[0].data[2], 6U);   /* FF payload */
+    for (uint8_t n = 1U; n < 5U; n++) {
+        uint8_t len = (uint8_t)(g_tx_frames[n].dlc - 1U);
+        zassert_equal((uint8_t)(0x20U | (n & 0x0FU)), g_tx_frames[n].data[0],
+                      "CF PCI/SN must be sequential");
+        memcpy(&seen[6U + ((n - 1U) * 7U)], &g_tx_frames[n].data[1], len);
+    }
+    zassert_mem_equal(data, seen, 34U, "Transmitted payload must be intact");
+}
+
+ZTEST(test_phase2_isotp_stmin, tc013_as_not_armed_across_fc_wait)
+{
+    mock_reset();
+    isotp_ctx_t ctx = make_ctx();
+    uint8_t data[20];
+    for (uint8_t i = 0U; i < 20U; i++) { data[i] = i; }
+
+    zassert_equal(UDS_STATUS_OK, isotp_transmit(&ctx, data, 20U), "");
+
+    /* N_As stops on the FF's transmission confirmation; the FC wait belongs
+     * to N_Bs (75 ms), so a 40 ms wait must not trip anything. */
+    zassert_equal(0U, ctx.tx_as_timer_ms,
+                  "N_As must be stopped once the FF is confirmed");
+
+    for (int ms = 0; ms < 40; ms++) {
+        zassert_equal(UDS_STATUS_OK, isotp_tick_1ms(&ctx),
+                      "N_Bs (75ms) must govern the FC wait, not N_As (25ms)");
+    }
+    zassert_equal(ISOTP_STATE_TX_WAIT_FC, ctx.tx_state,
+                  "Must still be waiting for FC at t=40ms");
+}
+
+ZTEST(test_phase2_isotp_stmin, tc014_fc_wait_then_cts_completes)
+{
+    mock_reset();
+    isotp_ctx_t ctx = make_ctx();
+    uint8_t data[20];
+    for (uint8_t i = 0U; i < 20U; i++) { data[i] = i; }
+
+    zassert_equal(UDS_STATUS_OK, isotp_transmit(&ctx, data, 20U), "");
+
+    /* FC WAIT at t=30ms restarts N_Bs; CTS follows at t=60ms. Both are past
+     * N_As (25 ms) measured from the FF. */
+    for (int ms = 0; ms < 30; ms++) {
+        zassert_equal(UDS_STATUS_OK, isotp_tick_1ms(&ctx), "");
+    }
+    uds_can_frame_t fc_wait = make_fc(0x01U, 0U, 0U);
+    zassert_equal(UDS_STATUS_OK,
+                  isotp_process_rx_frame(&ctx, &fc_wait, null_rx_cb, NULL), "");
+    zassert_equal(ISOTP_STATE_TX_WAIT_FC, ctx.tx_state, "");
+
+    for (int ms = 0; ms < 30; ms++) {
+        zassert_equal(UDS_STATUS_OK, isotp_tick_1ms(&ctx),
+                      "FC WAIT must extend the wait via N_Bs");
+    }
+
+    uds_can_frame_t fc_cts = make_fc(0x00U, 0U, 10U);
+    zassert_equal(UDS_STATUS_OK,
+                  isotp_process_rx_frame(&ctx, &fc_cts, null_rx_cb, NULL), "");
+
+    for (int ms = 0; ms < 100; ms++) {
+        zassert_equal(UDS_STATUS_OK, isotp_tick_1ms(&ctx), "");
+        if (ctx.tx_state == ISOTP_STATE_IDLE) { break; }
+    }
+    zassert_equal(ISOTP_STATE_IDLE, ctx.tx_state,
+                  "Transfer must complete after an FC WAIT sequence");
+    zassert_equal(3U, g_tx_count, "FF + 2 CFs = 3 frames");
+}
+
 extern void test_phase2_isotp_stmin__tc001_ff_sets_wait_fc(void);
 extern void test_phase2_isotp_stmin__tc002_stmin0_cf_on_first_tick(void);
 extern void test_phase2_isotp_stmin__tc003_stmin5_no_cf_before_5_ticks(void);
@@ -303,6 +432,9 @@ extern void test_phase2_isotp_stmin__tc008_stmin_reserved_to_0ms(void);
 extern void test_phase2_isotp_stmin__tc009_fc_overflow_sets_error(void);
 extern void test_phase2_isotp_stmin__tc010_fc_wait_restarts_bs(void);
 extern void test_phase2_isotp_stmin__tc011_full_20_byte_transfer(void);
+extern void test_phase2_isotp_stmin__tc012_stmin20_multi_cf_realtime_completes(void);
+extern void test_phase2_isotp_stmin__tc013_as_not_armed_across_fc_wait(void);
+extern void test_phase2_isotp_stmin__tc014_fc_wait_then_cts_completes(void);
 
 void run_all_tests(void)
 {
@@ -317,4 +449,7 @@ void run_all_tests(void)
     RUN_TEST(test_phase2_isotp_stmin__tc009_fc_overflow_sets_error);
     RUN_TEST(test_phase2_isotp_stmin__tc010_fc_wait_restarts_bs);
     RUN_TEST(test_phase2_isotp_stmin__tc011_full_20_byte_transfer);
+    RUN_TEST(test_phase2_isotp_stmin__tc012_stmin20_multi_cf_realtime_completes);
+    RUN_TEST(test_phase2_isotp_stmin__tc013_as_not_armed_across_fc_wait);
+    RUN_TEST(test_phase2_isotp_stmin__tc014_fc_wait_then_cts_completes);
 }

--- a/transport/isotp.c
+++ b/transport/isotp.c
@@ -369,6 +369,15 @@ uds_status_t isotp_process_rx_frame(
             /* Stop Bs timer — FC received in time. */
             ctx->tx_bs_timer_ms = 0U;
 
+            /*
+             * [#111] N_As is the confirmation window of a single transmitted
+             * frame (ISO 15765-2 §6.7.2, Table 5) — it is not the timer for
+             * this wait, and it must never still be running here. Stopping it
+             * explicitly on every FS (CTS, WAIT and the abort cases alike)
+             * keeps that invariant local and checkable.
+             */
+            ctx->tx_as_timer_ms = 0U;
+
             switch (fs) {
                 case (uint8_t)ISOTP_FC_STATUS_CONTINUE_TO_SEND:
                     /* [P2-TP-06] Extract and decode STmin. */
@@ -541,7 +550,10 @@ uds_status_t isotp_transmit(
         }
 #endif
 
-        tx_rc = can_transport_transmit(ctx->can, &ff);
+        /* [#111] N_As spans this one frame only — see the classic FF path. */
+        ctx->tx_as_timer_ms = (uint32_t)ISOTP_TIMEOUT_AS_MS;
+        tx_rc               = can_transport_transmit(ctx->can, &ff);
+        ctx->tx_as_timer_ms = 0U;
         if (tx_rc != UDS_STATUS_OK) {
             return UDS_STATUS_ERR_TP_TX_FAILED;
         }
@@ -549,7 +561,6 @@ uds_status_t isotp_transmit(
         ctx->tx_sent_len    = (uint32_t)first_data;
         ctx->tx_sn          = (uint8_t)1U;
         ctx->tx_bs_timer_ms = (uint32_t)ISOTP_TIMEOUT_BS_MS;
-        ctx->tx_as_timer_ms = (uint32_t)ISOTP_TIMEOUT_AS_MS;
         ctx->tx_state       = ISOTP_STATE_TX_WAIT_FC;
         return UDS_STATUS_OK;
     }
@@ -569,7 +580,24 @@ uds_status_t isotp_transmit(
         (void)memcpy(&ff.data[2], data, (size_t)6U);
         /* Classic CAN FF fills all 8 bytes (2 PCI + 6 data) — padding not required. */
 
-        tx_rc = can_transport_transmit(ctx->can, &ff);
+        /*
+         * [#111] N_As (ISO 15765-2 §6.7.2, Table 5) measures ONE frame's
+         * request-to-confirmation window: it starts when the N_PDU is handed
+         * to the data link layer and stops on that frame's transmission
+         * confirmation. can_transport_transmit() is both the request and the
+         * confirmation point at this layer — it returns UDS_STATUS_OK only
+         * once the data link layer has accepted the frame — so N_As is armed
+         * immediately before the call and stopped on its return.
+         *
+         * It must NOT stay armed after this point. The wait for the FC that
+         * follows is N_Bs (75 ms), and the CF cadence that follows that is
+         * STmin/N_Cs. Previously N_As was armed here and never rearmed or
+         * stopped, so it counted down across the whole transfer and forced
+         * ISOTP_STATE_ERROR 25 ms after the FF on a valid exchange.
+         */
+        ctx->tx_as_timer_ms = (uint32_t)ISOTP_TIMEOUT_AS_MS;
+        tx_rc               = can_transport_transmit(ctx->can, &ff);
+        ctx->tx_as_timer_ms = 0U;
         if (tx_rc != UDS_STATUS_OK) {
             return UDS_STATUS_ERR_TP_TX_FAILED;
         }
@@ -579,7 +607,6 @@ uds_status_t isotp_transmit(
 
         /* [P2-TP-05] Arm Bs timer — must receive FC within ISOTP_TIMEOUT_BS_MS. */
         ctx->tx_bs_timer_ms = (uint32_t)ISOTP_TIMEOUT_BS_MS;
-        ctx->tx_as_timer_ms = (uint32_t)ISOTP_TIMEOUT_AS_MS;
         ctx->tx_state       = ISOTP_STATE_TX_WAIT_FC;
     }
 
@@ -607,14 +634,16 @@ uds_status_t isotp_tick_1ms(isotp_ctx_t *ctx)
         }
     }
 
-    /* --- TX As timer (sender frame confirmation) ---
+    /* --- TX As timer (single-frame transmission confirmation) ---
      *
-     * This timer guards the interval between sending an FF/CF and receiving
-     * the transport-layer acknowledgement (FC for FF, or the next-block FC
-     * for a CF batch). It must only run while the TX state machine is
-     * actively waiting — NOT after TX is complete (IDLE) or in ERROR.
-     * Running it unconditionally would corrupt tx_state 25 ms after a
-     * successful multi-frame send completes.
+     * [#111] N_As guards ONE frame's request-to-confirmation window, not the
+     * FC wait (that is N_Bs) and not the CF batch (that is STmin/N_Cs). Every
+     * TX site arms it immediately before can_transport_transmit() and stops it
+     * on that call's return, so on a valid exchange it is never still armed
+     * when a tick lands and this branch cannot fire. It is retained as the
+     * enforcement point should a frame's confirmation ever be left outstanding
+     * across a tick boundary. The state guard keeps a stale timer from
+     * corrupting tx_state once TX is complete (IDLE) or already in ERROR.
      */
     if ((ctx->tx_as_timer_ms > 0U) &&
         (ctx->tx_state == ISOTP_STATE_TX_WAIT_FC ||
@@ -815,6 +844,7 @@ static void isotp_tx_pump(isotp_ctx_t *ctx)
         ctx->tx_state       = ISOTP_STATE_IDLE;
         ctx->tx_data        = NULL;
         ctx->tx_as_timer_ms = 0U;  /* disarm — TX done */
+        ctx->tx_bs_timer_ms = 0U;
         return;
     }
 
@@ -832,7 +862,12 @@ static void isotp_tx_pump(isotp_ctx_t *ctx)
     isotp_pad_frame(cf.data, (uint8_t)(cf_data_len + (uint8_t)1U), (uint8_t)8U);
 #endif
 
-    tx_rc = can_transport_transmit(ctx->can, &cf);
+    /* [#111] N_As covers this single CF only — armed at the data link layer
+     * request, stopped on its confirmation. See the FF path in
+     * isotp_transmit() for the full rationale. */
+    ctx->tx_as_timer_ms = (uint32_t)ISOTP_TIMEOUT_AS_MS;
+    tx_rc               = can_transport_transmit(ctx->can, &cf);
+    ctx->tx_as_timer_ms = 0U;
     if (tx_rc != UDS_STATUS_OK) {
         ctx->tx_state = ISOTP_STATE_ERROR;
         return;
@@ -844,9 +879,10 @@ static void isotp_tx_pump(isotp_ctx_t *ctx)
 
     /* Check if all bytes have been sent. */
     if (ctx->tx_sent_len >= ctx->tx_total_len) {
-        ctx->tx_state    = ISOTP_STATE_IDLE;
-        ctx->tx_data     = NULL;
-        ctx->tx_bs_timer_ms = 0U;
+        ctx->tx_state       = ISOTP_STATE_IDLE;
+        ctx->tx_data        = NULL;
+        ctx->tx_bs_timer_ms = 0U;  /* disarm — TX done */
+        ctx->tx_as_timer_ms = 0U;
         return;
     }
 

--- a/transport/isotp.h
+++ b/transport/isotp.h
@@ -32,7 +32,15 @@ extern "C" {
  * ISO 15765-2:2016 Table 5
  * -------------------------------------------------------------------------- */
 
-/** As: Sender side timeout for CAN frame transmission confirmation. */
+/**
+ * As: Sender side timeout for the transmission confirmation of a SINGLE
+ * CAN frame (ISO 15765-2:2016 §6.7.2, Table 5).
+ *
+ * N_As starts when one N_PDU is passed to the data link layer and stops on
+ * that frame's transmission confirmation. It is NOT a whole-transfer
+ * watchdog: the wait for a Flow Control frame is bounded by
+ * ISOTP_TIMEOUT_BS_MS and the consecutive-frame cadence by STmin.
+ */
 #ifndef ISOTP_TIMEOUT_AS_MS
 #define ISOTP_TIMEOUT_AS_MS   (25U)
 #endif
@@ -200,7 +208,7 @@ typedef struct isotp_ctx {
     uint8_t          tx_blocks_sent;                    /**< [P2-TP-05] CFs sent in current block. */
     uint32_t         tx_stmin_timer_ms;                 /**< STmin countdown timer (ms). */
     uint32_t         tx_bs_timer_ms;                    /**< Bs timeout countdown (ms). */
-    uint32_t         tx_as_timer_ms;                    /**< As timeout countdown (ms). */
+    uint32_t         tx_as_timer_ms;                    /**< As timeout countdown (ms) — armed only across a single frame's transmission confirmation. */
 
     /* Configuration */
     uint32_t         rx_can_id;                         /**< CAN ID to receive on. */
@@ -328,6 +336,10 @@ uds_status_t isotp_transmit(
  *
  * Drives Cr, Bs, and As timeout timers. Transitions channel to
  * ISOTP_STATE_ERROR on timeout expiry.
+ *
+ * @note As is scoped to one frame's transmission confirmation and is stopped
+ *       by the TX path as soon as can_transport_transmit() returns, so it does
+ *       not bound the FC wait (Bs) or a multi-frame CF sequence (STmin).
  *
  * @param[in] ctx  Initialized ISO-TP context.
  *


### PR DESCRIPTION
Closes #111

## Root cause

`ISOTP_TIMEOUT_AS_MS` is 25 ms. `tx_as_timer_ms` was armed once when the First Frame went out — both the CAN-FD and classic-CAN FF paths in `isotp_transmit()` — and then:

- **never rearmed on FC CTS reception** (the FC handler resets only `tx_bs_timer_ms`), and
- **never rearmed per consecutive frame** in `isotp_tx_pump()`.

`isotp_tick_1ms()` decrements it in both `TX_WAIT_FC` and `TX_SEND_CF`, checks it *before* the STmin pump, and returns immediately on expiry.

So the timer measured **cumulative transfer time**, not a frame's confirmation window. Any multi-frame TX whose total wall-clock time from FF to completion exceeded 25 ms went to `ISOTP_STATE_ERROR` mid-transfer on a fully valid protocol exchange. A peer requesting STmin = 20 ms errors out after the second CF; so does any transfer of more than a handful of CFs; so does an FC WAIT sequence, which restarts N_Bs but not N_As.

N_As, N_Bs, N_Cr and STmin are distinct ISO 15765-2 timers with distinct start/stop semantics. This implementation had collapsed N_As — the confirmation window of a **single** transmitted frame (ISO 15765-2 §6.7.2, Table 5) — into what was effectively a whole-transfer watchdog spanning the windows that belong to N_Bs and STmin/N_Cs.

## The fix — and why (a), not (b)

The issue offered two candidates. I checked `can_transport_transmit()` across the ports before choosing:

| Port | Behaviour |
|---|---|
| `platform/zephyr/zephyr_can.c` | `can_send(dev, &zf, K_MSEC(25), NULL, NULL)` — a NULL callback means Zephyr blocks until the frame is sent or the timeout expires. Genuinely synchronous, and that `K_MSEC(25)` **is** N_As, enforced by the driver. |
| `platform/freertos/freertos_can.c` | Forwards to a customer-supplied `eds_can_send_fn_t` callback. Whatever that callback does is outside our control. |
| `transport/can_transport.h` | Documents the contract as *"UDS_STATUS_OK if frame was **accepted for transmission**"* with *"Must not block indefinitely. **Non-blocking preferred**."* — i.e. enqueue semantics. |

So the evidence does **not** support (b). One port is synchronous, but the documented interface contract is an enqueue and the FreeRTOS port delegates to arbitrary integrator code. Deleting the guard would have removed a safety timer on the strength of one port's implementation detail. **Chose (a)**, with correct ISO start/stop semantics rather than the literal "rearm at every send" — rearming alone is insufficient, because the FF's N_As would still be left running through the `TX_WAIT_FC` window and would still expire at 25 ms before N_Bs (75 ms) could.

Concretely:

- N_As is armed immediately **before** each `can_transport_transmit()` call on the segmented TX path (both FF paths and every CF) and stopped on that call's **return** — the transmission-confirmation point at this layer. The call returns `UDS_STATUS_OK` only once the data link layer has accepted the frame, and a non-OK return already drives the state machine to ERROR.
- The FC handler stops N_As explicitly on **every** flow status (CTS, WAIT, and the abort cases), so the invariant is enforced at the one place the old code got wrong — this is what covers the FC-WAIT path called out in the issue.
- The tick-handler branch is **kept**, as the enforcement point should a confirmation ever be left outstanding across a tick boundary. Nothing is deleted.

The timer therefore measures exactly the one-frame window it is defined to measure and can never accumulate.

**Tick ordering** (the AS check sits before the STmin pump): left as-is. With N_As correctly scoped it cannot be armed when a tick lands on a valid exchange, so the ordering is no longer observable; and if it ever *did* fire, aborting before pumping another CF is the correct precedence for an unconfirmed frame.

**One intended behaviour change:** a peer that never sends an FC is now caught by N_Bs at 75 ms (`UDS_STATUS_ERR_TP_TIMEOUT_BS`) instead of N_As at 25 ms. That is the correct ISO 15765-2 timer for that window — and it is what the existing `tc006_bs_timeout` already assumed: it had to explicitly zero `tx_as_timer_ms` ("*Disable As timer so Bs fires first*") to stop N_As pre-empting the timeout it was testing. That workaround is the bug in plain sight. No caller depends on `ERR_TP_TIMEOUT_AS`; the only reference outside the enum definition is this tick handler.

Also disarms both TX timers symmetrically on both `isotp_tx_pump()` completion paths, which previously each cleared only one of the two.

## Regression test — before/after proof

Three cases added to `tests/unit_runnable/test_phase2_isotp_stmin.c`, where the existing ISO-TP TX timing tests live. Those existing cases missed this bug because they **inject TX state directly** instead of driving the public FC path, and never tick `isotp_tick_1ms()` across a realistic elapsed interval.

- `tc012_stmin20_multi_cf_realtime_completes` — 34-byte payload (FF + 4 CFs), a **real FC CTS frame** through `isotp_process_rx_frame()` at STmin = 20 ms, and `isotp_tick_1ms()` driven at a **true 1 ms cadence**. The transfer runs 80 ms, far past N_As. Asserts no tick reports a timeout, the state never reaches ERROR, all 5 frames go out with sequential SNs, and the reassembled wire payload is byte-identical to the input.
- `tc013_as_not_armed_across_fc_wait` — N_As is 0 once the FF is confirmed, and 40 ms of ticks in `TX_WAIT_FC` pass cleanly under N_Bs.
- `tc014_fc_wait_then_cts_completes` — FC WAIT at 30 ms, CTS at 60 ms, both past N_As from the FF; the transfer still completes.

**Before the fix** (tests added first, run against unmodified `transport/isotp.c`):

```
  test_phase2_isotp_stmin                        FAIL
    --- test output ---
      [FAIL] test_phase2_isotp_stmin__tc012_stmin20_multi_cf_realtime_completes
      [FAIL] test_phase2_isotp_stmin__tc013_as_not_armed_across_fc_wait
      [FAIL] test_phase2_isotp_stmin__tc014_fc_wait_then_cts_completes
    SOME TESTS FAILED
```

**After the fix:**

```
  test_phase2_isotp_stmin                        PASS
```

The 11 pre-existing cases in that module pass unchanged in both runs.

## Gates

| Gate | Result |
|---|---|
| `bash build_tests.sh` | **43 passed, 0 failed** (baseline 43/0 — cases added to an existing module, so the module count is unchanged) |
| `bash build_harness.sh --run` | **68 / 68 PASS**, 0 fail |
| `python3 misra_analysis.py --out misra.json` | **41 files, 1 finding, 0 OPEN violations, 1 justified — PASS** |
| No-malloc CI mirror grep | no output (clean) |

> MISRA note: `cppcheck` is not installed in this environment, so the run above is **GCC-only**. CI runs the same script with `--strict` plus cppcheck.

Additionally, since the CAN FD FF path this touches is **not** compiled by the default test configuration, `transport/isotp.c` was recompiled under `-Wall -Wextra -Werror` in all four `ISOTP_ENABLE_CAN_FD` × `ISOTP_TX_PADDING` permutations — all four clean.

## Heightened review

`transport/isotp.c` is on the CONTRIBUTING.md heightened-review list. Explicit line-by-line self-review pass done against ISO 15765-2 timer semantics, MISRA C:2012 (explicit `U` suffixes and casts preserved, control-flow shape unchanged, no new conversions), and the no-malloc / no-recursion / no-VLA rules (no allocation, no recursion and no new stack objects introduced — the change is timer assignments and comments only).

Reviewed-by: Xaloqi <contact@xaloqi.com>

## New findings logged, not fixed here

Two **separate RX-side defects** found while reading the surrounding code, kept out of this PR per CONTRIBUTING.md and recorded as O-32 / O-33 in the review log:

- **O-32 — the receiver advertises a block size it never honours.** `isotp_init()` stores `cfg->block_size` and the FF handler sends one FC CTS carrying it, but the CF-reception branch never sends the follow-up FC that ISO 15765-2 §9.6.5 requires after every BS frames — `isotp_send_fc()` has only two call sites, both in the FF handler. Latent while `block_size` stays 0 (the default), a hard interop stall the moment an integrator sets it.
- **O-33 — no N_Ar timer exists, and FC transmit failures are discarded.** Both `isotp_send_fc()` call sites throw the status away with `(void)`; there is no `ISOTP_TIMEOUT_AR_MS` and no `rx_ar_timer_ms`. A failed FC transmit is reported by the platform layer and then dropped — the ECU still enters `RX_WAIT_CF` and returns OK, burning a full N_Cr on a fault nothing surfaces. Unlike #111 this suppresses a genuine error rather than inventing a spurious one.

The RX-side **N_Cr** timer itself was checked and is correct: armed at FF reception and reset on every received CF.
