### PR TITLE
fix: reject oversized TransferData block instead of silently clamping (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,26 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   128 calls; and a truly stalled peer is bounded and reported as a failure
   the caller must close the connection over.
 
+- **TransferData (0x36): an oversized block was silently clamped to
+  `bytes_remaining` instead of being rejected.** (#112) When a tester sent
+  more payload than the remaining declared transfer size (e.g. a
+  `RequestDownload` size=100, 98 bytes already received via one block, then
+  a 20-byte block with only 2 bytes remaining), `service_0x36.c` truncated
+  `payload_len` down to `bytes_remaining`, fed the truncated data into the
+  running CRC-32, wrote it to flash, and advanced the block sequence
+  counter as if the block were well-formed — silently discarding the
+  excess bytes rather than treating the malformed block as an error. Now
+  the handler rejects the block with NRC 0x31 (`requestOutOfRange`) and
+  aborts the transfer context via `uds_transfer_ctx_reset()`, mirroring how
+  `service_0x37.c` already handles the symmetric REQ-DL-002 case (too few
+  bytes at `RequestTransferExit`). A subsequent 0x36 after the abort now
+  correctly sees no active transfer (NRC 0x24) instead of resuming a
+  half-torn-down context. Added regression tests reproducing the exact
+  issue scenario and asserting the post-abort context is a clean reset,
+  not a partially-updated one; the pre-existing test that encoded the old
+  clamp-and-continue behavior as correct has been rewritten to assert the
+  reject-and-abort behavior instead.
+
 ### Changed
 
 - **README and COMMERCIAL_NOTICE spell out the proprietary-firmware linking

--- a/core/uds_services/service_0x36.c
+++ b/core/uds_services/service_0x36.c
@@ -30,6 +30,9 @@
  *   NRC 0x13 (incorrectMessageLengthOrInvalidFormat) — request < 3 bytes
  *   NRC 0x24 (requestSequenceError)                  — no active transfer
  *   NRC 0x73 (wrongBlockSequenceCounter)              — counter mismatch
+ *   NRC 0x31 (requestOutOfRange)                      — payload exceeds
+ *                                                        bytes_remaining;
+ *                                                        transfer is aborted
  *   NRC 0x72 (generalProgrammingFailure)              — flash write failed
  *
  * BLOCK COUNTER WRAP LOGIC (REQ-DL-001):
@@ -53,6 +56,9 @@
  * SAFETY:
  *   REQ-DL-001: Block counter wrap enforced.
  *   REQ-DL-002: bytes_remaining decremented per payload byte written.
+ *               A block whose payload exceeds bytes_remaining is rejected
+ *               (NRC 0x31) and the transfer context is aborted rather than
+ *               being silently truncated to fit.
  *   REQ-FLASH-003: CRC accumulator updated for every payload byte.
  *
  * STANDARD: MISRA C:2012 alignment intended.
@@ -222,9 +228,14 @@ uds_status_t uds_service_0x36_handler(
     payload     = &req->data[SVC_0x36_DATA_OFFSET];
     payload_len = (uint16_t)(req->length - (uint16_t)SVC_0x36_DATA_OFFSET);
 
-    /* Do not accept more data than bytes_remaining. */
+    /* REQ-DL-002: A block must not carry more data than bytes_remaining.
+     * Silently truncating and continuing would discard tester bytes while
+     * still advancing the block sequence and CRC as if the block were
+     * well-formed. Reject and abort instead (mirrors the 0x37 handling of
+     * REQ-DL-002 for the "too few bytes" case). */
     if ((uint32_t)payload_len > tctx->bytes_remaining) {
-        payload_len = (uint16_t)tctx->bytes_remaining;
+        uds_transfer_ctx_reset(tctx); /* abort — REQ-DL-003 */
+        return UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE; /* NRC 0x31 */
     }
 
     /* --- Update running CRC-32 (REQ-FLASH-003) --- */

--- a/tests/unit_runnable/test_service_0x36.c
+++ b/tests/unit_runnable/test_service_0x36.c
@@ -24,8 +24,14 @@
  *   TC-0x36-013  Write failure → ERR_PLATFORM, transfer reset to IDLE
  *   TC-0x36-014  CRC accumulator updated over payload bytes
  *   TC-0x36-015  No flash ops after 0x34 → ERR_CONDITIONS_NOT_MET
- *   TC-0x36-016  Payload capped at bytes_remaining (oversized last block)
+ *   TC-0x36-016  Oversized block (payload > bytes_remaining) rejected with
+ *                NRC 0x31 and aborts the transfer (issue #112)
  *   TC-0x36-017  Second block accepted with correct incremented counter
+ *   TC-0x36-018  Issue #112 regression: size=100 download, 98-byte block 1
+ *                accepted, then a 20-byte block 2 (only 2 bytes remaining)
+ *                is rejected + aborted, not silently clamped to 2 bytes
+ *   TC-0x36-019  A 0x36/0x37 sent after an oversized-block abort operates
+ *                on a clean IDLE context (NRC 0x24), not a half-torn-down one
  *
  * Coverage (upload direction — SID 0x35 active):
  *   TC-0x36-UL-001  Upload: [0x36, 0x01] → response [0x76, 0x01, data[0..N]]
@@ -404,19 +410,26 @@ ZTEST(svc_0x36, test_flash_ops_null_after_active_transfer)
                   uds_service_0x36_handler(&s_srv, &s_req, &s_resp), "");
 }
 
-/* TC-0x36-016  Payload capped at bytes_remaining (oversized last block) */
-ZTEST(svc_0x36, test_payload_capped_at_bytes_remaining)
+/* TC-0x36-016  Oversized block (payload > bytes_remaining) is rejected with
+ * NRC 0x31 (requestOutOfRange) and the transfer is aborted (issue #112).
+ *
+ * Formerly this handler silently clamped payload_len down to
+ * bytes_remaining, discarded the excess bytes, fed the truncated data into
+ * the running CRC, and advanced the block sequence as if the block were
+ * well-formed. That behaviour was itself the bug — see TC-0x36-018 for the
+ * exact scenario from the issue report. */
+ZTEST(svc_0x36, test_oversized_block_rejected_and_aborted)
 {
     /* Set bytes_remaining to just 4 bytes, but send 16. */
     prime_active_transfer(4U);
 
     build_req(0x01U, 0xCCU, 16U);
-    zassert_equal(UDS_STATUS_OK,
-                  uds_service_0x36_handler(&s_srv, &s_req, &s_resp), "");
-    /* bytes_remaining must be exactly 0 after capping to 4. */
-    zassert_equal((uint32_t)0U,
-                  uds_transfer_ctx_get()->bytes_remaining,
-                  "bytes_remaining must be 0 after last block");
+    zassert_equal(UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE,
+                  uds_service_0x36_handler(&s_srv, &s_req, &s_resp),
+                  "oversized block must be rejected with NRC 0x31, not clamped");
+    zassert_equal(UDS_TRANSFER_IDLE,
+                  uds_transfer_ctx_get()->state,
+                  "REQ-DL-003: transfer must be aborted (IDLE) after oversized block");
 }
 
 /* TC-0x36-017  Second block accepted with correctly incremented counter */
@@ -438,6 +451,79 @@ ZTEST(svc_0x36, test_second_block_accepted)
     zassert_equal(0x03U,
                   uds_transfer_ctx_get()->next_expected_block_seq,
                   "counter must advance to 0x03 after second block");
+}
+
+/* TC-0x36-018  Issue #112 regression scenario, verbatim:
+ *   RequestDownload size=100 -> TransferData block 1 (98 bytes, accepted,
+ *   bytes_remaining now 2) -> TransferData block 2 (20 bytes, only 2
+ *   remaining) -> must be rejected with NRC 0x31 and the transfer must be
+ *   aborted, NOT silently clamped to the remaining 2 bytes and continued. */
+ZTEST(svc_0x36, test_issue_112_oversized_final_block_rejected)
+{
+    prime_active_transfer(100U);
+
+    /* Block 1: 98 bytes, accepted. bytes_remaining -> 2. */
+    build_req(0x01U, 0x11U, 98U);
+    zassert_equal(UDS_STATUS_OK,
+                  uds_service_0x36_handler(&s_srv, &s_req, &s_resp),
+                  "block 1 (98 bytes) must be accepted");
+    zassert_equal((uint32_t)2U,
+                  uds_transfer_ctx_get()->bytes_remaining,
+                  "bytes_remaining must be 2 after block 1");
+    zassert_equal(0x02U,
+                  uds_transfer_ctx_get()->next_expected_block_seq,
+                  "counter must advance to 0x02 after block 1");
+
+    /* Block 2: 20 bytes sent, only 2 remaining -> reject + abort. */
+    memset(&s_resp, 0, sizeof(s_resp));
+    build_req(0x02U, 0x22U, 20U);
+    zassert_equal(UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE,
+                  uds_service_0x36_handler(&s_srv, &s_req, &s_resp),
+                  "oversized final block must be rejected with NRC 0x31");
+    zassert_equal(UDS_TRANSFER_IDLE,
+                  uds_transfer_ctx_get()->state,
+                  "transfer must be aborted (IDLE), not clamped and continued");
+    /* Positive response must NOT have been produced for the rejected block
+     * (s_resp is zeroed above; the handler must return before writing it). */
+    zassert_equal((uint8_t)0U, s_resp.data[0],
+                  "no positive response bytes may be written for a rejected block");
+}
+
+/* TC-0x36-019  A 0x36 sent after an oversized-block abort must operate on a
+ * clean IDLE context, not a half-torn-down one: it is rejected with
+ * requestSequenceError (NRC 0x24), exactly like any other 0x36 with no
+ * active transfer, and the context's fields read back as the IDLE reset
+ * defaults rather than stale in-progress values. */
+ZTEST(svc_0x36, test_post_abort_transfer_state_is_clean_idle)
+{
+    prime_active_transfer(100U);
+
+    build_req(0x01U, 0x11U, 98U);
+    zassert_equal(UDS_STATUS_OK,
+                  uds_service_0x36_handler(&s_srv, &s_req, &s_resp), "");
+
+    memset(&s_resp, 0, sizeof(s_resp));
+    build_req(0x02U, 0x22U, 20U);
+    zassert_equal(UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE,
+                  uds_service_0x36_handler(&s_srv, &s_req, &s_resp), "");
+
+    /* Context must read back as a clean, fully-reset IDLE context. */
+    zassert_equal(UDS_TRANSFER_IDLE, uds_transfer_ctx_get()->state, "");
+    zassert_equal((uint32_t)0U, uds_transfer_ctx_get()->bytes_remaining,
+                  "bytes_remaining must be reset, not left at the pre-abort value");
+    zassert_equal((uint8_t)0U, uds_transfer_ctx_get()->next_expected_block_seq,
+                  "next_expected_block_seq must be reset, not left mid-sequence");
+    zassert_equal((uint16_t)0U, uds_transfer_ctx_get()->write_buf_fill,
+                  "write_buf_fill must be reset, not left holding stale bytes");
+
+    /* A subsequent 0x36 must be rejected as "no active transfer" (NRC 0x24),
+     * proving it is not still operating on the aborted context. */
+    memset(&s_resp, 0, sizeof(s_resp));
+    build_req(0x01U, 0x33U, 4U);
+    zassert_equal(UDS_STATUS_ERR_SEC_SEED_UNAVAILABLE,
+                  uds_service_0x36_handler(&s_srv, &s_req, &s_resp),
+                  "0x36 after abort must see no active transfer (NRC 0x24), "
+                  "not resume a half-torn-down transfer");
 }
 
 /* ==========================================================================
@@ -559,8 +645,10 @@ void run_all_tests(void)
     RUN_TEST(svc_0x36__test_write_failure_resets_transfer);
     RUN_TEST(svc_0x36__test_crc_accumulator_updated);
     RUN_TEST(svc_0x36__test_flash_ops_null_after_active_transfer);
-    RUN_TEST(svc_0x36__test_payload_capped_at_bytes_remaining);
+    RUN_TEST(svc_0x36__test_oversized_block_rejected_and_aborted);
     RUN_TEST(svc_0x36__test_second_block_accepted);
+    RUN_TEST(svc_0x36__test_issue_112_oversized_final_block_rejected);
+    RUN_TEST(svc_0x36__test_post_abort_transfer_state_is_clean_idle);
     RUN_TEST(svc_0x36__test_upload_block_accepted);
     RUN_TEST(svc_0x36__test_upload_read_cb_failure);
     RUN_TEST(svc_0x36__test_upload_bytes_remaining_decremented);


### PR DESCRIPTION
Closes #112

## Root cause

`core/uds_services/service_0x36.c` (SID 0x36 — TransferData), lines ~226-227:

```c
if ((uint32_t)payload_len > tctx->bytes_remaining) {
    payload_len = (uint16_t)tctx->bytes_remaining;
}
```

When a tester sent more payload than `bytes_remaining` (e.g. `RequestDownload`
declared size=100, 90 bytes already received, tester sends a 20-byte block),
the handler silently truncated `payload_len` down to the 10 remaining bytes,
fed the *truncated* data into the running CRC-32, wrote it to flash, and
advanced the block sequence counter — as if the oversized block had been a
normal, well-formed one. The excess bytes the tester actually sent were
discarded without any error signalled back to the tester.

## Fix

If `payload_len > bytes_remaining`, reject the block with NRC 0x31
(`requestOutOfRange`, via `UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE`) and abort
the transfer context with `uds_transfer_ctx_reset()`, instead of clamping
and continuing.

This reuses the exact existing mechanism `service_0x37.c` already uses for
the symmetric REQ-DL-002 case (tester sends *too few* bytes total, detected
at `RequestTransferExit`): reject with NRC 0x31 and
`uds_transfer_ctx_reset(tctx)`. No new abort/error-signalling mechanism was
invented.

`uds_transfer_ctx_reset()` fully `memset`s the transfer context back to
`UDS_TRANSFER_IDLE`, so a subsequent 0x36 (or 0x37) after the abort sees "no
active transfer" (NRC 0x24) rather than operating on stale/half-torn-down
state — verified explicitly by a new regression test (see below).

Diff is a 4-line behavioural change (clamp → reject+abort) plus doc-comment
updates; no new files, no malloc/recursion/VLA, matches surrounding MISRA
style (explicit casts/suffixes already present, reused verbatim).

## Regression tests

Added to `tests/unit_runnable/test_service_0x36.c` (existing 0x36 test file):

- **`test_issue_112_oversized_final_block_rejected`** — the exact scenario
  from the issue report: `RequestDownload` size=100 → TransferData block 1
  (98 bytes, accepted, `bytes_remaining` → 2) → TransferData block 2 (20
  bytes, only 2 remaining) → expects `UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE`
  and the transfer context aborted (`UDS_TRANSFER_IDLE`), not a positive
  response with the block silently clamped to 2 bytes.
- **`test_post_abort_transfer_state_is_clean_idle`** — after the same abort,
  confirms the context reads back as a *fully* reset IDLE context
  (`bytes_remaining`, `next_expected_block_seq`, `write_buf_fill` all back
  to their reset defaults, not left holding stale in-progress values), and
  that a following 0x36 is rejected as "no active transfer" (NRC 0x24)
  rather than resuming a half-torn-down transfer.

### Pre-existing test that encoded the OLD (buggy) clamping behaviour

`TC-0x36-016` / `test_payload_capped_at_bytes_remaining` existed already and
asserted the *old* behaviour was correct — that a 16-byte block against 4
remaining bytes should return `UDS_STATUS_OK` with `bytes_remaining` clamped
to 0. That test was itself encoding the bug as intended behaviour. It has
been rewritten in place as `test_oversized_block_rejected_and_aborted`,
asserting the new reject-and-abort behaviour (NRC 0x31 / `UDS_TRANSFER_IDLE`)
instead of the old clamp-and-continue one. Calling this out explicitly per
the task brief rather than quietly papering over it.

### Before/after proof (manual, this session)

With the fix stashed out (old clamping code restored) and rebuilt:

```
test_service_0x36                              FAIL
=== Unit Test Summary: 42 passed, 1 failed ===
```
```
[FAIL] svc_0x36__test_oversized_block_rejected_and_aborted
  Expected 86 but got 54 (uds_service_0x36_handler(...))
[FAIL] svc_0x36__test_issue_112_oversized_final_block_rejected
  Expected 86 but got 54 (uds_service_0x36_handler(...))
[FAIL] svc_0x36__test_post_abort_transfer_state_is_clean_idle
  Expected 86 but got 54 (uds_service_0x36_handler(...))
Tests run: 23  Tests passed: 20  Tests failed: 3
```
(86 = `UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE`, 54 = `UDS_STATUS_OK` — i.e. the
old code kept returning OK for what should now be a rejection.)

With the fix restored and rebuilt, all three pass and the module is back to
23/23:

```
[PASS] svc_0x36__test_oversized_block_rejected_and_aborted
[PASS] svc_0x36__test_issue_112_oversized_final_block_rejected
[PASS] svc_0x36__test_post_abort_transfer_state_is_clean_idle
Tests run: 23  Tests passed: 23  Tests failed: 0
```

## Harness (Group N: Download/Transfer/Exit)

`harness/` in this worktree is a gitignored symlink into the separate
`EDS-toolchain` repo (per the shared task brief), so it's outside this PR's
git tree / this repo's scope. Existing `HN-001`–`HN-004` cases in Group N
cover the happy path, block-counter wrap, and two malformed-request cases
for 0x34, but none for an oversized 0x36 block. An `HN-005` case mirroring
`test_issue_112_oversized_final_block_rejected` end-to-end (through the
ISO-TP/DoIP transport) would be a good addition to `EDS-toolchain`, but is
out of scope for this PR since that repo isn't part of this change set.

## Gate results (this worktree, origin/main @ 8762593 + this commit)

- `bash build_tests.sh` → **43 passed, 0 failed** (baseline: 43/0 — unchanged,
  no new test module added, only new/updated cases within the existing
  `test_service_0x36.c`).
- `bash build_harness.sh --run` → **68 / 68 PASS** (baseline: 68/68 —
  unchanged; harness is out of scope per above).
- `python3 misra_analysis.py --out misra.json` → **41 files analysed, 1
  finding, 0 OPEN violations, 1 justified → PASS** (baseline: identical).
  cppcheck is not installed in this environment so this ran GCC-only; CI
  runs the stricter `--strict` + cppcheck pass.
- No-malloc grep gate (`core/`, `transport/`, `config/`,
  `examples/basic_ecu/generated/`) → no output, clean pass.
- `git status` clean apart from the 3 intended files
  (`core/uds_services/service_0x36.c`, `tests/unit_runnable/test_service_0x36.c`,
  `CHANGELOG.md`).

## Other notes

- `core/uds_services/service_0x36.c` is not on CONTRIBUTING.md's
  heightened-review file list, but it's a flashing/programming-protocol
  boundary, so I reviewed the diff carefully by hand anyway (it's a 4-line
  behavioural change reusing an existing, already-reviewed abort pattern
  from `service_0x37.c`).
- Searched the rest of `core/uds_services/` for the same
  clamp-to-remaining-length pattern; found no other instance of it — no new
  FINDINGS.md entry from this task.
- `CHANGELOG.md` `[Unreleased]` → `### Fixed` entry added, following the
  existing convention for recent merged fixes (e.g. #105).
