### PR TITLE
fix: add integrity header + CRC-32 to the DTC NVM mirror (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,32 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **DTC NVM mirror: no integrity check — a truncated/corrupted record
+  degraded to silent partial success.** (#114) `config/dtc_mirror.c`'s
+  on-disk format was just a 2-byte entry count followed by fixed-size
+  entries — no magic number, version, or CRC. On load, a truncated entry
+  mid-loop simply `break`d out of the parse loop and the function still
+  returned `UDS_STATUS_OK`, so a corrupted record was indistinguishable
+  from a legitimately short one and whatever entries had been parsed so
+  far were silently applied. The on-disk format is now
+  `[magic:2][version:1][count:2][entries...][crc32:4]`, reusing the
+  existing transfer-service CRC-32 engine
+  (`uds_transfer_crc32_update`/`_finalise` in `core/uds_transfer_ctx.c`,
+  already a global include for `config/` per the declared build-layer
+  order). `dtc_mirror_load()` now validates magic, version, declared
+  length, and CRC-32 *before* applying any entry, so a corrupt record can
+  never partially apply — it is now reported distinctly via the new
+  `UDS_STATUS_ERR_NVM_DATA_CORRUPT` status instead. A record that is too
+  short or does not carry the new magic (including a legacy pre-fix
+  record with the old headerless format) is deliberately treated as "no
+  mirror yet" and discarded — a documented, one-time migration trade-off
+  on first boot after upgrading to this fix. `dtc_mirror_flush_all()` and
+  `dtc_mirror_clear_all()` now share one writer for the new format. New
+  regression tests in `tests/unit_runnable/test_dtc_mirror.c` cover a
+  valid round-trip, a CRC-mismatched entry, a truncated record, a legacy
+  (no-magic) record, and an unsupported version — all reported as the
+  correct one of the three distinct cases (no-mirror / valid / corrupt).
+
 - **ISO-TP: the N_As timer was armed once at First Frame and never rearmed or
   stopped, aborting any multi-frame TX that took longer than 25 ms.** (#111)
   `tx_as_timer_ms` was set to `ISOTP_TIMEOUT_AS_MS` (25 ms) when the FF went

--- a/config/dtc_mirror.c
+++ b/config/dtc_mirror.c
@@ -16,6 +16,16 @@
 #include "dtc_database.h"
 #include "nvm_store.h"
 #include "uds_types.h"
+#include "uds_transfer_ctx.h" /* uds_transfer_crc32_update/finalise — shared CRC-32
+                                * engine also used by the transfer/flashing path
+                                * (core/uds_transfer_ctx.c). Reused here rather than
+                                * reimplemented: config/ is downstream of core/ in the
+                                * declared build-layer order (see CMakeLists.txt —
+                                * "application -> core -> transport -> config ->
+                                * platform"), core/ is already a global include dir
+                                * for the app target, and core/ has no dependency back
+                                * on config/, so this does not create a layering
+                                * inversion. */
 
 #include <string.h>
 #include <stdint.h>
@@ -30,60 +40,57 @@ static bool s_initialized = false;
 static uint8_t s_mirror_buf[DTC_MIRROR_MAX_BYTES];
 
 /* --------------------------------------------------------------------------
+ * Internal CRC helper
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @brief Compute the CRC-32 used to protect a serialized mirror record.
+ *
+ * Thin wrapper around the shared transfer-service CRC-32 engine, using the
+ * same init/finalise convention as its other callers (the flash_ops drivers
+ * under platform/zephyr and platform/freertos).
+ */
+static uint32_t mirror_crc32(const uint8_t *data, size_t len)
+{
+    uint32_t crc = uds_transfer_crc32_update((uint32_t)0xFFFFFFFFUL, data, (uint32_t)len);
+
+    return uds_transfer_crc32_finalise(crc);
+}
+
+/* --------------------------------------------------------------------------
  * Internal serialization helpers
  * -------------------------------------------------------------------------- */
 
 /**
- * @brief Serialize the live DTC table into s_mirror_buf.
+ * @brief Serialize the live DTC table into s_mirror_buf, with the new v1
+ *        integrity header (magic + version + count) and CRC-32 trailer.
  *
- * Format: [count_hi][count_lo][code_b2][code_b1][code_b0][status] × n
+ * Format: [magic:2][version:1][count:2][code_b2][code_b1][code_b0][status] × n [crc32:4]
  *
- * @param[out] out_len  Number of bytes written into s_mirror_buf.
+ * @param[in]  force_status_zero  If true, every entry is written with a
+ *                                 status byte of 0x00 regardless of the live
+ *                                 database value (used by dtc_mirror_clear_all()).
+ * @param[out] out_len            Number of bytes written into s_mirror_buf.
  */
-static uds_status_t mirror_serialize(size_t *out_len)
+static uds_status_t mirror_serialize_internal(bool force_status_zero, size_t *out_len)
 {
-    uint16_t count;
     size_t   pos;
-    uds_status_t rc;
+    uint16_t count;
+    uint32_t crc;
 
-    /* Count registered DTCs. */
-    rc = dtc_database_count_by_status(0xFFU, &count);
-    if (rc != UDS_STATUS_OK) {
-        /* 0xFF mask counts any non-zero status. For total count use a separate
-         * approach: iterate up to UDS_MAX_DTC_COUNT with find-by-index.
-         * Workaround: issue a count against an always-true mask — but
-         * dtc_database_count_by_status only counts non-zero. Use 0x00 is wrong.
-         * Best approach: expose dtc_database_get_count() — add it inline here. */
-        count = 0U;
-    }
-
-    /*
-     * Since dtc_database_count_by_status(0xFF) only counts non-zero status bytes,
-     * we take a different approach: serialize ALL registered DTC entries regardless
-     * of status, using a linear scan via dtc_database_find() which we cannot use
-     * without knowing all codes. We need dtc_database_iterate().
-     *
-     * Since dtc_database doesn't expose an iterator in Phase 2, we use
-     * dtc_database_get_all() added below, or serialize by code range scan.
-     *
-     * Clean solution: add dtc_database_get_all() accessor.
-     */
-    (void)rc;
-    (void)count;
-
-    /*
-     * Serialize by querying each entry via the internal table accessor.
-     * We call dtc_database_iterate_all() defined below.
-     */
     pos = (size_t)0U;
 
-    /* Reserve 2 bytes for count — filled in at end. */
+    s_mirror_buf[pos++] = DTC_MIRROR_MAGIC_0;
+    s_mirror_buf[pos++] = DTC_MIRROR_MAGIC_1;
+    s_mirror_buf[pos++] = DTC_MIRROR_FORMAT_VERSION;
+
+    /* Reserve 2 bytes for count — filled in after the entry loop. */
     s_mirror_buf[pos++] = (uint8_t)0U;
     s_mirror_buf[pos++] = (uint8_t)0U;
 
     count = (uint16_t)0U;
 
-    /* Iterate using the export accessor we'll add to dtc_database. */
+    /* Iterate using the dtc_database export accessor. */
     {
         uint16_t max_dtcs = (uint16_t)UDS_MAX_DTC_COUNT;
         uint16_t idx;
@@ -91,6 +98,7 @@ static uds_status_t mirror_serialize(size_t *out_len)
         for (idx = (uint16_t)0U; idx < max_dtcs; idx++) {
             uint32_t dtc_code;
             uint8_t  status_byte;
+            uds_status_t rc;
 
             rc = dtc_database_get_by_index(idx, &dtc_code, &status_byte);
             if (rc == UDS_STATUS_ERR_DID_NOT_FOUND) {
@@ -100,7 +108,9 @@ static uds_status_t mirror_serialize(size_t *out_len)
                 continue;
             }
 
-            if ((pos + (size_t)DTC_MIRROR_ENTRY_BYTES) > (size_t)DTC_MIRROR_MAX_BYTES) {
+            /* Leave room for this entry AND the trailing CRC. */
+            if ((pos + (size_t)DTC_MIRROR_ENTRY_BYTES + (size_t)DTC_MIRROR_CRC_BYTES)
+                > (size_t)DTC_MIRROR_MAX_BYTES) {
                 break; /* Buffer full — should never happen with correct sizing */
             }
 
@@ -108,17 +118,36 @@ static uds_status_t mirror_serialize(size_t *out_len)
             s_mirror_buf[pos++] = (uint8_t)((dtc_code >> 16U) & 0xFFU);
             s_mirror_buf[pos++] = (uint8_t)((dtc_code >>  8U) & 0xFFU);
             s_mirror_buf[pos++] = (uint8_t)((dtc_code       ) & 0xFFU);
-            s_mirror_buf[pos++] = status_byte;
+            s_mirror_buf[pos++] = force_status_zero ? (uint8_t)0x00U : status_byte;
             count++;
         }
     }
 
     /* Back-fill count in header. */
-    s_mirror_buf[0] = (uint8_t)((count >> 8U) & 0xFFU);
-    s_mirror_buf[1] = (uint8_t)( count         & 0xFFU);
+    s_mirror_buf[3] = (uint8_t)((count >> 8U) & 0xFFU);
+    s_mirror_buf[4] = (uint8_t)( count         & 0xFFU);
+
+    /* CRC-32 over [version..last entry byte], i.e. everything written so
+     * far except the 2 magic bytes. */
+    crc = mirror_crc32(&s_mirror_buf[2], pos - (size_t)2U);
+
+    s_mirror_buf[pos++] = (uint8_t)((crc >> 24U) & 0xFFU);
+    s_mirror_buf[pos++] = (uint8_t)((crc >> 16U) & 0xFFU);
+    s_mirror_buf[pos++] = (uint8_t)((crc >>  8U) & 0xFFU);
+    s_mirror_buf[pos++] = (uint8_t)( crc         & 0xFFU);
 
     *out_len = pos;
     return UDS_STATUS_OK;
+}
+
+/**
+ * @brief Serialize the live DTC table into s_mirror_buf (status bytes as-is).
+ *
+ * @param[out] out_len  Number of bytes written into s_mirror_buf.
+ */
+static uds_status_t mirror_serialize(size_t *out_len)
+{
+    return mirror_serialize_internal(false, out_len);
 }
 
 /* --------------------------------------------------------------------------
@@ -141,8 +170,12 @@ uds_status_t dtc_mirror_load(void)
     uint8_t  buf[DTC_MIRROR_MAX_BYTES];
     size_t   bytes_read;
     uint16_t count;
+    size_t   entries_bytes;
+    size_t   expected_total;
     size_t   pos;
     uint16_t i;
+    uint32_t crc_computed;
+    uint32_t crc_stored;
     uds_status_t rc;
 
     if (!s_initialized) {
@@ -162,23 +195,74 @@ uds_status_t dtc_mirror_load(void)
         return UDS_STATUS_ERR_PLATFORM;
     }
 
+    /*
+     * MIGRATION (issue #114, deliberate decision — see dtc_mirror.h): a
+     * record too short to hold a v1 header, or whose leading bytes do not
+     * match the v1 magic, is treated as "no valid v1 mirror present" and
+     * discarded exactly like the first-boot case above (OK, nothing
+     * applied). This bucket also covers a legacy pre-header record written
+     * by firmware built before this fix — it cannot be safely told apart
+     * from unrelated short/garbage data by shape alone, so it is not
+     * specially parsed. Losing legacy DTC history once, on first boot
+     * after upgrading to this fix, is an accepted, documented trade-off.
+     * A record that DOES carry the v1 magic is fully validated below —
+     * any failure from here on is reported distinctly as
+     * UDS_STATUS_ERR_NVM_DATA_CORRUPT rather than folded into this bucket.
+     */
     if (bytes_read < (size_t)DTC_MIRROR_HEADER_BYTES) {
-        return UDS_STATUS_ERR_PLATFORM; /* Truncated header */
+        return UDS_STATUS_OK;
+    }
+    if ((buf[0] != DTC_MIRROR_MAGIC_0) || (buf[1] != DTC_MIRROR_MAGIC_1)) {
+        return UDS_STATUS_OK;
     }
 
-    /* Decode count from header. */
-    count  = (uint16_t)((uint16_t)buf[0] << 8U);
-    count |= (uint16_t)  buf[1];
+    if (buf[2] != DTC_MIRROR_FORMAT_VERSION) {
+        /* Known magic, unsupported/foreign version — cannot safely
+         * reinterpret the layout. Distinct corrupt condition. */
+        return UDS_STATUS_ERR_NVM_DATA_CORRUPT;
+    }
 
+    count  = (uint16_t)((uint16_t)buf[3] << 8U);
+    count |= (uint16_t)  buf[4];
+
+    if (count > (uint16_t)UDS_MAX_DTC_COUNT) {
+        /* Declared count exceeds the largest table this build could ever
+         * have written — cannot be a genuine record from this format. */
+        return UDS_STATUS_ERR_NVM_DATA_CORRUPT;
+    }
+
+    entries_bytes  = (size_t)count * (size_t)DTC_MIRROR_ENTRY_BYTES;
+    expected_total = (size_t)DTC_MIRROR_HEADER_BYTES + entries_bytes
+                    + (size_t)DTC_MIRROR_CRC_BYTES;
+
+    if (bytes_read != expected_total) {
+        /* Truncated (or overlong) relative to what the header declares. */
+        return UDS_STATUS_ERR_NVM_DATA_CORRUPT;
+    }
+
+    /*
+     * Validate the CRC-32 over the whole record (version+count+entries)
+     * BEFORE applying anything. This is what makes a corrupt record
+     * all-or-nothing instead of the original partial-apply bug: no
+     * dtc_database_set_status() call happens until every check above and
+     * this CRC check have passed.
+     */
+    crc_computed = mirror_crc32(&buf[2], (size_t)3U + entries_bytes);
+    crc_stored   = ((uint32_t)buf[expected_total - 4U] << 24U)
+                 | ((uint32_t)buf[expected_total - 3U] << 16U)
+                 | ((uint32_t)buf[expected_total - 2U] <<  8U)
+                 | ((uint32_t)buf[expected_total - 1U]       );
+
+    if (crc_computed != crc_stored) {
+        return UDS_STATUS_ERR_NVM_DATA_CORRUPT;
+    }
+
+    /* Record fully validated — apply every entry. */
     pos = (size_t)DTC_MIRROR_HEADER_BYTES;
 
     for (i = (uint16_t)0U; i < count; i++) {
         uint32_t dtc_code;
         uint8_t  status_byte;
-
-        if ((pos + (size_t)DTC_MIRROR_ENTRY_BYTES) > bytes_read) {
-            break; /* Truncated entry */
-        }
 
         dtc_code   = ((uint32_t)buf[pos + 0U] << 16U)
                    | ((uint32_t)buf[pos + 1U] <<  8U)
@@ -235,9 +319,7 @@ uds_status_t dtc_mirror_save_one(uint32_t dtc_code, uint8_t status_byte)
 
 uds_status_t dtc_mirror_clear_all(void)
 {
-    size_t   pos;
-    uint16_t i;
-    uint16_t count;
+    size_t       serial_len;
     uds_status_t rc;
 
     if (!s_initialized) {
@@ -248,34 +330,15 @@ uds_status_t dtc_mirror_clear_all(void)
         return UDS_STATUS_ERR_NOT_INITIALIZED;
     }
 
-    /* Serialize with all status bytes set to 0x00. */
-    pos   = (size_t)0U;
-    count = (uint16_t)0U;
-
-    s_mirror_buf[pos++] = 0U; /* count placeholder */
-    s_mirror_buf[pos++] = 0U;
-
-    for (i = (uint16_t)0U; i < (uint16_t)UDS_MAX_DTC_COUNT; i++) {
-        uint32_t dtc_code;
-        uint8_t  status_unused;
-
-        rc = dtc_database_get_by_index(i, &dtc_code, &status_unused);
-        if (rc == UDS_STATUS_ERR_DID_NOT_FOUND) { break; }
-        if (rc != UDS_STATUS_OK) { continue; }
-
-        if ((pos + (size_t)DTC_MIRROR_ENTRY_BYTES) > (size_t)DTC_MIRROR_MAX_BYTES) { break; }
-
-        s_mirror_buf[pos++] = (uint8_t)((dtc_code >> 16U) & 0xFFU);
-        s_mirror_buf[pos++] = (uint8_t)((dtc_code >>  8U) & 0xFFU);
-        s_mirror_buf[pos++] = (uint8_t)((dtc_code       ) & 0xFFU);
-        s_mirror_buf[pos++] = (uint8_t)0x00U; /* cleared status */
-        count++;
+    /* Serialize with all status bytes forced to 0x00 (same v1 header/CRC
+     * writer as dtc_mirror_flush_all() — one code path for the on-disk
+     * format keeps the two writers from ever diverging). */
+    rc = mirror_serialize_internal(true, &serial_len);
+    if (rc != UDS_STATUS_OK) {
+        return rc;
     }
 
-    s_mirror_buf[0] = (uint8_t)((count >> 8U) & 0xFFU);
-    s_mirror_buf[1] = (uint8_t)( count         & 0xFFU);
-
-    return nvm_store_write((uint16_t)NVM_KEY_DTC_MIRROR, s_mirror_buf, pos);
+    return nvm_store_write((uint16_t)NVM_KEY_DTC_MIRROR, s_mirror_buf, serial_len);
 }
 
 bool dtc_mirror_is_ready(void)

--- a/config/dtc_mirror.h
+++ b/config/dtc_mirror.h
@@ -23,10 +23,27 @@
  *            - dtc_mirror_save()        → called from dtc_database_set_status()
  *            - dtc_mirror_flush_all()   → called from zephyr_port_nvm_flush()
  *
- * WIRE FORMAT (NVM_KEY_DTC_MIRROR):
- *   [count:2][entry_0:4][entry_1:4]...[entry_n:4]
+ * WIRE FORMAT (NVM_KEY_DTC_MIRROR) — v1, integrity-checked (issue #114):
+ *   [magic:2][version:1][count:2][entry_0:4]...[entry_n:4][crc32:4]
  *   Each entry: [dtc_code:3 big-endian][status_byte:1]
- *   Maximum payload: 2 + 128 × 4 = 514 bytes.
+ *   magic   = 0x44,0x4D ("DM"). Identifies a v1-or-later record.
+ *   version = DTC_MIRROR_FORMAT_VERSION. Bump on any layout change.
+ *   count   = number of entries, big-endian.
+ *   crc32   = CRC-32 (same polynomial/algorithm as the transfer-service
+ *             helper in core/uds_transfer_ctx.c) computed over
+ *             [version..last entry byte] (i.e. everything except the
+ *             magic and the CRC field itself), big-endian.
+ *   Maximum payload: 5 + 128 × 4 + 4 = 521 bytes.
+ *
+ * INTEGRITY (issue #114 fix):
+ *   Before this fix, the mirror was [count:2][entries...] with no way to
+ *   tell a truncated/corrupted record from a legitimately short one — a
+ *   short read mid-loop silently applied only the entries it had parsed
+ *   and still returned UDS_STATUS_OK. dtc_mirror_load() now validates the
+ *   whole record (magic, version, declared length, CRC-32) BEFORE applying
+ *   any entry to the live database, so a corrupt record can never partially
+ *   apply. See dtc_mirror_load() below for the exact case breakdown and the
+ *   deliberate legacy-record migration decision.
  *
  * SAFETY  : ASIL-B candidate. Confirmed DTC bits are safety-relevant.
  * STANDARD: MISRA C:2012 alignment intended.
@@ -48,15 +65,29 @@ extern "C" {
  * Wire format constants
  * -------------------------------------------------------------------------- */
 
-/** Header: 2-byte entry count. */
-#define DTC_MIRROR_HEADER_BYTES  (2U)
+/** Magic bytes identifying a v1-or-later (integrity-checked) mirror record.
+ *  Chosen so a legacy pre-header record's leading count field can never
+ *  collide with it: a legacy count is bounded by UDS_MAX_DTC_COUNT (128),
+ *  so its high byte is always 0x00, whereas DTC_MIRROR_MAGIC_0 is not. */
+#define DTC_MIRROR_MAGIC_0       ((uint8_t)0x44U) /* 'D' */
+#define DTC_MIRROR_MAGIC_1       ((uint8_t)0x4DU) /* 'M' */
+
+/** Wire format version of the header below. Bump on any layout change. */
+#define DTC_MIRROR_FORMAT_VERSION ((uint8_t)1U)
+
+/** Fixed-position header fields: magic(2) + version(1) + count(2). */
+#define DTC_MIRROR_HEADER_BYTES  (5U)
 
 /** Per-entry size: 3-byte DTC code + 1-byte status. */
 #define DTC_MIRROR_ENTRY_BYTES   (4U)
 
-/** Maximum mirror payload: header + max_entries × entry_size. */
+/** CRC-32 trailer appended after the last entry. */
+#define DTC_MIRROR_CRC_BYTES     (4U)
+
+/** Maximum mirror payload: header + max_entries × entry_size + CRC trailer. */
 #define DTC_MIRROR_MAX_BYTES     ((uint16_t)(DTC_MIRROR_HEADER_BYTES + \
-                                  (UDS_MAX_DTC_COUNT * DTC_MIRROR_ENTRY_BYTES)))
+                                  (UDS_MAX_DTC_COUNT * DTC_MIRROR_ENTRY_BYTES) + \
+                                  DTC_MIRROR_CRC_BYTES))
 
 /* --------------------------------------------------------------------------
  * Public API
@@ -77,16 +108,48 @@ uds_status_t dtc_mirror_init(void);
 /**
  * @brief Load persisted DTC status bytes from NVM into the live database.
  *
- * Reads the NVM mirror and calls dtc_database_set_status() for each entry
- * found. Entries in the mirror for DTCs not registered in the database are
- * silently skipped (e.g. after a firmware update removes a DTC).
+ * Reads the NVM mirror, validates it as a whole (magic, version, declared
+ * length, CRC-32), and — only if every check passes — calls
+ * dtc_database_set_status() for each entry. Validation happens before any
+ * entry is applied, so a corrupt record can never partially apply (issue
+ * #114). Entries in a valid mirror for DTCs not registered in the current
+ * database are silently skipped (e.g. after a firmware update removes a
+ * DTC).
  *
  * Must be called after both nvm_store_init() and dtc_database_init()
  * (and after all DTCs have been registered via dtc_database_register()).
  *
- * @return UDS_STATUS_OK if mirror loaded (or no mirror found — first boot).
- * @return UDS_STATUS_ERR_NOT_INITIALIZED if dtc_mirror_init() not called.
+ * Three cases are distinguished:
+ *   1. No record present, OR a record that does not begin with the v1
+ *      magic (DTC_MIRROR_MAGIC_0/1) — returns OK, no entries applied.
+ *      DELIBERATE MIGRATION DECISION (issue #114): this bucket also
+ *      covers a legacy pre-header record written by firmware built before
+ *      this fix (format was [count:2][entries...], no magic). Such a
+ *      record cannot be safely told apart from unrelated short/garbage
+ *      data by shape alone, so it is not specially parsed — it is
+ *      discarded exactly like "no mirror yet". This is a one-time,
+ *      expected event on first boot after upgrading to this fix: the
+ *      device boots with DTC status at defaults instead of restoring
+ *      whatever the legacy record held. Everything logged/reported from
+ *      here on is therefore about NEW-format records only.
+ *   2. A record with valid magic, version, length and CRC — restored,
+ *      returns OK.
+ *   3. A record with valid magic but a version mismatch, a byte count
+ *      inconsistent with its declared entry count, or a CRC-32 mismatch —
+ *      returns UDS_STATUS_ERR_NVM_DATA_CORRUPT and applies nothing. This
+ *      is the case the original bug silently mishandled: a corrupted
+ *      NEW-format record is now reported as a distinct condition rather
+ *      than partially (and silently) applied.
+ *
+ * @return UDS_STATUS_OK if mirror loaded (or no/legacy mirror — case 1).
+ * @return UDS_STATUS_ERR_NOT_INITIALIZED if dtc_mirror_init() not called,
+ *         or NVM is not ready.
  * @return UDS_STATUS_ERR_PLATFORM if NVM read error.
+ * @return UDS_STATUS_ERR_NVM_DATA_CORRUPT if a v1-tagged record fails
+ *         validation (case 3 above). Note: callers written before this
+ *         fix that only treat OK/ERR_NOT_INITIALIZED/ERR_PLATFORM as
+ *         non-fatal will treat this new status as a hard error — see
+ *         issue #114 PR discussion.
  */
 uds_status_t dtc_mirror_load(void);
 

--- a/core/uds_types.h
+++ b/core/uds_types.h
@@ -160,6 +160,16 @@ typedef enum uds_status {
     UDS_STATUS_ERR_PLATFORM              = 0x60, /**< Platform-specific error. */
     UDS_STATUS_ERR_OS_RESOURCE           = 0x61, /**< OS resource allocation failed. */
 
+    /* --- NVM persistence integrity errors --- */
+    UDS_STATUS_ERR_NVM_DATA_CORRUPT      = 0x62U, /**< Persisted NVM record failed an
+                                                         integrity check (bad magic, bad
+                                                         version, bad CRC, or a byte count
+                                                         inconsistent with the declared
+                                                         entry count) — distinct from
+                                                         ERR_PLATFORM (I/O failure) and
+                                                         ERR_NOT_INITIALIZED (no record
+                                                         present / module not ready). */
+
     UDS_STATUS_MAX                                /**< Sentinel — do not use as return value. */
 } uds_status_t;
 

--- a/tests/unit_runnable/test_dtc_mirror.c
+++ b/tests/unit_runnable/test_dtc_mirror.c
@@ -55,6 +55,17 @@
  *                    the uds_generated_init() pattern (does not block init chain)
  *     TC-MIRROR-023  Status bytes survive: set → flush → power-cycle → load
  *
+ *   Integrity checking (issue #114 — DTC mirror header/CRC fix):
+ *     TC-MIRROR-024  Bit-flip in a flushed entry → load() reports
+ *                    ERR_NVM_DATA_CORRUPT and applies nothing (not partial)
+ *     TC-MIRROR-025  Record truncated below what its own header declares →
+ *                    load() reports ERR_NVM_DATA_CORRUPT (was the original
+ *                    bug: silently applied whatever fit and returned OK)
+ *     TC-MIRROR-026  Legacy pre-header record (no magic) → load() returns
+ *                    OK and discards it (deliberate migration decision)
+ *     TC-MIRROR-027  Valid magic + unsupported version → load() reports
+ *                    ERR_NVM_DATA_CORRUPT
+ *
  * FRAMEWORK: Zephyr Ztest (via ztest_shim.h for host compilation)
  * NVM:       NVM_STORE_HOST_MOCK (RAM-backed mock, controlled via nvm_mock_reset /
  *            nvm_mock_deinit)
@@ -335,18 +346,22 @@ ZTEST(dtc_mirror, test_flush_all_writes_correct_header)
 
     zassert_equal(UDS_STATUS_OK, dtc_mirror_flush_all(), "flush_all must return OK");
 
-    /* Verify NVM record exists and has correct layout. */
+    /* Verify NVM record exists and has the v1 integrity-checked layout:
+     * [magic:2][version:1][count:2][entry×2][crc32:4] = 5 + 8 + 4 = 17 bytes. */
     uint8_t buf[64];
     size_t  len = 0U;
     zassert_equal(UDS_STATUS_OK,
                   nvm_store_read(NVM_KEY_DTC_MIRROR, buf, sizeof(buf), &len),
                   "NVM record must exist after flush");
 
-    /* Minimum size: 2-byte header + 2 × 4-byte entries = 10 bytes. */
-    zassert_true(len >= 10U, "NVM record too short");
+    zassert_equal((size_t)17U, len,
+                  "record length must be header(5) + 2 entries(8) + crc(4) = 17");
+    zassert_equal(DTC_MIRROR_MAGIC_0, buf[0], "magic byte 0 must match");
+    zassert_equal(DTC_MIRROR_MAGIC_1, buf[1], "magic byte 1 must match");
+    zassert_equal((uint8_t)DTC_MIRROR_FORMAT_VERSION, buf[2], "version must match");
 
-    /* Header bytes: count big-endian.  2 DTCs registered → count == 2. */
-    uint16_t count = (uint16_t)(((uint16_t)buf[0] << 8U) | (uint16_t)buf[1]);
+    /* Count bytes: big-endian.  2 DTCs registered → count == 2. */
+    uint16_t count = (uint16_t)(((uint16_t)buf[3] << 8U) | (uint16_t)buf[4]);
     zassert_equal(2U, count, "NVM mirror count must be 2");
 }
 
@@ -359,16 +374,19 @@ ZTEST(dtc_mirror, test_flush_all_empty_table_writes_zero_count)
     zassert_equal(UDS_STATUS_OK, dtc_mirror_flush_all(),
                   "flush_all on empty table must return OK");
 
-    uint8_t buf[8];
+    uint8_t buf[16];
     size_t  len = 0U;
     zassert_equal(UDS_STATUS_OK,
                   nvm_store_read(NVM_KEY_DTC_MIRROR, buf, sizeof(buf), &len),
                   "NVM record must exist");
 
-    /* Header only: 2 bytes, count = 0. */
-    zassert_equal(2U,    (uint16_t)len, "empty flush must produce 2-byte record");
-    zassert_equal(0x00U, buf[0], "count high byte must be 0");
-    zassert_equal(0x00U, buf[1], "count low byte must be 0");
+    /* Header + crc only, no entries: 5 + 0 + 4 = 9 bytes, count = 0. */
+    zassert_equal((size_t)9U, len, "empty flush must produce a 9-byte record");
+    zassert_equal(DTC_MIRROR_MAGIC_0, buf[0], "magic byte 0 must match");
+    zassert_equal(DTC_MIRROR_MAGIC_1, buf[1], "magic byte 1 must match");
+    zassert_equal((uint8_t)DTC_MIRROR_FORMAT_VERSION, buf[2], "version must match");
+    zassert_equal(0x00U, buf[3], "count high byte must be 0");
+    zassert_equal(0x00U, buf[4], "count low byte must be 0");
 }
 
 /* ==========================================================================
@@ -623,6 +641,155 @@ ZTEST(dtc_mirror, test_h3_fix_full_persistence_scenario)
 }
 
 /* ==========================================================================
+ * Integrity checking tests (issue #114)
+ *
+ * These craft raw NVM bytes directly (bypassing dtc_mirror's own writer) to
+ * simulate flash corruption / a truncated write / a pre-fix legacy record,
+ * then assert dtc_mirror_load()'s response distinguishes them per the
+ * DELIBERATE cases documented in dtc_mirror.h:
+ *   (1) no/legacy record → OK, nothing applied
+ *   (2) valid record     → OK, restored (covered by TC-MIRROR-008 etc.)
+ *   (3) corrupt record   → ERR_NVM_DATA_CORRUPT, nothing applied
+ * ========================================================================== */
+
+/* TC-MIRROR-024  Bit-flip in a flushed entry (CRC no longer matches) →
+ * load() reports ERR_NVM_DATA_CORRUPT and applies NOTHING (all-or-nothing,
+ * not a partial apply). */
+ZTEST(dtc_mirror, test_load_reports_corrupt_on_bad_crc)
+{
+    uint8_t raw[32];
+    size_t  raw_len = 0U;
+
+    (void)dtc_mirror_init();
+    (void)dtc_database_register(DTC_1, 0x00U, "DTC_1");
+    (void)dtc_database_set_status(DTC_1, 0x09U);
+    zassert_equal(UDS_STATUS_OK, dtc_mirror_flush_all(), "flush must succeed");
+
+    zassert_equal(UDS_STATUS_OK,
+                  nvm_store_read(NVM_KEY_DTC_MIRROR, raw, sizeof(raw), &raw_len),
+                  "must read back the flushed record");
+    zassert_equal((size_t)13U, raw_len, "1-entry record must be 5+4+4=13 bytes");
+
+    /* Flip the entry's status byte (offset 5+3=8) without touching the CRC
+     * trailer — simulates a flash bit-flip after a valid write. */
+    raw[8] ^= 0xFFU;
+    zassert_equal(UDS_STATUS_OK,
+                  nvm_store_write(NVM_KEY_DTC_MIRROR, raw, raw_len),
+                  "must be able to write back the corrupted record");
+
+    /* Power-cycle: fresh database, DTC_1 defaults back to 0x00. */
+    simulate_power_cycle();
+    (void)dtc_database_register(DTC_1, 0x00U, "DTC_1");
+
+    uds_status_t rc = dtc_mirror_load();
+
+    zassert_equal(UDS_STATUS_ERR_NVM_DATA_CORRUPT, rc,
+                  "CRC-mismatched record must be reported as a distinct corrupt condition");
+    zassert_equal(0x00U, dtc_database_find(DTC_1)->status_byte,
+                  "corrupt record must not be applied at all, not even partially");
+}
+
+/* TC-MIRROR-025  Record truncated below what its own header declares →
+ * load() reports ERR_NVM_DATA_CORRUPT. This is the exact original bug
+ * shape: a short read mid-loop used to `break` and still return OK with
+ * whatever entries had been parsed so far. */
+ZTEST(dtc_mirror, test_load_reports_corrupt_on_truncated_record)
+{
+    uint8_t raw[32];
+    size_t  raw_len = 0U;
+
+    (void)dtc_mirror_init();
+    (void)dtc_database_register(DTC_1, 0x00U, "DTC_1");
+    (void)dtc_database_register(DTC_2, 0x00U, "DTC_2");
+    (void)dtc_database_set_status(DTC_1, 0x09U);
+    (void)dtc_database_set_status(DTC_2, 0x04U);
+    zassert_equal(UDS_STATUS_OK, dtc_mirror_flush_all(), "flush must succeed");
+
+    zassert_equal(UDS_STATUS_OK,
+                  nvm_store_read(NVM_KEY_DTC_MIRROR, raw, sizeof(raw), &raw_len),
+                  "must read back the flushed record");
+    zassert_equal((size_t)17U, raw_len, "2-entry record must be 5+8+4=17 bytes");
+
+    /* Header still declares count=2 (bytes[3..5) unchanged), but write back
+     * only header + first entry — second entry and CRC trailer missing. */
+    size_t truncated_len = (size_t)9U; /* 5-byte header + 1 entry, no CRC */
+    zassert_equal(UDS_STATUS_OK,
+                  nvm_store_write(NVM_KEY_DTC_MIRROR, raw, truncated_len),
+                  "must be able to write back the truncated record");
+
+    simulate_power_cycle();
+    (void)dtc_database_register(DTC_1, 0x00U, "DTC_1");
+    (void)dtc_database_register(DTC_2, 0x00U, "DTC_2");
+
+    uds_status_t rc = dtc_mirror_load();
+
+    zassert_equal(UDS_STATUS_ERR_NVM_DATA_CORRUPT, rc,
+                  "truncated record must be reported as corrupt, not silently accepted");
+    zassert_equal(0x00U, dtc_database_find(DTC_1)->status_byte,
+                  "truncated record must not partially apply DTC_1 (issue #114)");
+    zassert_equal(0x00U, dtc_database_find(DTC_2)->status_byte,
+                  "truncated record must not partially apply DTC_2 (issue #114)");
+}
+
+/* TC-MIRROR-026  A legacy pre-header record (the old [count:2][entries...]
+ * format, no magic, as left on flash by firmware built before issue #114)
+ * is discarded like "no mirror yet" — OK, nothing applied. This is the
+ * deliberate, documented migration decision (see dtc_mirror.h). */
+ZTEST(dtc_mirror, test_load_treats_legacy_record_as_no_mirror)
+{
+    uint8_t legacy[6];
+    size_t  pos = 0U;
+
+    /* Old wire format: [count_hi][count_lo][code_b2][code_b1][code_b0][status] */
+    legacy[pos++] = 0x00U;                                  /* count hi */
+    legacy[pos++] = 0x01U;                                  /* count lo -> 1 */
+    legacy[pos++] = (uint8_t)((DTC_1 >> 16U) & 0xFFU);
+    legacy[pos++] = (uint8_t)((DTC_1 >>  8U) & 0xFFU);
+    legacy[pos++] = (uint8_t)( DTC_1         & 0xFFU);
+    legacy[pos++] = 0x09U;                                  /* legacy status byte */
+
+    zassert_equal(UDS_STATUS_OK,
+                  nvm_store_write(NVM_KEY_DTC_MIRROR, legacy, pos),
+                  "must be able to write a legacy-format record directly");
+
+    (void)dtc_mirror_init();
+    (void)dtc_database_register(DTC_1, 0x00U, "DTC_1");
+
+    uds_status_t rc = dtc_mirror_load();
+
+    zassert_equal(UDS_STATUS_OK, rc,
+                  "MIGRATION: a legacy (pre-#114) record must load as OK, not corrupt");
+    zassert_equal(0x00U, dtc_database_find(DTC_1)->status_byte,
+                  "MIGRATION: legacy record content must be discarded, not reinterpreted");
+}
+
+/* TC-MIRROR-027  Valid magic but an unsupported/foreign version byte →
+ * load() reports ERR_NVM_DATA_CORRUPT (cannot safely reinterpret a layout
+ * from a version this build does not know). */
+ZTEST(dtc_mirror, test_load_reports_corrupt_on_bad_version)
+{
+    uint8_t raw[DTC_MIRROR_HEADER_BYTES];
+
+    raw[0] = DTC_MIRROR_MAGIC_0;
+    raw[1] = DTC_MIRROR_MAGIC_1;
+    raw[2] = (uint8_t)0xFFU; /* unsupported version */
+    raw[3] = 0x00U;
+    raw[4] = 0x00U;
+
+    zassert_equal(UDS_STATUS_OK,
+                  nvm_store_write(NVM_KEY_DTC_MIRROR, raw, sizeof(raw)),
+                  "must be able to write the record");
+
+    (void)dtc_mirror_init();
+    (void)dtc_database_register(DTC_1, 0x00U, "DTC_1");
+
+    uds_status_t rc = dtc_mirror_load();
+
+    zassert_equal(UDS_STATUS_ERR_NVM_DATA_CORRUPT, rc,
+                  "unsupported version under a valid magic must be reported as corrupt");
+}
+
+/* ==========================================================================
  * run_all_tests
  * ========================================================================== */
 
@@ -662,4 +829,10 @@ void run_all_tests(void)
     RUN_TEST(dtc_mirror__test_h3_fix_correct_call_order);
     RUN_TEST(dtc_mirror__test_h3_fix_soft_degrade_nvm_not_ready);
     RUN_TEST(dtc_mirror__test_h3_fix_full_persistence_scenario);
+
+    /* Integrity checking (issue #114) */
+    RUN_TEST(dtc_mirror__test_load_reports_corrupt_on_bad_crc);
+    RUN_TEST(dtc_mirror__test_load_reports_corrupt_on_truncated_record);
+    RUN_TEST(dtc_mirror__test_load_treats_legacy_record_as_no_mirror);
+    RUN_TEST(dtc_mirror__test_load_reports_corrupt_on_bad_version);
 }

--- a/tests/unit_runnable/test_phase3_nvm_dtc.c
+++ b/tests/unit_runnable/test_phase3_nvm_dtc.c
@@ -236,14 +236,17 @@ void test_flush_empty_table(void)
     /* No DTCs registered */
     TEST_ASSERT_EQUAL(UDS_STATUS_OK, dtc_mirror_flush_all());
 
-    uint8_t buf[8];
+    uint8_t buf[16];
     size_t  len = 0U;
     TEST_ASSERT_EQUAL(UDS_STATUS_OK,
         nvm_store_read(NVM_KEY_DTC_MIRROR, buf, sizeof(buf), &len));
-    /* Header only: 2 bytes, count = 0 */
-    TEST_ASSERT_EQUAL_INT((int)2U, (int)len);
-    TEST_ASSERT_EQUAL_UINT8(0x00U, buf[0]); /* count high */
-    TEST_ASSERT_EQUAL_UINT8(0x00U, buf[1]); /* count low  */
+    /* Header(5) + no entries + crc(4) = 9 bytes, count = 0 */
+    TEST_ASSERT_EQUAL_INT((int)9U, (int)len);
+    TEST_ASSERT_EQUAL_UINT8(DTC_MIRROR_MAGIC_0, buf[0]);
+    TEST_ASSERT_EQUAL_UINT8(DTC_MIRROR_MAGIC_1, buf[1]);
+    TEST_ASSERT_EQUAL_UINT8((uint8_t)DTC_MIRROR_FORMAT_VERSION, buf[2]);
+    TEST_ASSERT_EQUAL_UINT8(0x00U, buf[3]); /* count high */
+    TEST_ASSERT_EQUAL_UINT8(0x00U, buf[4]); /* count low  */
 }
 
 /* 10. dtc_mirror_init returns ERR_ALREADY_INITIALIZED on second call within same setUp */


### PR DESCRIPTION
Closes #114

## Root cause

`config/dtc_mirror.c`'s on-disk mirror format was just a 2-byte entry count
followed by fixed-size entries — no magic number, version, sequence, or
CRC/checksum. On load, a truncated entry mid-loop simply `break`d out of the
parse loop and the function still returned `UDS_STATUS_OK` (old
`config/dtc_mirror.c:180`). A corrupted record was therefore indistinguishable
from a legitimately short one, and whatever entries *had* been parsed before
hitting the truncation were silently applied — a partial, unreported success.

## The fix

New on-disk format for `NVM_KEY_DTC_MIRROR`:

```
[magic:2][version:1][count:2][entry_0:4]...[entry_n:4][crc32:4]
  magic   = 0x44,0x4D ("DM") — identifies a v1-or-later record
  version = 1 (bump on any layout change)
  count   = entry count, big-endian
  entry   = [dtc_code:3 big-endian][status_byte:1]
  crc32   = CRC-32 over [version..last entry byte], big-endian
```

`dtc_mirror_load()` now validates the **whole** record — magic, version,
declared length vs. actual bytes read, and CRC-32 — **before** applying a
single `dtc_database_set_status()` call. That's what makes a corrupt record
all-or-nothing instead of the original partial-apply bug. Three cases are now
distinguished:

1. **No record / record too short or without the v1 magic** → `UDS_STATUS_OK`,
   nothing applied. (This bucket also covers a legacy pre-#114 record — see
   Migration below.)
2. **Valid record** → `UDS_STATUS_OK`, entries restored.
3. **Magic present but version mismatch, declared-length mismatch, or CRC
   mismatch** → new `UDS_STATUS_ERR_NVM_DATA_CORRUPT`, nothing applied.

### New status code

Added `UDS_STATUS_ERR_NVM_DATA_CORRUPT = 0x62U` to `core/uds_status_t`
(`core/uds_types.h`) — no existing code means "persisted record fails its own
integrity check" distinctly from `ERR_PLATFORM` (I/O failure) or
`ERR_NOT_INITIALIZED` (no record/module not ready), and the issue explicitly
asks for a *distinct* reported condition, so folding it into an existing code
would defeat the point. Checked `srv_status_to_nrc()` (`core/uds_server.c`) —
it has a `default:` case, so the new enum value doesn't break that switch's
exhaustiveness. `dtc_mirror_load()`'s only real caller today is the generated
`uds_init.c` Step 5.5 block (see **Known consequence** below).

### CRC-32 reuse decision

Reused the existing `uds_transfer_crc32_update`/`uds_transfer_crc32_finalise`
engine (`core/uds_transfer_ctx.c`, also used by the transfer/flashing path and
by `platform/zephyr/zephyr_flash_ops.c` / `platform/freertos/freertos_flash_ops.c`)
rather than reimplementing CRC-32 in `config/`. This is layering-safe, not a
layering violation: `CMakeLists.txt`'s declared build-layer order is
`application -> core -> transport -> config -> platform`, `core/` is already a
global include directory for the `app` target, and `core/` has no dependency
back on `config/` — `config/` depending on `core/` is exactly the direction the
declared layering allows.

### Migration decision (deliberate, per the issue's own suggestion)

Existing deployments have headerless (pre-#114) mirrors on flash. A legacy
record can't be safely told apart from unrelated short/garbage data by shape
alone (its leading bytes are just an entry count, not chosen to avoid
colliding with anything). Rather than guess, **any record that is too short
for a v1 header, or whose leading bytes don't match the v1 magic, is treated
identically to "no mirror present"** — `UDS_STATUS_OK`, nothing applied. This
is a one-time, expected event on first boot after upgrading to this fix: the
device boots with DTC status at defaults instead of restoring whatever the
legacy record held. Documented in `config/dtc_mirror.h` and inline in
`dtc_mirror_load()`. Everything from the magic check onward applies only to
genuine v1 records, and a v1 record that fails validation is reported as
case 3 (corrupt), not folded into this bucket.

### Buffer sizing

`DTC_MIRROR_MAX_BYTES` grows from 2 + 128×4 = 514 to 5 + 128×4 + 4 = 521
bytes to fit the new header + CRC trailer. The entry-serialization loop's
bounds check (`mirror_serialize_internal`) now reserves room for the trailing
CRC as well as the next entry, so the writer can never overrun `s_mirror_buf`.
`dtc_mirror_load()`'s length/count validation (case 3 above) rejects any
record whose declared `count` would overflow the buffer before ever indexing
into it.

**Found while checking this (not fixed here, filed instead):** both the old
(514B) and new (521B) worst-case sizes already exceed
`NVM_MAX_RECORD_BYTES` (512, `platform/nvm_store.h`) at the top of the DTC
count range — a pre-existing latent bug (safe ceiling was 127 DTCs before
this PR, 125 after) where `nvm_store_write()` starts silently rejecting the
mirror write once the table nears its declared max capacity. Out of scope
for an on-disk-format fix, and `platform/nvm_store.h` is shared by unrelated
NVM consumers. Filed as `xaloqi-knowledge/reviews/FINDINGS.md` O-34
(separate commit, that repo).

### Known consequence for generated boot code (documented, not fixed here)

`examples/*/generated/uds_init.c`'s Step 5.5 block (produced by the private
`EDS-toolchain` template, not hand-edited in this repo) only treats
`{OK, ERR_NOT_INITIALIZED, ERR_PLATFORM}` as non-fatal and propagates anything
else as a fatal `uds_stack_init()` failure. The new `UDS_STATUS_ERR_NVM_DATA_CORRUPT`
is deliberately **not** added to that allowlist — an integrity violation on
safety-relevant persisted data shouldn't be silently trusted — which means
today a corrupted DTC mirror will abort the whole stack's boot on all 10
examples, rather than soft-degrading. This is a real, larger-blast-radius
behavior change versus the original bug (DTC-history loss only) and belongs
in the template's own explicit decision, not as a side effect of the
allowlist simply predating this status code. Filed as
`xaloqi-knowledge/reviews/FINDINGS.md` O-35 (separate commit, that repo) with
a suggested `EDS-toolchain` template fix + regeneration, same pattern as
EDS#99/#101 (O-27/O-28).

## Regression tests

Added to `tests/unit_runnable/test_dtc_mirror.c` (TC-MIRROR-024..027):

- **TC-MIRROR-024** `test_load_reports_corrupt_on_bad_crc` — flip a bit in a
  flushed entry's status byte (CRC trailer untouched) → `ERR_NVM_DATA_CORRUPT`,
  and the DTC's status is confirmed to still be at its pre-load default (no
  partial apply).
- **TC-MIRROR-025** `test_load_reports_corrupt_on_truncated_record` — write
  back only the header + first entry of a real 2-entry flush (header still
  declares count=2) → `ERR_NVM_DATA_CORRUPT`, neither entry applied. This is
  the exact shape of the original bug.
- **TC-MIRROR-026** `test_load_treats_legacy_record_as_no_mirror` — hand-craft
  an old-format `[count:2][entry:4]` record with no magic → `UDS_STATUS_OK`,
  content discarded (proves the migration decision).
- **TC-MIRROR-027** `test_load_reports_corrupt_on_bad_version` — valid magic,
  version byte 0xFF → `ERR_NVM_DATA_CORRUPT`.
- Valid round-trip (save → power-cycle → load restores all DTCs) was already
  covered by the existing TC-MIRROR-008/`test_h3_fix_full_persistence_scenario`,
  now exercising the new format.
- Genuinely-absent mirror → OK was already covered by the existing
  TC-MIRROR-007.

Two existing tests that inspected raw NVM bytes were updated for the new
header offsets: TC-MIRROR-013/014 in `test_dtc_mirror.c`, and
`test_flush_empty_table` in `test_phase3_nvm_dtc.c`.

### Before/after proof

Reverted the 3 source files (`config/dtc_mirror.c`, `config/dtc_mirror.h`,
`core/uds_types.h`) while keeping the new tests, and re-ran `build_tests.sh`:

```
=== Unit Test Summary: 41 passed, 2 failed ===
```

`test_dtc_mirror` and `test_phase3_nvm_dtc` both **fail to build** against
the pre-fix source — the new tests reference `UDS_STATUS_ERR_NVM_DATA_CORRUPT`,
`DTC_MIRROR_MAGIC_0/1`, and `DTC_MIRROR_FORMAT_VERSION`, none of which exist
before this fix. That's expected: these tests exercise API surface this PR
adds. Restored the fix (`git apply` the saved patch) and re-ran:

```
=== Unit Test Summary: 43 passed, 0 failed ===
```

Full before/after cycle confirmed clean (`git status` clean apart from the
intended 6 files both times).

## Gate results (this worktree, origin/main @ 8762593 base)

| Gate | Baseline | This PR |
|---|---|---|
| `bash build_tests.sh` | 43 passed, 0 failed | **43 passed, 0 failed** |
| `bash build_harness.sh --run` | 68/68 PASS | **68/68 PASS** |
| `python3 misra_analysis.py --out misra.json` | 41 files, 1 finding, 0 OPEN, 1 justified → PASS | **41 files, 1 finding, 0 OPEN, 1 justified → PASS** |
| No-malloc grep (core/, transport/, config/, examples/basic_ecu/generated/) | clean | **clean** |

`cppcheck` is not installed in this environment, so the MISRA run above is
GCC-only; CI runs it with `--strict` + cppcheck.

## Heightened review (CONTRIBUTING.md)

`config/dtc_mirror.c` is explicitly listed ("Any file under `config/` that
defines DTC status persistence"). Did an explicit self-review pass over the
diff for: buffer-overflow safety (bounds checks on both the writer's entry
loop and the reader's count/length validation, checked against the new
521-byte max before any indexing), no malloc/recursion/VLA, MISRA style
(explicit `U` suffixes, explicit casts, `(void)` on ignored returns), and
that the new enum value doesn't break the one exhaustive-looking switch on
`uds_status_t` in the codebase (`core/uds_server.c`, which has a `default:`).

Reviewed-by: Xaloqi <contact@xaloqi.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
