### PR TITLE
docs: consolidate fragmented [Unreleased] section headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   CONTRIBUTING.md's new-service checklist said to update "`ci.yml`" without
   saying which of the two files it meant.
 
+- **README and COMMERCIAL_NOTICE spell out the proprietary-firmware linking
+  right explicitly.** (#106) The open-core section and COMMERCIAL_NOTICE
+  already stated that a commercial license covers shipping closed-source
+  firmware, but not the specific question a reviewer evaluating the license
+  actually asks: can the GPL runtime (`core/`, `transport/`, `config/`,
+  `platform/`) be statically or dynamically linked into that firmware and
+  the binary distributed, with no GPL disclosure obligation for the
+  licensee's own code? Both files now answer that plainly, sourced from
+  `LICENSE_COMMERCIAL.txt` §5 — no change to the actual license terms.
+
 ### Fixed
 
 - **Stale counts and dead script paths across the prose docs, now guarded in
@@ -49,35 +59,6 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   `tests/unit_runnable/test_*.c` or references a `scripts/build_*.sh` path.
   `CHANGELOG.md` and `docs/PHASE1_SECURITY_CHANGES.md` are exempt — both are
   historical records of what was true at the time.
-
-### Security
-
-- **BREAKING: UDS access-control table now fails CLOSED for any service_id
-  with no explicit ACL row — audit your deployment before merging.** (#113)
-  `core/uds_access_table.c`'s `uds_access_table_lookup()` /
-  `uds_access_table_enforce()`, and `core/uds_server.c`'s
-  `srv_check_access_rights()`, treated a service_id absent from the active
-  access table (the built-in default table, or an OEM-supplied custom one
-  via `uds_server_cfg_t.access_table`) as "no restriction" — fully
-  reachable, in every session, with no security check, purely by omission.
-  A new SID added to `service_registration.c` without a matching ACL row
-  became silently unauthenticated. The default is now fail-closed: an
-  unlisted service_id is DENIED (NRC 0x7F, serviceNotSupportedInActiveSession)
-  unless the new compile-time opt-in `UDS_ACL_ALLOW_UNLISTED_SERVICES`
-  (Kconfig: `CONFIG_UDS_ACL_ALLOW_UNLISTED_SERVICES`, default `n`/`0`) is
-  explicitly set. **Every service_id the built-in default table ships today
-  keeps its exact prior behaviour** — including SID 0x31 RoutineControl,
-  the one registered service that previously had no ACL row at all and now
-  has an explicit, deliberately permissive one (see the row's comment in
-  `core/uds_access_table.c`). The behaviour change applies to: (1) any
-  future SID added without a matching ACL row, and (2) any OEM-supplied
-  custom `access_table` that does not cover every service_id it registers —
-  audit your custom table's coverage, or set the opt-in, before upgrading a
-  production deployment past this change. See the PR for the full SID
-  audit and regression tests (fake SID 0x99 denied by default across
-  sessions; opt-in verified to restore the old behaviour end-to-end).
-
-### Fixed
 
 - **DoIP: a UDS response of 4085–4095 bytes was silently dropped — no frame,
   not even a negative response.** (#108) `uds_msg_buf_t.data` is sized
@@ -214,17 +195,32 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   clamp-and-continue behavior as correct has been rewritten to assert the
   reject-and-abort behavior instead.
 
-### Changed
+### Security
 
-- **README and COMMERCIAL_NOTICE spell out the proprietary-firmware linking
-  right explicitly.** (#106) The open-core section and COMMERCIAL_NOTICE
-  already stated that a commercial license covers shipping closed-source
-  firmware, but not the specific question a reviewer evaluating the license
-  actually asks: can the GPL runtime (`core/`, `transport/`, `config/`,
-  `platform/`) be statically or dynamically linked into that firmware and
-  the binary distributed, with no GPL disclosure obligation for the
-  licensee's own code? Both files now answer that plainly, sourced from
-  `LICENSE_COMMERCIAL.txt` §5 — no change to the actual license terms.
+- **BREAKING: UDS access-control table now fails CLOSED for any service_id
+  with no explicit ACL row — audit your deployment before merging.** (#113)
+  `core/uds_access_table.c`'s `uds_access_table_lookup()` /
+  `uds_access_table_enforce()`, and `core/uds_server.c`'s
+  `srv_check_access_rights()`, treated a service_id absent from the active
+  access table (the built-in default table, or an OEM-supplied custom one
+  via `uds_server_cfg_t.access_table`) as "no restriction" — fully
+  reachable, in every session, with no security check, purely by omission.
+  A new SID added to `service_registration.c` without a matching ACL row
+  became silently unauthenticated. The default is now fail-closed: an
+  unlisted service_id is DENIED (NRC 0x7F, serviceNotSupportedInActiveSession)
+  unless the new compile-time opt-in `UDS_ACL_ALLOW_UNLISTED_SERVICES`
+  (Kconfig: `CONFIG_UDS_ACL_ALLOW_UNLISTED_SERVICES`, default `n`/`0`) is
+  explicitly set. **Every service_id the built-in default table ships today
+  keeps its exact prior behaviour** — including SID 0x31 RoutineControl,
+  the one registered service that previously had no ACL row at all and now
+  has an explicit, deliberately permissive one (see the row's comment in
+  `core/uds_access_table.c`). The behaviour change applies to: (1) any
+  future SID added without a matching ACL row, and (2) any OEM-supplied
+  custom `access_table` that does not cover every service_id it registers —
+  audit your custom table's coverage, or set the opt-in, before upgrading a
+  production deployment past this change. See the PR for the full SID
+  audit and regression tests (fake SID 0x99 denied by default across
+  sessions; opt-in verified to restore the old behaviour end-to-end).
 
 ## [1.11.0] — 2026-08-29
 


### PR DESCRIPTION
No `Closes` — this is cleanup, not a bug in shipped behavior.

## What happened

#120 and #125 each merged with their entry prepended at the top of `[Unreleased]`, following the "each appended at the top" convention #102 established. That convention assumes a PR's entry lands directly above whatever was already there — but by the time #120 and #125 merged, #113/#114/#111/#105/#112 had already split the section into `### Security` / `### Fixed` / `### Changed` blocks. The new entries landed in front of that split instead of merging into it, leaving **two non-contiguous `### Changed` headers and two non-contiguous `### Fixed` headers** in the same section:

```
### Changed   ← #119
### Fixed     ← #119
### Security  ← #113
### Fixed     ← #108, #114, #111, #105, #112
### Changed   ← #106
```

Same drift class #30/#102 fixed before — a duplicate/fragmented section header from stacking one PR's changelog edit onto another's.

## Fix

Merged by category, preserving the relative order of first appearance (`Changed`, `Fixed`, `Security`) and, within each merged block, the top-to-bottom order the bullets already had:

```
### Changed   ← #119, #106
### Fixed     ← #119, #108, #114, #111, #105, #112
### Security  ← #113
```

No entry was dropped or reworded. Verified every `(#NNN)` reference appears the same number of times before and after — `#119` twice (its own Changed item and Fixed item, correctly distinct), every other issue once.

## Gates

- `bash build_tests.sh` → **44 passed, 0 failed**
- `python3 scripts/verify_doc_counts.py` → **PASS**

`CHANGELOG.md` only.