### PR TITLE
fix: ACL fails open on unregistered service, flip to fail-closed default (#113)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
 
   # ── Job 1: Host unit tests ─────────────────────────────────────────────────
   unit-tests:
-    name: "Unit Tests (43 modules)"
+    name: "Unit Tests (44 modules)"
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -272,8 +272,8 @@ jobs:
         run: |
           result=$(bash build_tests.sh 2>&1 | tail -3)
           echo "$result"
-          echo "$result" | grep -q "43 passed, 0 failed" || \
-            (echo "ERROR: Expected '43 passed, 0 failed'" && exit 1)
+          echo "$result" | grep -q "44 passed, 0 failed" || \
+            (echo "ERROR: Expected '44 passed, 0 failed'" && exit 1)
 
       - name: Verify pre-committed test files present
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+### Security
+
+- **BREAKING: UDS access-control table now fails CLOSED for any service_id
+  with no explicit ACL row — audit your deployment before merging.** (#113)
+  `core/uds_access_table.c`'s `uds_access_table_lookup()` /
+  `uds_access_table_enforce()`, and `core/uds_server.c`'s
+  `srv_check_access_rights()`, treated a service_id absent from the active
+  access table (the built-in default table, or an OEM-supplied custom one
+  via `uds_server_cfg_t.access_table`) as "no restriction" — fully
+  reachable, in every session, with no security check, purely by omission.
+  A new SID added to `service_registration.c` without a matching ACL row
+  became silently unauthenticated. The default is now fail-closed: an
+  unlisted service_id is DENIED (NRC 0x7F, serviceNotSupportedInActiveSession)
+  unless the new compile-time opt-in `UDS_ACL_ALLOW_UNLISTED_SERVICES`
+  (Kconfig: `CONFIG_UDS_ACL_ALLOW_UNLISTED_SERVICES`, default `n`/`0`) is
+  explicitly set. **Every service_id the built-in default table ships today
+  keeps its exact prior behaviour** — including SID 0x31 RoutineControl,
+  the one registered service that previously had no ACL row at all and now
+  has an explicit, deliberately permissive one (see the row's comment in
+  `core/uds_access_table.c`). The behaviour change applies to: (1) any
+  future SID added without a matching ACL row, and (2) any OEM-supplied
+  custom `access_table` that does not cover every service_id it registers —
+  audit your custom table's coverage, or set the opt-in, before upgrading a
+  production deployment past this change. See the PR for the full SID
+  audit and regression tests (fake SID 0x99 denied by default across
+  sessions; opt-in verified to restore the old behaviour end-to-end).
+
 ### Fixed
 
 - **DoIP: `tcp_send()` short writes were treated as a complete send, silently

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Bug reports, documentation improvements, and issue comments never require a CLA.
 - Changes that remove or weaken any step of the 5-step ASIL-B safety wrapper chain
 - Dynamic memory allocation (`malloc`, `free`) anywhere in the stack
 - Recursion in any safety-critical module
-- Changes that break the `native_sim` CI build or cause any unit test to fail (currently 43 — see build_tests.sh, which enforces its own count via an anti-drift check)
+- Changes that break the `native_sim` CI build or cause any unit test to fail (currently 44 — see build_tests.sh, which enforces its own count via an anti-drift check)
 - Hand-written changes to files under `generated/` — these are codegen output;
   fix the template in `tools/templates/` instead
 - External runtime dependencies not already present in the stack
@@ -126,7 +126,7 @@ python3 tools/codegen.py \
   --out generated/ \
   --safety-wrappers --asil-level B --test-gen
 
-# All unit tests must pass (currently 43)
+# All unit tests must pass (currently 44)
 bash build_tests.sh
 
 # All 68 harness tests must pass

--- a/Kconfig
+++ b/Kconfig
@@ -172,4 +172,41 @@ config DIAG_PLACEHOLDER_KEYS_ONLY
 	  CI can compile and run functional tests without real keys.
 	  TRACEABILITY: CRIT-4 / SEC-KEY-GATE-01
 
+# ---------------------------------------------------------------------------
+# Access control table  [#113 FIX]
+# ---------------------------------------------------------------------------
+
+config UDS_ACL_ALLOW_UNLISTED_SERVICES
+	bool "Permit UDS services with no access-table entry (NOT RECOMMENDED)"
+	default n
+	help
+	  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+	  WARNING: leave this 'n' unless you have specifically audited every
+	  service_id in your deployment that has no row in the active access
+	  table (the built-in default table, or a custom one supplied via
+	  uds_server_cfg_t.access_table) and decided it should be reachable
+	  with NO session or security restriction at the ACL layer.
+	  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+	  Prior to #113, a service_id with no matching row in the access table
+	  was silently PERMITTED with no restriction at all — the ACL layer's
+	  default was fail-open. That meant a new SID added to
+	  service_registration.c (or to a custom table) without a matching ACL
+	  row became fully accessible, in every session, with no security
+	  check, purely by omission.
+
+	  With this option left 'n' (the default), any service_id absent from
+	  the active table is now DENIED — the server returns NRC 0x7F
+	  (serviceNotSupportedInActiveSession) instead of dispatching the
+	  handler. Set 'y' only to restore the pre-#113 permissive behaviour
+	  for every unlisted service in your deployment; to allow just ONE
+	  specific service with no ACL-layer restriction, add an explicit row
+	  for that service_id to your table instead (see the SID 0x31
+	  RoutineControl row in core/uds_access_table.c for a worked example)
+	  and leave this option at its secure default.
+
+	  FreeRTOS / bare-metal builds: define UDS_ACL_ALLOW_UNLISTED_SERVICES
+	  (no CONFIG_ prefix) directly, e.g. -DUDS_ACL_ALLOW_UNLISTED_SERVICES=1.
+	  TRACEABILITY: #113
+
 endmenu

--- a/build_tests.sh
+++ b/build_tests.sh
@@ -140,6 +140,12 @@ extra_flags_for_test() {
             # fail-closed path is exercised on a host build.
             echo "-DCONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0"
             ;;
+        test_uds_acl_permissive_opt_in)
+            # [#113] Forces the pre-#113 permissive-by-default ACL behaviour
+            # so the opt-in itself is exercised on a host build; every other
+            # test module compiles against the fail-closed default.
+            echo "-DUDS_ACL_ALLOW_UNLISTED_SERVICES=1"
+            ;;
         *)
             echo ""
             ;;
@@ -285,6 +291,11 @@ TESTS=(
     # reached from the default dev-configuration build used by every other
     # test in this list.
     test_trng_fail_closed
+    # [#113] Permissive opt-in (UDS_ACL_ALLOW_UNLISTED_SERVICES=1) proof.
+    # Compiled separately (see extra_flags_for_test above) because that
+    # behaviour cannot be reached from the default (fail-closed) build used
+    # by every other test in this list, including test_phase5_access_table.
+    test_uds_acl_permissive_opt_in
 )
 
 # ---------------------------------------------------------------------------

--- a/core/uds_access_table.c
+++ b/core/uds_access_table.c
@@ -83,6 +83,13 @@
  *        Restricted to non-default sessions. Turning off DTC setting from
  *        Default session could mask faults during normal vehicle operation.
  *
+ *   0x31 RoutineControl  [#113]
+ *        Available in all sessions; no ACL-layer security requirement.
+ *        Deliberately permissive here — real per-routine session/security
+ *        gating happens inside service_0x31.c against routine_database.c's
+ *        per-RID min_session/security_level. See the row's own comment
+ *        below for the full rationale.
+ *
  * -------------------------------------------------------------------------- */
 
 static const uds_access_entry_t k_default_table[UDS_ACCESS_TABLE_DEFAULT_COUNT] = {
@@ -272,6 +279,37 @@ static const uds_access_entry_t k_default_table[UDS_ACCESS_TABLE_DEFAULT_COUNT] 
         .required_sec_level = (uint8_t)1U,
         .require_unlocked   = true,
     },
+
+    /* [15] 0x31 RoutineControl — all sessions, no ACL-layer security. [#113]
+     *
+     *  ADDED as part of the #113 fail-closed fix. Prior to this fix, 0x31
+     *  was registered in service_registration.c but had NO row in this
+     *  table; under the old fail-open default that meant "no restriction",
+     *  which happened to match this row's effect. Flipping the table's
+     *  default to fail-closed would otherwise have made RoutineControl
+     *  completely unreachable in every session — this explicit row keeps
+     *  its behaviour unchanged.
+     *
+     *  session_mask=ALL / require_unlocked=false is intentional, not an
+     *  oversight: unlike every other service in this table, RoutineControl
+     *  access is NOT uniform across all routines — routine_database.c
+     *  carries a per-RID min_session and security_level, enforced inside
+     *  service_0x31.c's s_validate_routine_access() (REQ-SAFE-002,
+     *  REQ-SAFE-003) *after* dispatch. Gating 0x31 itself at the ACL layer
+     *  would either (a) block routines that are legitimately callable from
+     *  Default session, or (b) require this table to know every OEM's
+     *  per-RID policy, which belongs in routine_database.c, not here. The
+     *  ACL layer's job for 0x31 is only to make sure a missing row can
+     *  never silently grant access the way #113 describes — this row
+     *  documents that "no ACL restriction" is the deliberate, audited
+     *  policy for this SID, not an accidental gap.
+     */
+    {
+        .service_id         = UDS_SID_ROUTINE_CONTROL,
+        .session_mask       = UDS_ACL_SESSION_ALL,
+        .required_sec_level = (uint8_t)0U,
+        .require_unlocked   = false,
+    },
 };
 
 /* --------------------------------------------------------------------------
@@ -354,7 +392,17 @@ uds_status_t uds_access_table_lookup(
         return UDS_STATUS_OK;
     }
 
-    /* No matching entry found — no restriction. */
+    /*
+     * [#113] No matching entry found. This function's own contract is
+     * unchanged: return OK with *out_entry == NULL so the caller can tell
+     * "not in table" apart from "in table, wrong session" (non-NULL entry,
+     * session bit clear — handled above). Whether "not in table" ultimately
+     * ALLOWS or DENIES access is decided in ONE place only —
+     * uds_access_table_enforce(), gated by UDS_ACL_ALLOW_UNLISTED_SERVICES —
+     * so every caller (uds_server.c's dispatcher and any OEM code calling
+     * this API directly) gets the same fail-closed-by-default decision
+     * instead of re-implementing it.
+     */
     *out_entry = NULL;
     return UDS_STATUS_OK;
 }
@@ -365,9 +413,33 @@ uds_status_t uds_access_table_enforce(
 {
     bool unlocked;
 
-    /* No entry → no restriction → access granted. */
+    /*
+     * [#113] No entry → access DECISION for the "not in table" case.
+     *
+     * Prior to #113 this returned UDS_STATUS_OK unconditionally ("no
+     * restriction"), so a service_id with no ACL row — e.g. a new SID added
+     * to service_registration.c without a matching row here — was fully
+     * reachable with no session or security gate at all. That is the wrong
+     * default for security-relevant middleware: fail-closed (deny) is now
+     * the default, with an explicit, deployment-wide opt-in
+     * (UDS_ACL_ALLOW_UNLISTED_SERVICES, default 0) for integrators who have
+     * deliberately chosen permissive-by-default behaviour. See the
+     * "UDS_ACL_ALLOW_UNLISTED_SERVICES" section of uds_access_table.h for
+     * the full rationale and how to set it per platform.
+     *
+     * UDS_STATUS_ERR_SERVICE_NOT_SUPPORTED_IN_SESSION is deliberately reused
+     * here rather than introducing a new status: it already maps to NRC
+     * 0x7F (serviceNotSupportedInActiveSession) in uds_server.c, which is
+     * the NRC this file's own lookup() comment above says a missing rule
+     * should have produced all along ("This behaviour enables proper NRC
+     * 0x7F ... vs leaving access open when there's simply no rule").
+     */
     if (entry == NULL) {
+#if UDS_ACL_ALLOW_UNLISTED_SERVICES
         return UDS_STATUS_OK;
+#else
+        return UDS_STATUS_ERR_SERVICE_NOT_SUPPORTED_IN_SESSION;
+#endif
     }
 
     /*

--- a/core/uds_access_table.h
+++ b/core/uds_access_table.h
@@ -28,16 +28,50 @@
  *   session_mask is a bitfield — one bit per session type. Multiple sessions
  *   can share the same access rule in a single entry.
  *
- *   A service with no matching entry is ALLOWED (the default is permissive so
- *   that service-level guards in individual handlers remain authoritative).
- *   The table only ADDS restrictions on top of the handler's own checks.
+ *   [#113 FIX] A service with NO matching entry is DENIED by default
+ *   (fail-closed) — see UDS_ACL_ALLOW_UNLISTED_SERVICES below. A missing row
+ *   most often means a new SID was added to service_registration.c and the
+ *   author forgot to add a corresponding ACL row; treating that as "no
+ *   restriction" silently granted full, unauthenticated access to it in
+ *   every session. Prior to this fix the default was permissive (see
+ *   issue #113 for the incident that prompted this change); every SID that
+ *   is actually reachable through the built-in default table has an
+ *   explicit row below so this flip does not change behaviour for any
+ *   service this stack ships today.
  *
  * LOOKUP ALGORITHM:
  *   1. Walk the table from entry 0 to entry (count - 1).
  *   2. If entry.service_id matches AND (1 << active_session) & entry.session_mask != 0:
  *        → enforce entry.required_sec + entry.require_unlocked
- *   3. If no matching entry: access granted.
+ *   3. If no matching entry: uds_access_table_lookup() itself still returns
+ *      NULL (so callers can distinguish "not in table" from "in table, wrong
+ *      session"); the access DECISION for that NULL case is made by
+ *      uds_access_table_enforce(), gated by UDS_ACL_ALLOW_UNLISTED_SERVICES
+ *      (deny unless the integrator opts in).
  *   4. First match wins — put more specific rules before general ones.
+ *
+ * UDS_ACL_ALLOW_UNLISTED_SERVICES — permissive opt-in for unlisted services:
+ *
+ *   Compile-time switch (same convention as ISOTP_TX_PADDING in
+ *   transport/isotp.h). Default 0 (fail-closed): a service_id with no
+ *   matching row in the active table — default or OEM-custom — is DENIED.
+ *   Set to 1 to restore the pre-#113 permissive behaviour for a specific
+ *   deployment that has audited every unlisted SID and deliberately wants
+ *   it reachable with no ACL-layer restriction (handler-level guards, if
+ *   any, still apply).
+ *
+ *   Zephyr:                 CONFIG_UDS_ACL_ALLOW_UNLISTED_SERVICES=y in
+ *                            prj.conf (see Kconfig).
+ *   FreeRTOS / bare-metal:   #define UDS_ACL_ALLOW_UNLISTED_SERVICES 1
+ *                            before including this header, or pass
+ *                            -DUDS_ACL_ALLOW_UNLISTED_SERVICES=1 to the
+ *                            compiler.
+ *
+ *   This is a per-deployment policy decision, not a per-SID one: it applies
+ *   to every service_id absent from whichever table is active. OEMs who
+ *   want permissive behaviour for only SOME unlisted services should instead
+ *   add explicit ACL rows for those specific SIDs and leave this switch at
+ *   its secure default.
  *
  * DEFAULT TABLE (uds_access_table_get_default() / UDS_ACCESS_TABLE_DEFAULT):
  *
@@ -50,13 +84,25 @@
  *                                         (security guard is inside the handler)
  *   SID  0x28 CommunicationControl     — Extended+Programming, no security
  *   SID  0x2E WriteDataByIdentifier    — Extended+Programming, Level 1 required
+ *   SID  0x31 RoutineControl           — all sessions, no ACL-layer security
+ *                                         (per-routine session/security gate
+ *                                         enforced inside service_0x31.c —
+ *                                         see [#113] row rationale in
+ *                                         uds_access_table.c)
  *   SID  0x3E TesterPresent            — all sessions, no security
  *   SID  0x85 ControlDTCSetting        — Extended+Programming, no security
+ *
+ *   (SIDs 0x23/0x2A/0x2F/0x34/0x35/0x36/0x37/0x3D also have rows — see the
+ *   table definition in uds_access_table.c for the full, current list.)
  *
  * OEM CUSTOMISATION:
  *   Declare a custom uds_access_entry_t[] array and pass it via the
  *   access_table / access_table_count fields in uds_server_cfg_t.
- *   NULL leaves the default table active.
+ *   NULL leaves the default table active. Remember: with the fail-closed
+ *   default, any service_id NOT covered by your custom table is now DENIED
+ *   rather than silently allowed — audit your table's coverage after
+ *   upgrading past #113, or set UDS_ACL_ALLOW_UNLISTED_SERVICES=1 if you
+ *   need the old behaviour immediately while you do that audit.
  *
  * STANDARD: MISRA C:2012 alignment intended.
  * SPDX-License-Identifier: GPL-2.0-only
@@ -72,6 +118,24 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+
+/* --------------------------------------------------------------------------
+ * [#113] Fail-closed-by-default permissive opt-in.
+ *
+ * See the "UDS_ACL_ALLOW_UNLISTED_SERVICES" section of the file header
+ * comment above for the full rationale and wiring instructions. Kept as a
+ * plain, non-CONFIG_-prefixed macro (matching ISOTP_TX_PADDING's convention
+ * in transport/isotp.h) so it is usable identically from Zephyr (via the
+ * Kconfig symbol of the same name), FreeRTOS, and bare-metal builds, and
+ * from host unit tests via a plain -D compiler flag.
+ *
+ * Default 0 — fail-closed: a service_id absent from the active table is
+ * DENIED. Set to 1 only for a deployment that has deliberately chosen
+ * permissive-by-default behaviour for its unlisted services.
+ * -------------------------------------------------------------------------- */
+#ifndef UDS_ACL_ALLOW_UNLISTED_SERVICES
+#define UDS_ACL_ALLOW_UNLISTED_SERVICES 0
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -172,8 +236,14 @@ typedef struct uds_access_entry {
 
 /**
  * @brief Number of entries in the built-in default access rights table.
+ *
+ * [#113] 18 -> 19: added the SID 0x31 (RoutineControl) row, which was
+ * previously absent (fell through the old fail-open default). See the row
+ * comment in uds_access_table.c for why it is intentionally permissive at
+ * the ACL layer (per-routine session/security checks live in
+ * core/uds_services/service_0x31.c instead).
  */
-#define UDS_ACCESS_TABLE_DEFAULT_COUNT  (18U)
+#define UDS_ACCESS_TABLE_DEFAULT_COUNT  (19U)
 
 /* --------------------------------------------------------------------------
  * Public API

--- a/core/uds_server.c
+++ b/core/uds_server.c
@@ -388,7 +388,10 @@ static uds_nrc_t srv_status_to_nrc(uds_status_t status)
  * Flow:
  *   1. Select table: use cfg.access_table if provided, else default.
  *   2. Look up (service_id, active_session) in the table.
- *   3. No entry found → access granted (permissive default).
+ *   3. No entry found → uds_access_table_enforce(NULL, ...) decides: DENIED
+ *      by default (NRC 0x7F serviceNotSupportedInActiveSession) as of
+ *      [#113], unless UDS_ACL_ALLOW_UNLISTED_SERVICES=1 opts back into the
+ *      pre-#113 permissive behaviour. See uds_access_table.h/.c.
  *   4. Entry found, session_mask does NOT cover active session
  *      → NRC 0x7F serviceNotSupportedInActiveSession.
  *   5. require_unlocked=true and required security level is not active
@@ -398,6 +401,9 @@ static uds_nrc_t srv_status_to_nrc(uds_status_t status)
  * OEM CUSTOMISATION:
  *   Pass a custom uds_access_entry_t[] via uds_server_cfg_t.access_table.
  *   The stack never needs to be recompiled to change access policy.
+ *   [#113] Remember: with the fail-closed default, any service_id NOT
+ *   covered by your custom table is now DENIED rather than silently
+ *   allowed — audit your table's SID coverage.
  */
 static uds_status_t srv_check_access_rights(
     uds_server_ctx_t          *ctx,
@@ -435,22 +441,42 @@ static uds_status_t srv_check_access_rights(
         return UDS_STATUS_ERR_CONDITIONS_NOT_MET;
     }
 
-    if (acl_entry == NULL) {
-        /* No entry in table — no restriction. */
-        return UDS_STATUS_OK;
+    /*
+     * [#113 FIX] acl_entry == NULL ("not in table") used to short-circuit
+     * straight to UDS_STATUS_OK right here — a second, independent copy of
+     * the fail-open "no restriction" decision that uds_access_table.c's own
+     * enforce() also made. That duplication was the actual production bug:
+     * even after making uds_access_table_enforce() fail-closed, THIS
+     * function never called it for the acl_entry == NULL case, so real
+     * dispatch (every request that reaches here) stayed permissive
+     * regardless of what enforce() decided.
+     *
+     * Fix: only run the session_mask check when there IS a matching entry
+     * (unchanged from before), then ALWAYS fall through to
+     * uds_access_table_enforce() — including with acl_entry == NULL — so
+     * there is exactly one place (uds_access_table_enforce(), gated by
+     * UDS_ACL_ALLOW_UNLISTED_SERVICES) that decides what "not in table"
+     * means. See core/uds_access_table.c / uds_access_table.h for the
+     * rationale.
+     */
+    if (acl_entry != NULL) {
+        /*
+         * Entry found. Verify that the active session is covered by the
+         * entry's session_mask. The lookup populates acl_entry on any
+         * service_id match, even when the session bit is missing — that
+         * signals "wrong session".
+         */
+        session_bit = (uint8_t)((uint8_t)1U << ((uint8_t)active_session - (uint8_t)1U));
+        if ((acl_entry->session_mask & session_bit) == (uint8_t)0U) {
+            return UDS_STATUS_ERR_SERVICE_NOT_SUPPORTED_IN_SESSION;
+        }
     }
 
     /*
-     * Entry found. Verify that the active session is covered by the entry's
-     * session_mask. The lookup populates acl_entry on any service_id match,
-     * even when the session bit is missing — that signals "wrong session".
+     * Enforce security level requirement — or, if acl_entry is NULL, the
+     * fail-closed-by-default "not in table" decision itself (see comment
+     * above and uds_access_table_enforce()'s own doc comment).
      */
-    session_bit = (uint8_t)((uint8_t)1U << ((uint8_t)active_session - (uint8_t)1U));
-    if ((acl_entry->session_mask & session_bit) == (uint8_t)0U) {
-        return UDS_STATUS_ERR_SERVICE_NOT_SUPPORTED_IN_SESSION;
-    }
-
-    /* Enforce security level requirement. */
     rc = uds_access_table_enforce(acl_entry, ctx->cfg.security_ctx);
     if (rc != UDS_STATUS_OK) {
         if (rc == UDS_STATUS_ERR_SEC_NOT_UNLOCKED) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -220,7 +220,7 @@ embedded-diagnostics-suite/
 │   └── mocks/                  # Zephyr port mock + NVM mock for host builds
 │
 └── scripts/
-    ├── build_tests.sh          # Runs all 43 unit test modules
+    ├── build_tests.sh          # Runs all 44 unit test modules
     └── build_harness.sh        # Runs all 68 harness tests
 ```
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -6,7 +6,7 @@
 - Zephyr workspace with EDS checked out
 - A minimal ECU firmware built and running in the simulator
 - UDS service 0x22 (ReadDataByIdentifier) responding to requests
-- All 43 unit tests passing
+- All 44 unit tests passing
 
 **No prior Zephyr knowledge assumed.**
 
@@ -518,7 +518,7 @@ Run the integration tests in a second terminal to send traffic while it's runnin
 | `west build -b nucleo_h743zi2 examples/basic_ecu` | Cross-compile for STM32 Nucleo-H743ZI2 |
 | `west build -b mr_canhubk3 examples/basic_ecu -- -DEXTRA_CONF_FILE=boards/mr_canhubk3/mr_canhubk3.conf -DDTC_OVERLAY_FILE=boards/mr_canhubk3/mr_canhubk3.overlay` | Cross-compile for NXP MR-CANHUBK3 (S32K344) |
 | `west flash` | Flash to connected hardware |
-| `bash build_tests.sh` | Run 43 unit tests |
+| `bash build_tests.sh` | Run 44 unit tests |
 | `pytest tests/integration/ -v` | Run Python integration tests |
 | `cd gui && npm ci && npm start` | Start GUI configurator |
 | `python3 tools/testgen.py --config CONFIG --out OUT` | Generate pytest test suite |

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -1,7 +1,7 @@
 # Testing Strategy — Xaloqi EDS
 
 **Version:** v1.10.1  
-**Status:** 43/43 unit test modules passing. 68/68 harness tests passing. 21/21 CI jobs green. FreeRTOS, SafeBoot (Zephyr + FreeRTOS), DoIP, and sensor examples all covered.
+**Status:** 44/44 unit test modules passing. 68/68 harness tests passing. 21/21 CI jobs green. FreeRTOS, SafeBoot (Zephyr + FreeRTOS), DoIP, and sensor examples all covered.
 
 ---
 
@@ -105,7 +105,7 @@ bash scripts/build_tests.sh
 # Expected: 42 tests, 0 failures
 ```
 
-### Coverage — 43 unit test modules
+### Coverage — 44 unit test modules
 
 **UDS Core (4 modules)**
 
@@ -173,12 +173,18 @@ bash scripts/build_tests.sh
 |---|---|
 | `test_did_safety_wrappers.c` | All 5 steps exercised individually; each produces the correct NRC |
 
-**Phase-specific test modules (10 modules in `unit_runnable/`)**
+**Phase-specific test modules (11 modules in `unit_runnable/`)**
 
 Additional tests added in Phases 2–5 covering: suppress-bit handling, STmin boundary
 conditions, session transition matrix, NVM DTC persistence, security algorithm correctness,
 DID access table validation, and replay-protection logic — plus the DoIP module (counted
 separately above) and the periodic scheduler (counted above under Generated Code).
+
+`test_uds_acl_permissive_opt_in.c` covers the `UDS_ACL_ALLOW_UNLISTED_SERVICES`
+opt-in added by [#113](https://github.com/Xaloqi/EDS/issues/113): with the
+fail-closed default a service ID absent from the access table is denied in every
+session, and with the opt-in compiled in the pre-#113 permissive behaviour is
+restored.
 
 ---
 
@@ -424,7 +430,7 @@ All 8 jobs must pass before a PR can be merged.
 
 Added in v1.3.0. Builds `examples/basic_ecu_freertos` with `-DEDS_PLATFORM=freertos`
 targeting QEMU ARM Cortex-M4. Downloads FreeRTOS-Kernel from GitHub, runs codegen,
-builds the ELF, and verifies it exists. The same 43 unit tests run against the FreeRTOS
+builds the ELF, and verifies it exists. The same 44 unit tests run against the FreeRTOS
 platform HAL (they mock the platform layer and are platform-independent).
 
 ### SafeBoot CI job (within `unit-tests`)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -606,6 +606,22 @@ add_diag_test(test_trng_fail_closed
         CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0
 )
 
+# ---------------------------------------------------------------------------
+# test_uds_acl_permissive_opt_in  [#113]
+#      Module under test: core/uds_access_table.c / core/uds_server.c in
+#      the UDS_ACL_ALLOW_UNLISTED_SERVICES=1 (permissive opt-in) build
+#      configuration, which cannot be reached from the default host build
+#      used by every other test module here. Mirrors test_trng_fail_closed's
+#      per-target DEFINES pattern.
+# ---------------------------------------------------------------------------
+add_diag_test(test_uds_acl_permissive_opt_in
+    SOURCES
+        "${TEST_UNIT_DIR}/test_uds_acl_permissive_opt_in.c"
+        ${DIAG_STACK_SRCS}
+    DEFINES
+        UDS_ACL_ALLOW_UNLISTED_SERVICES=1
+)
+
 # ===========================================================================
 # Summary target: print all registered tests
 # ===========================================================================

--- a/tests/unit_runnable/test_phase5_access_table.c
+++ b/tests/unit_runnable/test_phase5_access_table.c
@@ -27,12 +27,27 @@
  *   TC-ACL-017  lookup() with NULL table returns ERR_NULL_PTR
  *   TC-ACL-018  lookup() with NULL out_entry returns ERR_NULL_PTR
  *   TC-ACL-019  lookup() count=0 → no match (NULL out_entry, OK return)
- *   TC-ACL-020  Unknown SID not in table → NULL out_entry (no restriction)
+ *   TC-ACL-020  Unknown SID not in table → lookup() still returns NULL
+ *               out_entry (the ALLOW/DENY decision itself is made by
+ *               enforce(), see TC-ACL-022/026-029)
  *   TC-ACL-021  Custom single-entry table overrides default for a specific SID
- *   TC-ACL-022  enforce() with NULL entry → OK (no restriction)
+ *   TC-ACL-022  [#113] enforce() with NULL entry → DENY by default
+ *               (fail-closed; was OK/"no restriction" pre-#113)
  *   TC-ACL-023  enforce() with NULL security_ctx and require_unlocked → ERR_NULL_PTR
  *   TC-ACL-024  enforce() with require_unlocked=false → OK regardless of security state
  *   TC-ACL-025  acl_session_to_bit: session_mask bitmapping for all four types
+ *   TC-ACL-026  [#113 regression] Unregistered SID 0x99, DEFAULT session →
+ *               DENIED end-to-end (lookup + enforce) against the default
+ *               table
+ *   TC-ACL-027  [#113 regression] Unregistered SID 0x99, EXTENDED session →
+ *               DENIED end-to-end
+ *   TC-ACL-028  [#113 regression] Unregistered SID 0x99, PROGRAMMING
+ *               session → DENIED end-to-end
+ *   TC-ACL-029  [#113] Denial for an unlisted SID maps to
+ *               UDS_STATUS_ERR_SERVICE_NOT_SUPPORTED_IN_SESSION (NRC 0x7F)
+ *   TC-ACL-030  [#113] Default table has an explicit row for SID 0x31
+ *               RoutineControl (the one previously-unlisted registered
+ *               service — see UDS_ACCESS_TABLE_DEFAULT_COUNT 18→19)
  *
  * FRAMEWORK: Zephyr Ztest (via ztest_shim.h)
  * =============================================================================
@@ -71,6 +86,33 @@ static bool default_table_allows(uint8_t sid, uds_session_type_t sess)
     return ((entry->session_mask & bit) != (uint8_t)0U);
 }
 
+/**
+ * [#113] End-to-end access decision: lookup() followed by enforce(), the
+ * same two-step sequence uds_server.c's srv_check_access_rights() performs.
+ * Unlike default_table_allows() above (which only asks "did lookup() find a
+ * matching row in this session" and does not touch enforce()), this reflects
+ * the ACTUAL allow/deny decision — including the fail-closed default for a
+ * service_id with no ACL row at all.
+ */
+static uds_status_t default_table_decide(uint8_t sid, uds_session_type_t sess)
+{
+    const uds_access_entry_t *entry = NULL;
+    uds_status_t rc = uds_access_table_lookup(
+        uds_access_table_get_default(),
+        (uint8_t)UDS_ACCESS_TABLE_DEFAULT_COUNT,
+        sid, sess, &entry);
+
+    if (rc != UDS_STATUS_OK) { return rc; }
+
+    if ((entry != NULL) &&
+        ((entry->session_mask &
+          (uint8_t)((uint8_t)1U << ((uint8_t)sess - (uint8_t)1U))) == (uint8_t)0U)) {
+        return UDS_STATUS_ERR_SERVICE_NOT_SUPPORTED_IN_SESSION;
+    }
+
+    return uds_access_table_enforce(entry, NULL);
+}
+
 /* =========================================================================
  * Test cases
  * ========================================================================= */
@@ -91,12 +133,14 @@ ZTEST(test_phase5_access_table, tc001_get_default_not_null)
  * then 13 → 14 when 0x35 RequestUpload was added,
  * then 14 → 15 when 0x2F InputOutputControlByIdentifier was added,
  * then 15 → 16 when 0x2A ReadDataByPeriodicIdentifier was added,
- * then 16 → 18 when 0x23 ReadMemoryByAddress + 0x3D WriteMemoryByAddress were added.
+ * then 16 → 18 when 0x23 ReadMemoryByAddress + 0x3D WriteMemoryByAddress were added,
+ * then 18 → 19 [#113] when the previously-missing SID 0x31 RoutineControl
+ * row was added (see the fail-closed-default fix in this file's module).
  */
 ZTEST(test_phase5_access_table, tc002_default_table_count)
 {
-    zassert_equal((uint8_t)UDS_ACCESS_TABLE_DEFAULT_COUNT, (uint8_t)18U,
-        "default table must have exactly 18 entries");
+    zassert_equal((uint8_t)UDS_ACCESS_TABLE_DEFAULT_COUNT, (uint8_t)19U,
+        "default table must have exactly 19 entries");
 }
 
 /**
@@ -279,7 +323,12 @@ ZTEST(test_phase5_access_table, tc019_lookup_count_zero)
 }
 
 /**
- * TC-ACL-020: Unknown SID not in table → NULL out_entry (no restriction).
+ * TC-ACL-020: Unknown SID not in table → lookup() still returns NULL
+ * out_entry with status OK. This is lookup()'s own contract (it must let
+ * the caller tell "not in table" apart from "in table, wrong session") and
+ * is UNCHANGED by #113 — what changed is what enforce() does with that NULL
+ * entry afterwards (fail-closed by default; see TC-ACL-022 and
+ * TC-ACL-026..029 below for the actual allow/deny decision).
  */
 ZTEST(test_phase5_access_table, tc020_unknown_sid_no_restriction)
 {
@@ -292,7 +341,7 @@ ZTEST(test_phase5_access_table, tc020_unknown_sid_no_restriction)
         &entry);
     zassert_equal(rc, UDS_STATUS_OK, "unknown SID must return OK");
     zassert_is_null(entry,
-        "unknown SID must yield NULL entry (no restriction applied)");
+        "unknown SID must yield NULL entry from lookup()");
 }
 
 /**
@@ -323,15 +372,24 @@ ZTEST(test_phase5_access_table, tc021_custom_table_overrides_default)
 }
 
 /**
- * TC-ACL-022: enforce() with NULL entry → UDS_STATUS_OK (no restriction).
+ * TC-ACL-022: [#113] enforce() with NULL entry → DENY by default
+ * (fail-closed). Before #113 this asserted UDS_STATUS_OK ("no
+ * restriction") — that was the exact bug reported in issue #113: a
+ * service_id with no ACL row was silently fully permitted. With
+ * UDS_ACL_ALLOW_UNLISTED_SERVICES left at its default (0), a NULL entry is
+ * now denied with UDS_STATUS_ERR_SERVICE_NOT_SUPPORTED_IN_SESSION, which
+ * uds_server.c maps to NRC 0x7F. The permissive opt-in itself is exercised
+ * by tests/unit_runnable/test_uds_acl_permissive_opt_in.c, compiled with
+ * -DUDS_ACL_ALLOW_UNLISTED_SERVICES=1 (see tests/CMakeLists.txt /
+ * build_tests.sh), which restores this exact OK return.
  */
-ZTEST(test_phase5_access_table, tc022_enforce_null_entry_ok)
+ZTEST(test_phase5_access_table, tc022_enforce_null_entry_fail_closed_by_default)
 {
     uds_security_ctx_t sec_ctx;
     (void)memset(&sec_ctx, 0, sizeof(sec_ctx));
     uds_status_t rc = uds_access_table_enforce(NULL, &sec_ctx);
-    zassert_equal(rc, UDS_STATUS_OK,
-        "enforce with NULL entry must return OK (no restriction)");
+    zassert_equal(rc, UDS_STATUS_ERR_SERVICE_NOT_SUPPORTED_IN_SESSION,
+        "enforce with NULL entry must DENY by default (fail-closed, #113)");
 }
 
 /**
@@ -396,6 +454,74 @@ ZTEST(test_phase5_access_table, tc025_session_bitmask_mapping)
         "ALL mask must equal OR of all four session masks");
 }
 
+/**
+ * TC-ACL-026: [#113 regression] Register a fake/unregistered service, SID
+ * 0x99, with no ACL entry: access against the default table in the DEFAULT
+ * session must be DENIED, not silently allowed. This is the exact
+ * regression scenario from issue #113.
+ */
+ZTEST(test_phase5_access_table, tc026_fake_sid_0x99_denied_default)
+{
+    uds_status_t rc = default_table_decide((uint8_t)0x99U, UDS_SESSION_DEFAULT);
+    zassert_not_equal(rc, UDS_STATUS_OK,
+        "SID 0x99 (no ACL entry) must be DENIED in DEFAULT session, not allowed");
+}
+
+/**
+ * TC-ACL-027: [#113 regression] Same as TC-ACL-026, EXTENDED session.
+ */
+ZTEST(test_phase5_access_table, tc027_fake_sid_0x99_denied_extended)
+{
+    uds_status_t rc = default_table_decide((uint8_t)0x99U, UDS_SESSION_EXTENDED);
+    zassert_not_equal(rc, UDS_STATUS_OK,
+        "SID 0x99 (no ACL entry) must be DENIED in EXTENDED session, not allowed");
+}
+
+/**
+ * TC-ACL-028: [#113 regression] Same as TC-ACL-026, PROGRAMMING session.
+ */
+ZTEST(test_phase5_access_table, tc028_fake_sid_0x99_denied_programming)
+{
+    uds_status_t rc = default_table_decide((uint8_t)0x99U, UDS_SESSION_PROGRAMMING);
+    zassert_not_equal(rc, UDS_STATUS_OK,
+        "SID 0x99 (no ACL entry) must be DENIED in PROGRAMMING session, not allowed");
+}
+
+/**
+ * TC-ACL-029: [#113] The denial for an unlisted SID maps to the specific
+ * status uds_server.c translates to NRC 0x7F
+ * (serviceNotSupportedInActiveSession) — not just "any non-OK status".
+ */
+ZTEST(test_phase5_access_table, tc029_fake_sid_0x99_denial_status)
+{
+    uds_status_t rc = default_table_decide((uint8_t)0x99U, UDS_SESSION_DEFAULT);
+    zassert_equal(rc, UDS_STATUS_ERR_SERVICE_NOT_SUPPORTED_IN_SESSION,
+        "unlisted-SID denial must be UDS_STATUS_ERR_SERVICE_NOT_SUPPORTED_IN_SESSION"
+        " (NRC 0x7F)");
+}
+
+/**
+ * TC-ACL-030: [#113] SID 0x31 RoutineControl — the one registered service
+ * that had NO ACL row before #113 — now has an explicit row in the default
+ * table and is reachable exactly as before (all sessions, no ACL-layer
+ * security; per-routine gating happens inside service_0x31.c). This proves
+ * the fail-closed flip did not silently break RoutineControl.
+ */
+ZTEST(test_phase5_access_table, tc030_0x31_has_explicit_row_all_sessions)
+{
+    zassert_true(default_table_allows(UDS_SID_ROUTINE_CONTROL, UDS_SESSION_DEFAULT),
+        "0x31 must still be reachable (ACL layer) in DEFAULT session");
+    zassert_true(default_table_allows(UDS_SID_ROUTINE_CONTROL, UDS_SESSION_EXTENDED),
+        "0x31 must still be reachable (ACL layer) in EXTENDED session");
+    zassert_true(default_table_allows(UDS_SID_ROUTINE_CONTROL, UDS_SESSION_PROGRAMMING),
+        "0x31 must still be reachable (ACL layer) in PROGRAMMING session");
+
+    uds_status_t rc = default_table_decide(UDS_SID_ROUTINE_CONTROL, UDS_SESSION_DEFAULT);
+    zassert_equal(rc, UDS_STATUS_OK,
+        "0x31 end-to-end (lookup+enforce) must still be OK at the ACL layer"
+        " in DEFAULT session — per-routine gating happens inside the handler");
+}
+
 /* =========================================================================
  * run_all_tests
  * ========================================================================= */
@@ -421,10 +547,15 @@ extern void test_phase5_access_table__tc018_lookup_null_out_entry(void);
 extern void test_phase5_access_table__tc019_lookup_count_zero(void);
 extern void test_phase5_access_table__tc020_unknown_sid_no_restriction(void);
 extern void test_phase5_access_table__tc021_custom_table_overrides_default(void);
-extern void test_phase5_access_table__tc022_enforce_null_entry_ok(void);
+extern void test_phase5_access_table__tc022_enforce_null_entry_fail_closed_by_default(void);
 extern void test_phase5_access_table__tc023_enforce_null_sec_ctx_with_require(void);
 extern void test_phase5_access_table__tc024_enforce_no_security_required_ok(void);
 extern void test_phase5_access_table__tc025_session_bitmask_mapping(void);
+extern void test_phase5_access_table__tc026_fake_sid_0x99_denied_default(void);
+extern void test_phase5_access_table__tc027_fake_sid_0x99_denied_extended(void);
+extern void test_phase5_access_table__tc028_fake_sid_0x99_denied_programming(void);
+extern void test_phase5_access_table__tc029_fake_sid_0x99_denial_status(void);
+extern void test_phase5_access_table__tc030_0x31_has_explicit_row_all_sessions(void);
 
 void run_all_tests(void)
 {
@@ -449,8 +580,13 @@ void run_all_tests(void)
     RUN_TEST(test_phase5_access_table__tc019_lookup_count_zero);
     RUN_TEST(test_phase5_access_table__tc020_unknown_sid_no_restriction);
     RUN_TEST(test_phase5_access_table__tc021_custom_table_overrides_default);
-    RUN_TEST(test_phase5_access_table__tc022_enforce_null_entry_ok);
+    RUN_TEST(test_phase5_access_table__tc022_enforce_null_entry_fail_closed_by_default);
     RUN_TEST(test_phase5_access_table__tc023_enforce_null_sec_ctx_with_require);
     RUN_TEST(test_phase5_access_table__tc024_enforce_no_security_required_ok);
     RUN_TEST(test_phase5_access_table__tc025_session_bitmask_mapping);
+    RUN_TEST(test_phase5_access_table__tc026_fake_sid_0x99_denied_default);
+    RUN_TEST(test_phase5_access_table__tc027_fake_sid_0x99_denied_extended);
+    RUN_TEST(test_phase5_access_table__tc028_fake_sid_0x99_denied_programming);
+    RUN_TEST(test_phase5_access_table__tc029_fake_sid_0x99_denial_status);
+    RUN_TEST(test_phase5_access_table__tc030_0x31_has_explicit_row_all_sessions);
 }

--- a/tests/unit_runnable/test_uds_acl_permissive_opt_in.c
+++ b/tests/unit_runnable/test_uds_acl_permissive_opt_in.c
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2026 Xaloqi
+/*
+ * =============================================================================
+ * FILE: tests/unit_runnable/test_uds_acl_permissive_opt_in.c
+ *
+ * MODULE UNDER TEST: core/uds_access_table.c / core/uds_server.c, compiled
+ *                     with the permissive opt-in switch active.
+ *
+ * [#113] Regression test for issue #113's second requirement: prove that
+ * UDS_ACL_ALLOW_UNLISTED_SERVICES=1 restores the EXACT pre-#113 behaviour
+ * for a service_id absent from the active access table — i.e. the opt-in
+ * genuinely works, not just that the fail-closed default (proven by
+ * tests/unit_runnable/test_phase5_access_table.c's TC-ACL-022/026-029)
+ * exists.
+ *
+ * This only activates when UDS_ACL_ALLOW_UNLISTED_SERVICES == 1, which
+ * cannot be reached from the default host build used by every other test
+ * module (see build_tests.sh / tests/CMakeLists.txt). This file is
+ * therefore compiled as its own, separate test binary with
+ * -DUDS_ACL_ALLOW_UNLISTED_SERVICES=1 — mirroring the existing
+ * test_trng_fail_closed.c pattern for CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0.
+ *
+ * TEST CASES:
+ *   TC-ACLP-001  Compile-time proof this TU is actually built with the
+ *                opt-in active (UDS_ACL_ALLOW_UNLISTED_SERVICES == 1).
+ *   TC-ACLP-002  uds_access_table_enforce(NULL, ...) -> UDS_STATUS_OK with
+ *                the opt-in active (was DENY by default; see TC-ACL-022).
+ *   TC-ACLP-003  Fake SID 0x99 (no ACL entry), end-to-end lookup+enforce
+ *                against the default table, DEFAULT session -> ALLOWED.
+ *   TC-ACLP-004  End-to-end through uds_server_process_request(): a
+ *                registered service handler with NO row in the supplied
+ *                access_table is still DISPATCHED (handler runs) when the
+ *                opt-in is active — proves the restore reaches the real
+ *                production dispatch path in core/uds_server.c, not just
+ *                the uds_access_table.c library functions in isolation.
+ *
+ * FRAMEWORK: Zephyr Ztest (via ztest_shim.h)
+ * =============================================================================
+ */
+
+#include <zephyr/ztest.h>
+#include <string.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#include "uds_access_table.h"
+#include "uds_security.h"
+#include "uds_session.h"
+#include "uds_server.h"
+#include "uds_types.h"
+
+/* =============================================================================
+ * [#113] Compile-time proof this TU is actually built with the permissive
+ * opt-in active. Without this guard, a broken build-flag pipeline (e.g.
+ * build_tests.sh losing the -DUDS_ACL_ALLOW_UNLISTED_SERVICES=1 flag for
+ * this test) would silently compile this file against the fail-closed
+ * default instead, and every assertion below would simply fail loudly —
+ * this guard turns that into an unambiguous compile-time error instead of
+ * a confusing runtime failure.
+ * ============================================================================= */
+#if !UDS_ACL_ALLOW_UNLISTED_SERVICES
+#  error "[#113] test_uds_acl_permissive_opt_in.c must be built with " \
+         "-DUDS_ACL_ALLOW_UNLISTED_SERVICES=1 -- see the " \
+         "extra_flags_for_test() entry in build_tests.sh / the DEFINES " \
+         "on this target in tests/CMakeLists.txt."
+#endif
+
+ZTEST_SUITE(test_uds_acl_permissive_opt_in, NULL, NULL, NULL, NULL, NULL);
+
+/**
+ * TC-ACLP-001: sanity — the macro really is 1 in this translation unit.
+ */
+ZTEST(test_uds_acl_permissive_opt_in, tc001_opt_in_macro_is_active)
+{
+    zassert_equal(UDS_ACL_ALLOW_UNLISTED_SERVICES, 1,
+        "this test binary must be compiled with UDS_ACL_ALLOW_UNLISTED_SERVICES=1");
+}
+
+/**
+ * TC-ACLP-002: enforce(NULL, ...) restores the pre-#113 OK/"no restriction"
+ * result when the opt-in is active. Mirrors TC-ACL-022 in
+ * test_phase5_access_table.c, which proves the opposite (DENY) in the
+ * default build.
+ */
+ZTEST(test_uds_acl_permissive_opt_in, tc002_enforce_null_entry_allowed)
+{
+    uds_security_ctx_t sec_ctx;
+    (void)memset(&sec_ctx, 0, sizeof(sec_ctx));
+    uds_status_t rc = uds_access_table_enforce(NULL, &sec_ctx);
+    zassert_equal(rc, UDS_STATUS_OK,
+        "enforce with NULL entry must be OK when UDS_ACL_ALLOW_UNLISTED_SERVICES=1");
+}
+
+/**
+ * TC-ACLP-003: fake SID 0x99 (no ACL entry in the default table),
+ * end-to-end lookup + enforce, DEFAULT session -> ALLOWED. This is the same
+ * scenario TC-ACL-026 in test_phase5_access_table.c proves is DENIED in the
+ * default build.
+ */
+ZTEST(test_uds_acl_permissive_opt_in, tc003_fake_sid_0x99_allowed_default)
+{
+    const uds_access_entry_t *entry = NULL;
+    uds_status_t rc = uds_access_table_lookup(
+        uds_access_table_get_default(),
+        (uint8_t)UDS_ACCESS_TABLE_DEFAULT_COUNT,
+        (uint8_t)0x99U, UDS_SESSION_DEFAULT, &entry);
+    zassert_equal(rc, UDS_STATUS_OK, "lookup must return OK");
+    zassert_is_null(entry, "SID 0x99 must still be absent from the default table");
+
+    rc = uds_access_table_enforce(entry, NULL);
+    zassert_equal(rc, UDS_STATUS_OK,
+        "SID 0x99 (no ACL entry) must be ALLOWED with the permissive opt-in active");
+}
+
+/* =========================================================================
+ * TC-ACLP-004: end-to-end through uds_server_process_request().
+ * ========================================================================= */
+
+static uds_status_t stub_handler_ok(uds_server_ctx_t *ctx,
+                                     const uds_msg_buf_t *req,
+                                     uds_msg_buf_t *resp)
+{
+    (void)ctx; (void)req;
+    resp->data[0] = 0xD9U; /* 0x99 + 0x40 positive-response offset */
+    resp->data[1] = 0x00U;
+    resp->length  = 2U;
+    return UDS_STATUS_OK;
+}
+
+/* Artificial SID 0x99 — registered as a service, but deliberately given NO
+ * row in g_acl_table below, mirroring exactly the #113 scenario: a service
+ * handler exists with no corresponding ACL entry. */
+static const uds_service_entry_t g_svc_table[] = {
+    { 0x99U, stub_handler_ok, false },
+};
+#define SVC_TABLE_COUNT (1U)
+
+/* Empty ACL table: zero entries, so SID 0x99 can never match a row. With
+ * the opt-in active this must still permit dispatch (see file header). */
+static const uds_access_entry_t g_acl_table[1] = {{ 0 }};
+#define ACL_TABLE_COUNT (0U) /* count=0 -> lookup() always returns NULL */
+
+static uds_session_ctx_t  g_sess;
+static uds_security_ctx_t g_sec;
+static uds_server_ctx_t   g_srv;
+
+static uds_msg_buf_t make_req(uint8_t sid)
+{
+    uds_msg_buf_t req;
+    (void)memset(&req, 0, sizeof(req));
+    req.data[0] = sid;
+    req.length  = 1U;
+    return req;
+}
+
+ZTEST(test_uds_acl_permissive_opt_in, tc004_end_to_end_dispatch_allowed)
+{
+    (void)memset(&g_sess, 0, sizeof(g_sess));
+    (void)memset(&g_sec,  0, sizeof(g_sec));
+    (void)memset(&g_srv,  0, sizeof(g_srv));
+    uds_session_init(&g_sess, 5000U);
+
+    static const uds_security_cfg_t sec_cfg = {
+        .max_attempts = 3U,
+        .lockout_ms   = 100U,
+    };
+    uds_security_init(&g_sec, &sec_cfg);
+
+    const uds_server_cfg_t cfg = {
+        .p2_server_max_ms      = 25U,
+        .p2_star_server_max_ms = 5000U,
+        .session_ctx           = &g_sess,
+        .security_ctx          = &g_sec,
+        .service_table         = g_svc_table,
+        .service_table_count   = (uint8_t)SVC_TABLE_COUNT,
+        .access_table           = g_acl_table,
+        .access_table_count     = (uint8_t)ACL_TABLE_COUNT,
+    };
+    zassert_equal(uds_server_init(&g_srv, &cfg), UDS_STATUS_OK, "init failed");
+
+    uds_msg_buf_t req  = make_req(0x99U);
+    uds_msg_buf_t resp = {0};
+    uds_status_t rc = uds_server_process_request(&g_srv, &req, &resp);
+
+    zassert_equal(rc, UDS_STATUS_OK, "process_request must return OK");
+    zassert_equal(resp.data[0], 0xD9U,
+        "SID 0x99 (no ACL row) must reach stub_handler_ok with the "
+        "permissive opt-in active -- a negative response (0x7F) here would "
+        "mean the opt-in did not actually restore dispatch");
+    zassert_equal(resp.length, 2U, "response length mismatch");
+}
+
+/* run_all_tests shim */
+extern void test_uds_acl_permissive_opt_in__tc001_opt_in_macro_is_active(void);
+extern void test_uds_acl_permissive_opt_in__tc002_enforce_null_entry_allowed(void);
+extern void test_uds_acl_permissive_opt_in__tc003_fake_sid_0x99_allowed_default(void);
+extern void test_uds_acl_permissive_opt_in__tc004_end_to_end_dispatch_allowed(void);
+
+void run_all_tests(void)
+{
+    RUN_TEST(test_uds_acl_permissive_opt_in__tc001_opt_in_macro_is_active);
+    RUN_TEST(test_uds_acl_permissive_opt_in__tc002_enforce_null_entry_allowed);
+    RUN_TEST(test_uds_acl_permissive_opt_in__tc003_fake_sid_0x99_allowed_default);
+    RUN_TEST(test_uds_acl_permissive_opt_in__tc004_end_to_end_dispatch_allowed);
+}

--- a/tests/unit_runnable/test_uds_server.c
+++ b/tests/unit_runnable/test_uds_server.c
@@ -38,6 +38,7 @@
 #include "uds_session.h"
 #include "uds_security.h"
 #include "uds_types.h"
+#include "uds_access_table.h"
 
 /* =========================================================================
  * Shared stubs for session / security / service table
@@ -90,6 +91,26 @@ static const uds_service_entry_t g_test_service_table[] = {
 };
 #define TEST_SVC_TABLE_COUNT  (2U)
 
+/*
+ * [#113] ACL rows for this file's test services.
+ *
+ * Prior to #113, srv_check_access_rights() fell back to the built-in
+ * production default table (cfg.access_table left NULL) and silently
+ * PERMITTED SID 0xFF — an artificial test-only SID with no row of its own
+ * in that table — because a missing ACL row meant "no restriction". Under
+ * the #113 fail-closed default, a service_id absent from the active table
+ * is now DENIED, so this test suite must supply its own explicit table
+ * covering both test SIDs rather than relying on the production default
+ * table's (unrelated) coverage. All-sessions / no-security matches this
+ * suite's pre-#113 effective behaviour exactly — these tests exist to
+ * exercise dispatch and handler-error-to-NRC translation, not ACL policy.
+ */
+static const uds_access_entry_t g_test_access_table[] = {
+    { 0x3EU, UDS_ACL_SESSION_ALL, 0U, false },
+    { 0xFFU, UDS_ACL_SESSION_ALL, 0U, false },
+};
+#define TEST_ACL_TABLE_COUNT  (2U)
+
 /* =========================================================================
  * Helpers
  * ========================================================================= */
@@ -124,6 +145,9 @@ static uds_status_t srv_init_with_table(void)
         .security_ctx          = &g_sec,
         .service_table         = g_test_service_table,
         .service_table_count   = (uint8_t)TEST_SVC_TABLE_COUNT,
+        /* [#113] explicit ACL rows for both test SIDs — see g_test_access_table. */
+        .access_table          = g_test_access_table,
+        .access_table_count    = (uint8_t)TEST_ACL_TABLE_COUNT,
     };
     return uds_server_init(&g_srv, &cfg);
 }


### PR DESCRIPTION
Closes #113

## ⚠️ BEHAVIOR CHANGE — read before merging

**This is a breaking behavior change for any existing deployment that relies
on today's permissive default for services with no explicit ACL row.**
Before this PR, a `service_id` absent from the active access table (the
built-in default table, or an OEM-supplied custom table via
`uds_server_cfg_t.access_table`) was silently **PERMITTED** — reachable in
every session, with no security check, purely because no one wrote an ACL
row for it. After this PR, the default flips to **DENY** (fail-closed).

**Exactly which SIDs are affected:**

- **The built-in default table (this repo's own `uds_access_table.c`):
  NONE of its shipped services change behaviour.** I audited every SID
  registered in `core/uds_services/service_registration.c` (19 total)
  against the default ACL table (18 rows) and found exactly **one gap: SID
  `0x31` RoutineControl** — registered as a service, but with no ACL row at
  all. This PR adds an explicit row for it (`session_mask = ALL`,
  `require_unlocked = false`) so its behaviour is unchanged — real
  per-routine session/security gating already happens inside
  `service_0x31.c` against `routine_database.c`'s per-RID
  `min_session`/`security_level`, independent of this table. Verified this
  claim two ways: (1) `bash build_harness.sh --run` — Group M (`0x31`,
  9 cases, including session-gate and security-gate NRCs) is still 100%
  green after the fix; (2) a new unit test, `TC-ACL-030`, asserts `0x31` is
  still reachable at the ACL layer in all three sessions.
- **Behavior for any FUTURE unlisted SID changes by design** — that is the
  point of #113: a new SID added to `service_registration.c` without a
  matching ACL row is now blocked pending an explicit policy decision,
  instead of silently wide open.
- **Any OEM-supplied custom `access_table`** (passed via
  `uds_server_cfg_t.access_table`) that does not cover every `service_id`
  it registers will see those uncovered services flip from allowed to
  denied. **If you maintain a custom access table outside this repo, audit
  its SID coverage against your service table before upgrading.**

**What an integrator must do to keep the old (permissive) behaviour:**
Set the new compile-time opt-in `UDS_ACL_ALLOW_UNLISTED_SERVICES=1`
(Zephyr: `CONFIG_UDS_ACL_ALLOW_UNLISTED_SERVICES=y` in `prj.conf`;
FreeRTOS/bare-metal: `-DUDS_ACL_ALLOW_UNLISTED_SERVICES=1`). This restores
the exact pre-#113 behaviour for **every** unlisted service in the
deployment — it is a global, deployment-wide switch, not per-SID. To allow
just one specific service with no ACL-layer restriction instead, add an
explicit row for that `service_id` (see the new `0x31` row in
`uds_access_table.c` for a worked example) and leave the switch at its
secure default.

**Requesting a founder sanity-check on this before merge**, per the task
brief — this is exactly the kind of change that should not land as a silent
bugfix.

## Root cause

`core/uds_access_table.c:357,368` (`uds_access_table_lookup()` /
`uds_access_table_enforce()`) explicitly treated a missing ACL entry as "no
restriction" — the wrong default for security-relevant middleware.

Tracing the real production dispatch path turned up a second, independent
copy of the same bug: `core/uds_server.c`'s `srv_check_access_rights()`
does its own `if (acl_entry == NULL) { return UDS_STATUS_OK; }`
short-circuit **before** it ever calls `uds_access_table_enforce()`. So
fixing `uds_access_table_enforce()` alone would not have changed real
server behaviour at all — every actual request that reaches the dispatcher
would still have been silently permitted regardless of what `enforce()`
decided. Both places had to change together.

## Fix

1. **New compile-time opt-in**, `UDS_ACL_ALLOW_UNLISTED_SERVICES`
   (`core/uds_access_table.h`), default `0`. Kept as a plain,
   non-`CONFIG_`-prefixed macro — same convention as `ISOTP_TX_PADDING` in
   `transport/isotp.h` — with a matching Kconfig symbol
   (`CONFIG_UDS_ACL_ALLOW_UNLISTED_SERVICES`, default `n`, documented with
   the same warning-banner style as the existing
   `DIAG_PLACEHOLDER_KEYS_ONLY` security switch).
2. **`uds_access_table_enforce()`** (`core/uds_access_table.c`): the
   `entry == NULL` branch is now gated by that macro — `UDS_STATUS_OK` only
   when the opt-in is set; otherwise
   `UDS_STATUS_ERR_SERVICE_NOT_SUPPORTED_IN_SESSION` (maps to NRC 0x7F,
   which is what this file's own pre-existing comment already said a
   missing rule *should* produce). `uds_access_table_lookup()`'s own
   contract is unchanged — it still returns `*out_entry == NULL` for "not
   in table" so callers can distinguish that from "in table, wrong
   session"; the allow/deny **decision** for the NULL case now lives in
   exactly one place, `enforce()`.
3. **`srv_check_access_rights()`** (`core/uds_server.c`): removed the
   inline short-circuit; the session-mask check now only runs when there
   *is* a matching entry, and the function always falls through to
   `uds_access_table_enforce()` — including with `acl_entry == NULL` — so
   the dispatcher and `uds_access_table_enforce()` can never disagree
   again.
4. **Added the missing `0x31` RoutineControl ACL row** (see BEHAVIOR
   CHANGE section above).
5. Updated the stale "no matching entry is ALLOWED" documentation in
   `uds_access_table.h`'s file-header comment and `uds_server.c`'s flow
   comment, which described the old (buggy) behaviour as intentional design.

## Regression tests

- `tests/unit_runnable/test_phase5_access_table.c`:
  - `TC-ACL-022` (existing, retargeted): `enforce(NULL, ...)` now asserts
    the fail-closed deny status instead of the old `OK`.
  - `TC-ACL-026`/`027`/`028` (new): fake SID `0x99` (no ACL entry) denied
    end-to-end (`lookup()` + `enforce()`) in DEFAULT / EXTENDED /
    PROGRAMMING sessions — the exact scenario from the issue body.
  - `TC-ACL-029` (new): denial maps specifically to
    `UDS_STATUS_ERR_SERVICE_NOT_SUPPORTED_IN_SESSION` (NRC 0x7F), not just
    "any non-OK".
  - `TC-ACL-030` (new): `0x31` still reachable at the ACL layer in all
    sessions post-fix (proves the flip didn't silently break it).
  - `TC-ACL-002`: default table count `18 -> 19`.
- `tests/unit_runnable/test_uds_acl_permissive_opt_in.c` (**new test
  module**, compiled with `-DUDS_ACL_ALLOW_UNLISTED_SERVICES=1`, mirroring
  the existing `test_trng_fail_closed.c` per-target-flag pattern): proves
  the opt-in restores the *exact* old behaviour, including one end-to-end
  test through real `uds_server_process_request()` dispatch (a registered
  handler with no ACL row is actually invoked, not just that the library
  function returns `OK` in isolation).
- `tests/unit_runnable/test_uds_server.c`: one pre-existing test
  (`test_handler_error_returns_nrc_22`) relied — without realizing it — on
  the exact bug this PR fixes: its artificial test-only SID `0xFF` had no
  row in the production default ACL table it was implicitly falling back
  to, so it depended on fail-open just to reach the handler stub. Gave the
  suite its own explicit two-row ACL table (`0x3E`, `0xFF`, both
  all-sessions/no-security — identical to prior effective behaviour) so it
  no longer depends on ACL fail-open, and its actual purpose (handler-error
  → NRC translation) is decoupled from ACL policy.

### Before/after proof

Per the task workflow, reverted **only** the three source files
(`core/uds_access_table.h`, `core/uds_access_table.c`, `core/uds_server.c`)
to their `origin/main` content, keeping every test change, and rebuilt:

```
Before (source reverted): 43 passed, 1 failed
  [FAIL] test_phase5_access_table__tc002_default_table_count
  [FAIL] test_phase5_access_table__tc022_enforce_null_entry_fail_closed_by_default
  [FAIL] test_phase5_access_table__tc026_fake_sid_0x99_denied_default
  [FAIL] test_phase5_access_table__tc027_fake_sid_0x99_denied_extended
  [FAIL] test_phase5_access_table__tc028_fake_sid_0x99_denied_programming
  [FAIL] test_phase5_access_table__tc029_fake_sid_0x99_denial_status
```

Restored the fix and rebuilt:

```
After (fix restored): 44 passed, 0 failed
```

(`TC-ACL-030` correctly still passed pre-fix too — the old fail-open
default trivially allowed `0x31` as well, so its "still reachable"
assertion isn't a regression indicator by itself; it exists to catch a
*future* accidental restriction, not this bug.)

## Gates (this checkout, host build; harness = commercial `EDS-toolchain`
checkout linked via the gitignored `harness/` symlink)

- `bash build_tests.sh` → **44 passed, 0 failed** (baseline was 43/0; +1 for
  the new `test_uds_acl_permissive_opt_in` module).
- `bash build_harness.sh --run` → **68/68 PASS** (unchanged from baseline —
  includes Group M's 9 RoutineControl cases, confirming `0x31`'s
  behaviour is byte-for-byte unchanged).
- `python3 misra_analysis.py --out misra.json` → **41 files, 1 finding, 0
  OPEN violations, 1 justified → PASS** (unchanged from baseline). GCC-only
  locally (`cppcheck` not installed in this sandbox) — CI runs the
  `--strict` + cppcheck pass.
- No-malloc grep gate (CI mirror): clean, no output.
- `git status`: clean apart from the intended file list.

## Heightened review (CONTRIBUTING.md "Safety-relevant changes")

`core/uds_access_table.c` is security-relevant middleware and falls under
CONTRIBUTING.md's heightened-review spirit even though it isn't on the
file's explicit list; `core/uds_server.c`'s dispatcher is the actual
enforcement call site and got equal scrutiny for the same reason. Did an
explicit self-review pass over the full diff before opening this PR:
checked MISRA style consistency (explicit `U` suffixes / casts / `uds_status_t`
returns match surrounding code), confirmed the `#if UDS_ACL_ALLOW_UNLISTED_SERVICES`
gate follows the exact `ISOTP_TX_PADDING` precedent, confirmed
`session_bit` is never read outside the block where it's now conditionally
assigned (no uninitialized-use risk — corroborated by zero new GCC/MISRA
warnings), and re-verified the SID audit against `service_registration.c`
programmatically (`comm -23` diff of registered vs. ACL-covered SIDs), not
by eyeballing.

Reviewed-by: Xaloqi <contact@xaloqi.com>

## New findings

None found outside the scope of #113 itself — the second fail-open site in
`uds_server.c` is part of this bug (the actual production reachability
path), not a separate defect, so it's fixed here rather than logged to
`FINDINGS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
