### PR TITLE
fix: regenerate all 12 examples' uds_init.c, soft-degrade corrupt DTC mirror (#124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,21 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **A corrupted DTC mirror no longer aborts `uds_stack_init()` — boot now
+  soft-degrades instead.** (#124) `dtc_mirror_load()`'s
+  `UDS_STATUS_ERR_NVM_DATA_CORRUPT` return (added in #114/#118 for a
+  persisted record that fails its integrity check) was not on the generated
+  Step 5.5 non-fatal allowlist, so on all 12 bundled examples a corrupted DTC
+  mirror propagated as a fatal `uds_stack_init()` failure, taking down the
+  entire diagnostic stack's boot. `UDS_STATUS_ERR_NVM_DATA_CORRUPT` is now
+  treated the same as an absent/unreadable mirror (`UDS_STATUS_ERR_NOT_INITIALIZED`
+  / `UDS_STATUS_ERR_PLATFORM`): the corrupt record is discarded and boot
+  continues with all DTC status bytes at 0x00 — the same blast radius as the
+  original DTC-history-loss bug #114 fixed, not a new, larger one. Fixed in
+  the private EDS-toolchain template
+  ([EDS-toolchain#57](https://github.com/Xaloqi/EDS-toolchain/pull/57)); all
+  12 `examples/*/generated/uds_init.c` regenerated here.
+
 - **Stale counts and dead script paths across the prose docs, now guarded in
   CI.** (#119) Six places in `docs/` told the reader to run
   `scripts/build_tests.sh` or `scripts/build_harness.sh`; neither has ever

--- a/examples/ardep_ecu/generated/did_handlers.c
+++ b/examples/ardep_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/ardep_ecu/generated/did_handlers.h
+++ b/examples/ardep_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/ardep_ecu/generated/did_safety_wrappers.c
+++ b/examples/ardep_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/ardep_ecu/generated/did_safety_wrappers.h
+++ b/examples/ardep_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/ardep_ecu/generated/generated_config.h
+++ b/examples/ardep_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "ARDEP_IOController"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:45Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:03Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/ardep_ecu/generated/routine_handlers.c
+++ b/examples/ardep_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: ARDEP_IOController  v1.0.0  Generated: 2026-08-29T11:04:45Z
+// ECU: ARDEP_IOController  v1.0.0  Generated: 2026-08-30T11:15:03Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/ardep_ecu/generated/routine_handlers.h
+++ b/examples/ardep_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: ARDEP_IOController  v1.0.0  Generated: 2026-08-29T11:04:45Z
+// ECU: ARDEP_IOController  v1.0.0  Generated: 2026-08-30T11:15:03Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/ardep_ecu/generated/safety_config.h
+++ b/examples/ardep_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/ardep_ecu/generated/tests/README.md
+++ b/examples/ardep_ecu/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-05-20T07:21:48Z by tools/testgen.py*
+*Generated 2026-08-30T11:15:03Z by tools/testgen.py*

--- a/examples/ardep_ecu/generated/tests/conftest.py
+++ b/examples/ardep_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/ardep_ecu/generated/tests/conftest_firmware.py
+++ b/examples/ardep_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/ardep_ecu/generated/tests/test_did_2001.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2001.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2001  (PowerIO_OutputStateBitmask)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2002.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2002.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2002  (PowerIO_Output1_Current_mA)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2003.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2003.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2003  (PowerIO_Output2_Current_mA)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2004.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2004.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2004  (PowerIO_Output3_Current_mA)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2005.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2005.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2005  (PowerIO_Output4_Current_mA)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2006.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2006.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2006  (PowerIO_Output5_Current_mA)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2007.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2007.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2007  (PowerIO_Output6_Current_mA)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2010.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2010.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2010  (PowerIO_OutputControl)
 # Access    : read + write

--- a/examples/ardep_ecu/generated/tests/test_did_2101.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2101.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2101  (PowerIO_InputStateBitmask)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2102.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2102.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2102  (PowerIO_Input1_Voltage_mV)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2103.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2103.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2103  (PowerIO_Input2_Voltage_mV)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2104.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2104.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2104  (PowerIO_Input3_Voltage_mV)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2201.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2201.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2201  (CAN_BusStatus)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2202.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2202.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2202  (CAN_RxFrameCount)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2203.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2203.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2203  (CAN_TxFrameCount)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2211.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2211.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2211  (LIN_BusStatus)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2212.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2212.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2212  (LIN_SlaveCount)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2301.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2301.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2301  (ECU_SupplyVoltage_mV)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2302.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2302.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2302  (ECU_InternalTemperature_degC)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2303.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2303.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2303  (ECU_UptimeSeconds)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2304.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2304.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2304  (ECU_ResetCounter)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2305.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2305.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2305  (ECU_LastResetReason)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2306.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2306.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2306  (ECU_DiagnosticStackVersion)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2401.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2401.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2401  (CAN_BusBitrate_kbps)
 # Access    : read + write

--- a/examples/ardep_ecu/generated/tests/test_did_2402.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2402.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2402  (LIN_BusBaudrate_bps)
 # Access    : read + write

--- a/examples/ardep_ecu/generated/tests/test_did_2403.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2403.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2403  (PowerIO_OvercurrentThreshold_mA)
 # Access    : read + write

--- a/examples/ardep_ecu/generated/tests/test_did_2404.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2404.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2404  (WatchdogTimeout_ms)
 # Access    : read + write

--- a/examples/ardep_ecu/generated/tests/test_did_2501.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2501.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2501  (FirmwareVersion_Active)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2502.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2502.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2502  (FirmwareVersion_Pending)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2503.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2503.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x2503  (FirmwareUpdateStatus)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_f187.py
+++ b/examples/ardep_ecu/generated/tests/test_did_f187.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0xF187  (VehicleManufacturerSparePartNumber)
 # Access    : read + write

--- a/examples/ardep_ecu/generated/tests/test_did_f189.py
+++ b/examples/ardep_ecu/generated/tests/test_did_f189.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0xF189  (ECUSoftwareVersionNumber)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_f18c.py
+++ b/examples/ardep_ecu/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0xF18C  (ECUSerialNumber)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_f190.py
+++ b/examples/ardep_ecu/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0xF190  (VehicleIdentificationNumber)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_f197.py
+++ b/examples/ardep_ecu/generated/tests/test_did_f197.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0xF197  (SystemSupplierIdentifierDataIdentifier)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_firmware_services.py
+++ b/examples/ardep_ecu/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/ardep_ecu/generated/tests/test_routine_ff00.py
+++ b/examples/ardep_ecu/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # Routine   : 0xFF00  (ECU_SelfTest)
 # Session   : extended (ordinal 3)

--- a/examples/ardep_ecu/generated/tests/test_routine_ff01.py
+++ b/examples/ardep_ecu/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # Routine   : 0xFF01  (ResetCalibrationToDefaults)
 # Session   : extended (ordinal 3)

--- a/examples/ardep_ecu/generated/tests/test_routine_ff10.py
+++ b/examples/ardep_ecu/generated/tests/test_routine_ff10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # Routine   : 0xFF10  (EraseApplicationFlash)
 # Session   : programming (ordinal 2)

--- a/examples/ardep_ecu/generated/tests/test_routine_ff11.py
+++ b/examples/ardep_ecu/generated/tests/test_routine_ff11.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # Routine   : 0xFF11  (VerifyApplicationImage)
 # Session   : programming (ordinal 2)

--- a/examples/ardep_ecu/generated/tests/test_routine_ff20.py
+++ b/examples/ardep_ecu/generated/tests/test_routine_ff20.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # Routine   : 0xFF20  (ActivateOutputChannel)
 # Session   : extended (ordinal 3)

--- a/examples/ardep_ecu/generated/tests/test_routine_ff21.py
+++ b/examples/ardep_ecu/generated/tests/test_routine_ff21.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # Routine   : 0xFF21  (MeasureSupplyVoltage)
 # Session   : extended (ordinal 3)

--- a/examples/ardep_ecu/generated/uds_init.c
+++ b/examples/ardep_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -431,11 +431,22 @@ uds_status_t uds_generated_init(
      * DTC codes without corrupting the mirror.
      *
      * Soft-degrade behaviour:
-     *   UDS_STATUS_ERR_NOT_INITIALIZED → NVM not ready (first boot or NVM
+     *   UDS_STATUS_ERR_NOT_INITIALIZED  → NVM not ready (first boot or NVM
      *     subsystem failure). Treated as non-fatal: stack continues with all
      *     DTC status bytes at 0x00.
-     *   UDS_STATUS_ERR_PLATFORM        → NVM read error. Non-fatal: same
+     *   UDS_STATUS_ERR_PLATFORM         → NVM read error. Non-fatal: same
      *     degraded behaviour as first boot.
+     *   UDS_STATUS_ERR_NVM_DATA_CORRUPT → the persisted mirror record failed
+     *     an integrity check (bad tag/length/checksum — see dtc_mirror_load()).
+     *     Deliberately treated the same as "mirror absent" rather than as a
+     *     fatal boot error: the blast radius of trusting nothing from a
+     *     corrupt record is identical to the NOT_INITIALIZED case (DTC
+     *     history is lost, all status bytes stay at 0x00), which is the same
+     *     blast radius the original DTC-history-loss defect had. Aborting
+     *     uds_stack_init() over it would let a corrupted NVM record take down
+     *     the entire diagnostic stack, a materially larger failure than the
+     *     data loss it is guarding against. This is an explicit decision,
+     *     not an oversight — see Xaloqi/EDS#124.
      *
      * TRACEABILITY: REQ-DTC-NVM-01
      */
@@ -443,11 +454,14 @@ uds_status_t uds_generated_init(
         uds_status_t mirror_rc = dtc_mirror_load();
         if ((mirror_rc != UDS_STATUS_OK) &&
             (mirror_rc != UDS_STATUS_ERR_NOT_INITIALIZED) &&
-            (mirror_rc != UDS_STATUS_ERR_PLATFORM)) {
+            (mirror_rc != UDS_STATUS_ERR_PLATFORM) &&
+            (mirror_rc != UDS_STATUS_ERR_NVM_DATA_CORRUPT)) {
             /* Unexpected error — propagate to caller. */
             return mirror_rc;
         }
-        /* Soft-degrade: NOT_INITIALIZED and PLATFORM errors are non-fatal. */
+        /* Soft-degrade: NOT_INITIALIZED, PLATFORM, and NVM_DATA_CORRUPT
+         * errors are all non-fatal — the corrupted/unavailable mirror is
+         * discarded and boot continues with default (0x00) DTC status. */
     }
 
     /* ── Step 5.6: Register generated routine handlers ──────────────────────

--- a/examples/ardep_ecu/generated/uds_init.h
+++ b/examples/ardep_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/basic_ecu/generated/did_handlers.c
+++ b/examples/basic_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/basic_ecu/generated/did_handlers.h
+++ b/examples/basic_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/basic_ecu/generated/did_safety_wrappers.c
+++ b/examples/basic_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/basic_ecu/generated/did_safety_wrappers.h
+++ b/examples/basic_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/basic_ecu/generated/generated_config.h
+++ b/examples/basic_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "BasicECU"
 #define GEN_ECU_VERSION         "0.1.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:45Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:03Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/basic_ecu/generated/routine_handlers.c
+++ b/examples/basic_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU  v0.1.0  Generated: 2026-08-29T11:04:45Z
+// ECU: BasicECU  v0.1.0  Generated: 2026-08-30T11:15:03Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/basic_ecu/generated/routine_handlers.h
+++ b/examples/basic_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU  v0.1.0  Generated: 2026-08-29T11:04:45Z
+// ECU: BasicECU  v0.1.0  Generated: 2026-08-30T11:15:03Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/basic_ecu/generated/safety_config.h
+++ b/examples/basic_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/basic_ecu/generated/tests/README.md
+++ b/examples/basic_ecu/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-05-19T17:30:37Z by tools/testgen.py*
+*Generated 2026-08-30T11:15:03Z by tools/testgen.py*

--- a/examples/basic_ecu/generated/tests/conftest.py
+++ b/examples/basic_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-19T17:30:37Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/basic_ecu/generated/tests/conftest_firmware.py
+++ b/examples/basic_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-19T17:30:37Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/basic_ecu/generated/tests/test_did_0500.py
+++ b/examples/basic_ecu/generated/tests/test_did_0500.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-19T17:30:37Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x0500  (Coolant Temperature)
 # Access    : read

--- a/examples/basic_ecu/generated/tests/test_did_0c00.py
+++ b/examples/basic_ecu/generated/tests/test_did_0c00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-19T17:30:37Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x0C00  (Engine Speed)
 # Access    : read

--- a/examples/basic_ecu/generated/tests/test_did_f187.py
+++ b/examples/basic_ecu/generated/tests/test_did_f187.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-19T17:30:37Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0xF187  (Vehicle Manufacturer Spare Part Number)
 # Access    : read + write

--- a/examples/basic_ecu/generated/tests/test_did_f18c.py
+++ b/examples/basic_ecu/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-19T17:30:37Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0xF18C  (ECU Serial Number)
 # Access    : read

--- a/examples/basic_ecu/generated/tests/test_did_f190.py
+++ b/examples/basic_ecu/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-19T17:30:37Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0xF190  (Vehicle Identification Number)
 # Access    : read

--- a/examples/basic_ecu/generated/tests/test_firmware_services.py
+++ b/examples/basic_ecu/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-19T17:30:37Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/basic_ecu/generated/tests/test_routine_ff00.py
+++ b/examples/basic_ecu/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-19T17:30:37Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # Routine   : 0xFF00  (ECU_SelfTest)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu/generated/tests/test_routine_ff01.py
+++ b/examples/basic_ecu/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-19T17:30:37Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # Routine   : 0xFF01  (ResetToFactoryDefaults)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu/generated/tests/test_routine_ff10.py
+++ b/examples/basic_ecu/generated/tests/test_routine_ff10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-19T17:30:37Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # Routine   : 0xFF10  (EraseNVM)
 # Session   : programming (ordinal 2)

--- a/examples/basic_ecu/generated/uds_init.c
+++ b/examples/basic_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -278,11 +278,22 @@ uds_status_t uds_generated_init(
      * DTC codes without corrupting the mirror.
      *
      * Soft-degrade behaviour:
-     *   UDS_STATUS_ERR_NOT_INITIALIZED → NVM not ready (first boot or NVM
+     *   UDS_STATUS_ERR_NOT_INITIALIZED  → NVM not ready (first boot or NVM
      *     subsystem failure). Treated as non-fatal: stack continues with all
      *     DTC status bytes at 0x00.
-     *   UDS_STATUS_ERR_PLATFORM        → NVM read error. Non-fatal: same
+     *   UDS_STATUS_ERR_PLATFORM         → NVM read error. Non-fatal: same
      *     degraded behaviour as first boot.
+     *   UDS_STATUS_ERR_NVM_DATA_CORRUPT → the persisted mirror record failed
+     *     an integrity check (bad tag/length/checksum — see dtc_mirror_load()).
+     *     Deliberately treated the same as "mirror absent" rather than as a
+     *     fatal boot error: the blast radius of trusting nothing from a
+     *     corrupt record is identical to the NOT_INITIALIZED case (DTC
+     *     history is lost, all status bytes stay at 0x00), which is the same
+     *     blast radius the original DTC-history-loss defect had. Aborting
+     *     uds_stack_init() over it would let a corrupted NVM record take down
+     *     the entire diagnostic stack, a materially larger failure than the
+     *     data loss it is guarding against. This is an explicit decision,
+     *     not an oversight — see Xaloqi/EDS#124.
      *
      * TRACEABILITY: REQ-DTC-NVM-01
      */
@@ -290,11 +301,14 @@ uds_status_t uds_generated_init(
         uds_status_t mirror_rc = dtc_mirror_load();
         if ((mirror_rc != UDS_STATUS_OK) &&
             (mirror_rc != UDS_STATUS_ERR_NOT_INITIALIZED) &&
-            (mirror_rc != UDS_STATUS_ERR_PLATFORM)) {
+            (mirror_rc != UDS_STATUS_ERR_PLATFORM) &&
+            (mirror_rc != UDS_STATUS_ERR_NVM_DATA_CORRUPT)) {
             /* Unexpected error — propagate to caller. */
             return mirror_rc;
         }
-        /* Soft-degrade: NOT_INITIALIZED and PLATFORM errors are non-fatal. */
+        /* Soft-degrade: NOT_INITIALIZED, PLATFORM, and NVM_DATA_CORRUPT
+         * errors are all non-fatal — the corrupted/unavailable mirror is
+         * discarded and boot continues with default (0x00) DTC status. */
     }
 
     /* ── Step 5.6: Register generated routine handlers ──────────────────────

--- a/examples/basic_ecu/generated/uds_init.h
+++ b/examples/basic_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/basic_ecu_doip/generated/did_handlers.c
+++ b/examples/basic_ecu_doip/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/basic_ecu_doip/generated/did_handlers.h
+++ b/examples/basic_ecu_doip/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/basic_ecu_doip/generated/did_safety_wrappers.c
+++ b/examples/basic_ecu_doip/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/basic_ecu_doip/generated/did_safety_wrappers.h
+++ b/examples/basic_ecu_doip/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/basic_ecu_doip/generated/generated_config.h
+++ b/examples/basic_ecu_doip/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "BasicECU_DoIP"
 #define GEN_ECU_VERSION         "1.6.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:45Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:03Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/basic_ecu_doip/generated/routine_handlers.c
+++ b/examples/basic_ecu_doip/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU_DoIP  v1.6.0  Generated: 2026-08-29T11:04:45Z
+// ECU: BasicECU_DoIP  v1.6.0  Generated: 2026-08-30T11:15:03Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/basic_ecu_doip/generated/routine_handlers.h
+++ b/examples/basic_ecu_doip/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU_DoIP  v1.6.0  Generated: 2026-08-29T11:04:45Z
+// ECU: BasicECU_DoIP  v1.6.0  Generated: 2026-08-30T11:15:03Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/basic_ecu_doip/generated/safety_config.h
+++ b/examples/basic_ecu_doip/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/basic_ecu_doip/generated/tests/README.md
+++ b/examples/basic_ecu_doip/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-05-20T07:21:47Z by tools/testgen.py*
+*Generated 2026-08-30T11:15:03Z by tools/testgen.py*

--- a/examples/basic_ecu_doip/generated/tests/conftest.py
+++ b/examples/basic_ecu_doip/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/basic_ecu_doip/generated/tests/conftest_firmware.py
+++ b/examples/basic_ecu_doip/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/basic_ecu_doip/generated/tests/test_did_0500.py
+++ b/examples/basic_ecu_doip/generated/tests/test_did_0500.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x0500  (Coolant Temperature)
 # Access    : read

--- a/examples/basic_ecu_doip/generated/tests/test_did_0c00.py
+++ b/examples/basic_ecu_doip/generated/tests/test_did_0c00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0x0C00  (Engine Speed)
 # Access    : read

--- a/examples/basic_ecu_doip/generated/tests/test_did_f187.py
+++ b/examples/basic_ecu_doip/generated/tests/test_did_f187.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0xF187  (Vehicle Manufacturer Spare Part Number)
 # Access    : read + write

--- a/examples/basic_ecu_doip/generated/tests/test_did_f18c.py
+++ b/examples/basic_ecu_doip/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0xF18C  (ECU Serial Number)
 # Access    : read

--- a/examples/basic_ecu_doip/generated/tests/test_did_f190.py
+++ b/examples/basic_ecu_doip/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # DID       : 0xF190  (Vehicle Identification Number)
 # Access    : read

--- a/examples/basic_ecu_doip/generated/tests/test_firmware_services.py
+++ b/examples/basic_ecu_doip/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/basic_ecu_doip/generated/tests/test_routine_ff00.py
+++ b/examples/basic_ecu_doip/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # Routine   : 0xFF00  (ECU_SelfTest)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu_doip/generated/tests/test_routine_ff01.py
+++ b/examples/basic_ecu_doip/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # Routine   : 0xFF01  (ResetToFactoryDefaults)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu_doip/generated/tests/test_routine_ff10.py
+++ b/examples/basic_ecu_doip/generated/tests/test_routine_ff10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:03Z
 #
 # Routine   : 0xFF10  (EraseNVM)
 # Session   : programming (ordinal 2)

--- a/examples/basic_ecu_doip/generated/uds_init.c
+++ b/examples/basic_ecu_doip/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -278,11 +278,22 @@ uds_status_t uds_generated_init(
      * DTC codes without corrupting the mirror.
      *
      * Soft-degrade behaviour:
-     *   UDS_STATUS_ERR_NOT_INITIALIZED → NVM not ready (first boot or NVM
+     *   UDS_STATUS_ERR_NOT_INITIALIZED  → NVM not ready (first boot or NVM
      *     subsystem failure). Treated as non-fatal: stack continues with all
      *     DTC status bytes at 0x00.
-     *   UDS_STATUS_ERR_PLATFORM        → NVM read error. Non-fatal: same
+     *   UDS_STATUS_ERR_PLATFORM         → NVM read error. Non-fatal: same
      *     degraded behaviour as first boot.
+     *   UDS_STATUS_ERR_NVM_DATA_CORRUPT → the persisted mirror record failed
+     *     an integrity check (bad tag/length/checksum — see dtc_mirror_load()).
+     *     Deliberately treated the same as "mirror absent" rather than as a
+     *     fatal boot error: the blast radius of trusting nothing from a
+     *     corrupt record is identical to the NOT_INITIALIZED case (DTC
+     *     history is lost, all status bytes stay at 0x00), which is the same
+     *     blast radius the original DTC-history-loss defect had. Aborting
+     *     uds_stack_init() over it would let a corrupted NVM record take down
+     *     the entire diagnostic stack, a materially larger failure than the
+     *     data loss it is guarding against. This is an explicit decision,
+     *     not an oversight — see Xaloqi/EDS#124.
      *
      * TRACEABILITY: REQ-DTC-NVM-01
      */
@@ -290,11 +301,14 @@ uds_status_t uds_generated_init(
         uds_status_t mirror_rc = dtc_mirror_load();
         if ((mirror_rc != UDS_STATUS_OK) &&
             (mirror_rc != UDS_STATUS_ERR_NOT_INITIALIZED) &&
-            (mirror_rc != UDS_STATUS_ERR_PLATFORM)) {
+            (mirror_rc != UDS_STATUS_ERR_PLATFORM) &&
+            (mirror_rc != UDS_STATUS_ERR_NVM_DATA_CORRUPT)) {
             /* Unexpected error — propagate to caller. */
             return mirror_rc;
         }
-        /* Soft-degrade: NOT_INITIALIZED and PLATFORM errors are non-fatal. */
+        /* Soft-degrade: NOT_INITIALIZED, PLATFORM, and NVM_DATA_CORRUPT
+         * errors are all non-fatal — the corrupted/unavailable mirror is
+         * discarded and boot continues with default (0x00) DTC status. */
     }
 
     /* ── Step 5.6: Register generated routine handlers ──────────────────────

--- a/examples/basic_ecu_doip/generated/uds_init.h
+++ b/examples/basic_ecu_doip/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:03Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/basic_ecu_doip_freertos/generated/did_handlers.c
+++ b/examples/basic_ecu_doip_freertos/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/basic_ecu_doip_freertos/generated/did_handlers.h
+++ b/examples/basic_ecu_doip_freertos/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/basic_ecu_doip_freertos/generated/did_safety_wrappers.c
+++ b/examples/basic_ecu_doip_freertos/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/basic_ecu_doip_freertos/generated/did_safety_wrappers.h
+++ b/examples/basic_ecu_doip_freertos/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/basic_ecu_doip_freertos/generated/generated_config.h
+++ b/examples/basic_ecu_doip_freertos/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "BasicECU_DoIP_FreeRTOS"
 #define GEN_ECU_VERSION         "1.6.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:45Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:04Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/basic_ecu_doip_freertos/generated/routine_handlers.c
+++ b/examples/basic_ecu_doip_freertos/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU_DoIP_FreeRTOS  v1.6.0  Generated: 2026-08-29T11:04:45Z
+// ECU: BasicECU_DoIP_FreeRTOS  v1.6.0  Generated: 2026-08-30T11:15:04Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/basic_ecu_doip_freertos/generated/routine_handlers.h
+++ b/examples/basic_ecu_doip_freertos/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU_DoIP_FreeRTOS  v1.6.0  Generated: 2026-08-29T11:04:45Z
+// ECU: BasicECU_DoIP_FreeRTOS  v1.6.0  Generated: 2026-08-30T11:15:04Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/basic_ecu_doip_freertos/generated/safety_config.h
+++ b/examples/basic_ecu_doip_freertos/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/basic_ecu_doip_freertos/generated/tests/README.md
+++ b/examples/basic_ecu_doip_freertos/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-05-20T07:21:47Z by tools/testgen.py*
+*Generated 2026-08-30T11:15:04Z by tools/testgen.py*

--- a/examples/basic_ecu_doip_freertos/generated/tests/conftest.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/basic_ecu_doip_freertos/generated/tests/conftest_firmware.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_did_0500.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_did_0500.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0x0500  (Coolant Temperature)
 # Access    : read

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_did_0c00.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_did_0c00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0x0C00  (Engine Speed)
 # Access    : read

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_did_f187.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_did_f187.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xF187  (Vehicle Manufacturer Spare Part Number)
 # Access    : read + write

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_did_f18c.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xF18C  (ECU Serial Number)
 # Access    : read

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_did_f190.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xF190  (Vehicle Identification Number)
 # Access    : read

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_firmware_services.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_routine_ff00.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xFF00  (ECU_SelfTest)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_routine_ff01.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xFF01  (ResetToFactoryDefaults)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_routine_ff10.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_routine_ff10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xFF10  (EraseNVM)
 # Session   : programming (ordinal 2)

--- a/examples/basic_ecu_doip_freertos/generated/uds_init.c
+++ b/examples/basic_ecu_doip_freertos/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -278,11 +278,22 @@ uds_status_t uds_generated_init(
      * DTC codes without corrupting the mirror.
      *
      * Soft-degrade behaviour:
-     *   UDS_STATUS_ERR_NOT_INITIALIZED → NVM not ready (first boot or NVM
+     *   UDS_STATUS_ERR_NOT_INITIALIZED  → NVM not ready (first boot or NVM
      *     subsystem failure). Treated as non-fatal: stack continues with all
      *     DTC status bytes at 0x00.
-     *   UDS_STATUS_ERR_PLATFORM        → NVM read error. Non-fatal: same
+     *   UDS_STATUS_ERR_PLATFORM         → NVM read error. Non-fatal: same
      *     degraded behaviour as first boot.
+     *   UDS_STATUS_ERR_NVM_DATA_CORRUPT → the persisted mirror record failed
+     *     an integrity check (bad tag/length/checksum — see dtc_mirror_load()).
+     *     Deliberately treated the same as "mirror absent" rather than as a
+     *     fatal boot error: the blast radius of trusting nothing from a
+     *     corrupt record is identical to the NOT_INITIALIZED case (DTC
+     *     history is lost, all status bytes stay at 0x00), which is the same
+     *     blast radius the original DTC-history-loss defect had. Aborting
+     *     uds_stack_init() over it would let a corrupted NVM record take down
+     *     the entire diagnostic stack, a materially larger failure than the
+     *     data loss it is guarding against. This is an explicit decision,
+     *     not an oversight — see Xaloqi/EDS#124.
      *
      * TRACEABILITY: REQ-DTC-NVM-01
      */
@@ -290,11 +301,14 @@ uds_status_t uds_generated_init(
         uds_status_t mirror_rc = dtc_mirror_load();
         if ((mirror_rc != UDS_STATUS_OK) &&
             (mirror_rc != UDS_STATUS_ERR_NOT_INITIALIZED) &&
-            (mirror_rc != UDS_STATUS_ERR_PLATFORM)) {
+            (mirror_rc != UDS_STATUS_ERR_PLATFORM) &&
+            (mirror_rc != UDS_STATUS_ERR_NVM_DATA_CORRUPT)) {
             /* Unexpected error — propagate to caller. */
             return mirror_rc;
         }
-        /* Soft-degrade: NOT_INITIALIZED and PLATFORM errors are non-fatal. */
+        /* Soft-degrade: NOT_INITIALIZED, PLATFORM, and NVM_DATA_CORRUPT
+         * errors are all non-fatal — the corrupted/unavailable mirror is
+         * discarded and boot continues with default (0x00) DTC status. */
     }
 
     /* ── Step 5.6: Register generated routine handlers ──────────────────────

--- a/examples/basic_ecu_doip_freertos/generated/uds_init.h
+++ b/examples/basic_ecu_doip_freertos/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/basic_ecu_freertos/generated/did_handlers.c
+++ b/examples/basic_ecu_freertos/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/basic_ecu_freertos/generated/did_handlers.h
+++ b/examples/basic_ecu_freertos/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/basic_ecu_freertos/generated/did_safety_wrappers.c
+++ b/examples/basic_ecu_freertos/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/basic_ecu_freertos/generated/did_safety_wrappers.h
+++ b/examples/basic_ecu_freertos/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/basic_ecu_freertos/generated/generated_config.h
+++ b/examples/basic_ecu_freertos/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "BasicECU"
 #define GEN_ECU_VERSION         "0.1.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:45Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:04Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/basic_ecu_freertos/generated/routine_handlers.c
+++ b/examples/basic_ecu_freertos/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU  v0.1.0  Generated: 2026-08-29T11:04:45Z
+// ECU: BasicECU  v0.1.0  Generated: 2026-08-30T11:15:04Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/basic_ecu_freertos/generated/routine_handlers.h
+++ b/examples/basic_ecu_freertos/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU  v0.1.0  Generated: 2026-08-29T11:04:45Z
+// ECU: BasicECU  v0.1.0  Generated: 2026-08-30T11:15:04Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/basic_ecu_freertos/generated/safety_config.h
+++ b/examples/basic_ecu_freertos/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/basic_ecu_freertos/generated/tests/README.md
+++ b/examples/basic_ecu_freertos/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-05-20T07:21:48Z by tools/testgen.py*
+*Generated 2026-08-30T11:15:04Z by tools/testgen.py*

--- a/examples/basic_ecu_freertos/generated/tests/conftest.py
+++ b/examples/basic_ecu_freertos/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/basic_ecu_freertos/generated/tests/conftest_firmware.py
+++ b/examples/basic_ecu_freertos/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/basic_ecu_freertos/generated/tests/test_did_0500.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_did_0500.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0x0500  (Coolant Temperature)
 # Access    : read

--- a/examples/basic_ecu_freertos/generated/tests/test_did_0c00.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_did_0c00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0x0C00  (Engine Speed)
 # Access    : read

--- a/examples/basic_ecu_freertos/generated/tests/test_did_f187.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_did_f187.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xF187  (Vehicle Manufacturer Spare Part Number)
 # Access    : read + write

--- a/examples/basic_ecu_freertos/generated/tests/test_did_f18c.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xF18C  (ECU Serial Number)
 # Access    : read

--- a/examples/basic_ecu_freertos/generated/tests/test_did_f190.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xF190  (Vehicle Identification Number)
 # Access    : read

--- a/examples/basic_ecu_freertos/generated/tests/test_firmware_services.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/basic_ecu_freertos/generated/tests/test_routine_ff00.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xFF00  (ECU_SelfTest)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu_freertos/generated/tests/test_routine_ff01.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xFF01  (ResetToFactoryDefaults)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu_freertos/generated/tests/test_routine_ff10.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_routine_ff10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xFF10  (EraseNVM)
 # Session   : programming (ordinal 2)

--- a/examples/basic_ecu_freertos/generated/uds_init.c
+++ b/examples/basic_ecu_freertos/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -278,11 +278,22 @@ uds_status_t uds_generated_init(
      * DTC codes without corrupting the mirror.
      *
      * Soft-degrade behaviour:
-     *   UDS_STATUS_ERR_NOT_INITIALIZED → NVM not ready (first boot or NVM
+     *   UDS_STATUS_ERR_NOT_INITIALIZED  → NVM not ready (first boot or NVM
      *     subsystem failure). Treated as non-fatal: stack continues with all
      *     DTC status bytes at 0x00.
-     *   UDS_STATUS_ERR_PLATFORM        → NVM read error. Non-fatal: same
+     *   UDS_STATUS_ERR_PLATFORM         → NVM read error. Non-fatal: same
      *     degraded behaviour as first boot.
+     *   UDS_STATUS_ERR_NVM_DATA_CORRUPT → the persisted mirror record failed
+     *     an integrity check (bad tag/length/checksum — see dtc_mirror_load()).
+     *     Deliberately treated the same as "mirror absent" rather than as a
+     *     fatal boot error: the blast radius of trusting nothing from a
+     *     corrupt record is identical to the NOT_INITIALIZED case (DTC
+     *     history is lost, all status bytes stay at 0x00), which is the same
+     *     blast radius the original DTC-history-loss defect had. Aborting
+     *     uds_stack_init() over it would let a corrupted NVM record take down
+     *     the entire diagnostic stack, a materially larger failure than the
+     *     data loss it is guarding against. This is an explicit decision,
+     *     not an oversight — see Xaloqi/EDS#124.
      *
      * TRACEABILITY: REQ-DTC-NVM-01
      */
@@ -290,11 +301,14 @@ uds_status_t uds_generated_init(
         uds_status_t mirror_rc = dtc_mirror_load();
         if ((mirror_rc != UDS_STATUS_OK) &&
             (mirror_rc != UDS_STATUS_ERR_NOT_INITIALIZED) &&
-            (mirror_rc != UDS_STATUS_ERR_PLATFORM)) {
+            (mirror_rc != UDS_STATUS_ERR_PLATFORM) &&
+            (mirror_rc != UDS_STATUS_ERR_NVM_DATA_CORRUPT)) {
             /* Unexpected error — propagate to caller. */
             return mirror_rc;
         }
-        /* Soft-degrade: NOT_INITIALIZED and PLATFORM errors are non-fatal. */
+        /* Soft-degrade: NOT_INITIALIZED, PLATFORM, and NVM_DATA_CORRUPT
+         * errors are all non-fatal — the corrupted/unavailable mirror is
+         * discarded and boot continues with default (0x00) DTC status. */
     }
 
     /* ── Step 5.6: Register generated routine handlers ──────────────────────

--- a/examples/basic_ecu_freertos/generated/uds_init.h
+++ b/examples/basic_ecu_freertos/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/bms_ecu/generated/did_handlers.c
+++ b/examples/bms_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/bms_ecu/generated/did_handlers.h
+++ b/examples/bms_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/bms_ecu/generated/did_safety_wrappers.c
+++ b/examples/bms_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/bms_ecu/generated/did_safety_wrappers.h
+++ b/examples/bms_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/bms_ecu/generated/generated_config.h
+++ b/examples/bms_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "BMS_MainController"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:45Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:04Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/bms_ecu/generated/routine_handlers.c
+++ b/examples/bms_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: BMS_MainController  v1.0.0  Generated: 2026-08-29T11:04:45Z
+// ECU: BMS_MainController  v1.0.0  Generated: 2026-08-30T11:15:04Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/bms_ecu/generated/routine_handlers.h
+++ b/examples/bms_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: BMS_MainController  v1.0.0  Generated: 2026-08-29T11:04:45Z
+// ECU: BMS_MainController  v1.0.0  Generated: 2026-08-30T11:15:04Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/bms_ecu/generated/safety_config.h
+++ b/examples/bms_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/bms_ecu/generated/tests/README.md
+++ b/examples/bms_ecu/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-05-20T07:21:48Z by tools/testgen.py*
+*Generated 2026-08-30T11:15:04Z by tools/testgen.py*

--- a/examples/bms_ecu/generated/tests/conftest.py
+++ b/examples/bms_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/bms_ecu/generated/tests/conftest_firmware.py
+++ b/examples/bms_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/bms_ecu/generated/tests/test_did_d900.py
+++ b/examples/bms_ecu/generated/tests/test_did_d900.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xD900  (BMS_FaultFlagsBitmask)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_d901.py
+++ b/examples/bms_ecu/generated/tests/test_did_d901.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xD901  (BMS_FullChargeCapacity_Wh)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_d910.py
+++ b/examples/bms_ecu/generated/tests/test_did_d910.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xD910  (BMS_OVThreshold_mV)
 # Access    : read + write

--- a/examples/bms_ecu/generated/tests/test_did_d911.py
+++ b/examples/bms_ecu/generated/tests/test_did_d911.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xD911  (BMS_UVThreshold_mV)
 # Access    : read + write

--- a/examples/bms_ecu/generated/tests/test_did_db00.py
+++ b/examples/bms_ecu/generated/tests/test_did_db00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xDB00  (BMS_PackVoltage_mV)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_db01.py
+++ b/examples/bms_ecu/generated/tests/test_did_db01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xDB01  (BMS_PackCurrent_100mA)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_db02.py
+++ b/examples/bms_ecu/generated/tests/test_did_db02.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xDB02  (BMS_PackPower_10W)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_db03.py
+++ b/examples/bms_ecu/generated/tests/test_did_db03.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xDB03  (BMS_ContactorState)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_db04.py
+++ b/examples/bms_ecu/generated/tests/test_did_db04.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xDB04  (BMS_InsulationResistance_kOhm)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_dc01.py
+++ b/examples/bms_ecu/generated/tests/test_did_dc01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xDC01  (BMS_CellGroup1_Voltage_mV)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_dc02.py
+++ b/examples/bms_ecu/generated/tests/test_did_dc02.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xDC02  (BMS_CellGroup2_Voltage_mV)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_dc03.py
+++ b/examples/bms_ecu/generated/tests/test_did_dc03.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xDC03  (BMS_CellGroup3_Voltage_mV)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_dc04.py
+++ b/examples/bms_ecu/generated/tests/test_did_dc04.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xDC04  (BMS_CellGroup4_Voltage_mV)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_dd00.py
+++ b/examples/bms_ecu/generated/tests/test_did_dd00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xDD00  (BMS_MaxCellTemperature_degC)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_dd01.py
+++ b/examples/bms_ecu/generated/tests/test_did_dd01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xDD01  (BMS_MinCellTemperature_degC)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_dd02.py
+++ b/examples/bms_ecu/generated/tests/test_did_dd02.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xDD02  (BMS_CoolantInletTemperature_degC)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_dd03.py
+++ b/examples/bms_ecu/generated/tests/test_did_dd03.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xDD03  (BMS_BMSBoardTemperature_degC)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_de00.py
+++ b/examples/bms_ecu/generated/tests/test_did_de00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xDE00  (BMS_StateOfCharge_04pct)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_de01.py
+++ b/examples/bms_ecu/generated/tests/test_did_de01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xDE01  (BMS_StateOfHealth_04pct)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_de02.py
+++ b/examples/bms_ecu/generated/tests/test_did_de02.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xDE02  (BMS_BalancingStateBitmask)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_f187.py
+++ b/examples/bms_ecu/generated/tests/test_did_f187.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xF187  (VehicleManufacturerSparePartNumber)
 # Access    : read + write

--- a/examples/bms_ecu/generated/tests/test_did_f189.py
+++ b/examples/bms_ecu/generated/tests/test_did_f189.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xF189  (ECUSoftwareVersionNumber)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_f18c.py
+++ b/examples/bms_ecu/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xF18C  (ECUSerialNumber)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_f190.py
+++ b/examples/bms_ecu/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xF190  (VehicleIdentificationNumber)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_firmware_services.py
+++ b/examples/bms_ecu/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/bms_ecu/generated/tests/test_routine_bb00.py
+++ b/examples/bms_ecu/generated/tests/test_routine_bb00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xBB00  (BMS_SelfTest)
 # Session   : extended (ordinal 3)

--- a/examples/bms_ecu/generated/tests/test_routine_bb01.py
+++ b/examples/bms_ecu/generated/tests/test_routine_bb01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xBB01  (BMS_ForcePassiveBalance)
 # Session   : extended (ordinal 3)

--- a/examples/bms_ecu/generated/tests/test_routine_bb02.py
+++ b/examples/bms_ecu/generated/tests/test_routine_bb02.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xBB02  (BMS_ContactorFunctionalTest)
 # Session   : extended (ordinal 3)

--- a/examples/bms_ecu/generated/tests/test_routine_bb10.py
+++ b/examples/bms_ecu/generated/tests/test_routine_bb10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xBB10  (BMS_ResetSoCToFullCharge)
 # Session   : programming (ordinal 2)

--- a/examples/bms_ecu/generated/tests/test_routine_bb11.py
+++ b/examples/bms_ecu/generated/tests/test_routine_bb11.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xBB11  (BMS_ClearFaultHistory)
 # Session   : programming (ordinal 2)

--- a/examples/bms_ecu/generated/uds_init.c
+++ b/examples/bms_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -350,11 +350,22 @@ uds_status_t uds_generated_init(
      * DTC codes without corrupting the mirror.
      *
      * Soft-degrade behaviour:
-     *   UDS_STATUS_ERR_NOT_INITIALIZED → NVM not ready (first boot or NVM
+     *   UDS_STATUS_ERR_NOT_INITIALIZED  → NVM not ready (first boot or NVM
      *     subsystem failure). Treated as non-fatal: stack continues with all
      *     DTC status bytes at 0x00.
-     *   UDS_STATUS_ERR_PLATFORM        → NVM read error. Non-fatal: same
+     *   UDS_STATUS_ERR_PLATFORM         → NVM read error. Non-fatal: same
      *     degraded behaviour as first boot.
+     *   UDS_STATUS_ERR_NVM_DATA_CORRUPT → the persisted mirror record failed
+     *     an integrity check (bad tag/length/checksum — see dtc_mirror_load()).
+     *     Deliberately treated the same as "mirror absent" rather than as a
+     *     fatal boot error: the blast radius of trusting nothing from a
+     *     corrupt record is identical to the NOT_INITIALIZED case (DTC
+     *     history is lost, all status bytes stay at 0x00), which is the same
+     *     blast radius the original DTC-history-loss defect had. Aborting
+     *     uds_stack_init() over it would let a corrupted NVM record take down
+     *     the entire diagnostic stack, a materially larger failure than the
+     *     data loss it is guarding against. This is an explicit decision,
+     *     not an oversight — see Xaloqi/EDS#124.
      *
      * TRACEABILITY: REQ-DTC-NVM-01
      */
@@ -362,11 +373,14 @@ uds_status_t uds_generated_init(
         uds_status_t mirror_rc = dtc_mirror_load();
         if ((mirror_rc != UDS_STATUS_OK) &&
             (mirror_rc != UDS_STATUS_ERR_NOT_INITIALIZED) &&
-            (mirror_rc != UDS_STATUS_ERR_PLATFORM)) {
+            (mirror_rc != UDS_STATUS_ERR_PLATFORM) &&
+            (mirror_rc != UDS_STATUS_ERR_NVM_DATA_CORRUPT)) {
             /* Unexpected error — propagate to caller. */
             return mirror_rc;
         }
-        /* Soft-degrade: NOT_INITIALIZED and PLATFORM errors are non-fatal. */
+        /* Soft-degrade: NOT_INITIALIZED, PLATFORM, and NVM_DATA_CORRUPT
+         * errors are all non-fatal — the corrupted/unavailable mirror is
+         * discarded and boot continues with default (0x00) DTC status. */
     }
 
     /* ── Step 5.6: Register generated routine handlers ──────────────────────

--- a/examples/bms_ecu/generated/uds_init.h
+++ b/examples/bms_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/motor_controller_ecu/generated/did_handlers.c
+++ b/examples/motor_controller_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/motor_controller_ecu/generated/did_handlers.h
+++ b/examples/motor_controller_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/motor_controller_ecu/generated/did_safety_wrappers.c
+++ b/examples/motor_controller_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/motor_controller_ecu/generated/did_safety_wrappers.h
+++ b/examples/motor_controller_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/motor_controller_ecu/generated/generated_config.h
+++ b/examples/motor_controller_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "MotorController_Inverter"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:45Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:04Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/motor_controller_ecu/generated/routine_handlers.c
+++ b/examples/motor_controller_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: MotorController_Inverter  v1.0.0  Generated: 2026-08-29T11:04:45Z
+// ECU: MotorController_Inverter  v1.0.0  Generated: 2026-08-30T11:15:04Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/motor_controller_ecu/generated/routine_handlers.h
+++ b/examples/motor_controller_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: MotorController_Inverter  v1.0.0  Generated: 2026-08-29T11:04:45Z
+// ECU: MotorController_Inverter  v1.0.0  Generated: 2026-08-30T11:15:04Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/motor_controller_ecu/generated/safety_config.h
+++ b/examples/motor_controller_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/motor_controller_ecu/generated/tests/README.md
+++ b/examples/motor_controller_ecu/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-05-20T07:21:48Z by tools/testgen.py*
+*Generated 2026-08-30T11:15:04Z by tools/testgen.py*

--- a/examples/motor_controller_ecu/generated/tests/conftest.py
+++ b/examples/motor_controller_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/motor_controller_ecu/generated/tests/conftest_firmware.py
+++ b/examples/motor_controller_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/motor_controller_ecu/generated/tests/test_did_e001.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e001.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE001  (MC_RotorSpeed_rpm)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e002.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e002.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE002  (MC_TorqueDemand_01Nm)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e003.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e003.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE003  (MC_TorqueActual_01Nm)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e004.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e004.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE004  (MC_RotorElectricalAngle_raw)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e005.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e005.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE005  (MC_MechanicalPower_10W)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e101.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e101.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE101  (MC_PhaseA_Current_100mA)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e102.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e102.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE102  (MC_PhaseB_Current_100mA)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e103.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e103.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE103  (MC_PhaseC_Current_100mA)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e104.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e104.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE104  (MC_Iq_Current_100mA)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e105.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e105.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE105  (MC_Id_Current_100mA)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e201.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e201.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE201  (MC_DCLink_Voltage_mV)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e202.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e202.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE202  (MC_DCLink_Current_100mA)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e203.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e203.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE203  (MC_ModulationIndex_04pct)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e301.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e301.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE301  (MC_IGBT_PhaseA_JunctionTemp_degC)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e302.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e302.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE302  (MC_IGBT_PhaseB_JunctionTemp_degC)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e303.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e303.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE303  (MC_IGBT_PhaseC_JunctionTemp_degC)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e304.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e304.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE304  (MC_MotorStatorTemp_degC)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e305.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e305.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE305  (MC_CoolantInletTemp_degC)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e401.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e401.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE401  (MC_FaultStatusBitmask)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e402.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e402.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE402  (MC_OperatingMode)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e501.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e501.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE501  (MC_ResolverOffset_raw)
 # Access    : read + write

--- a/examples/motor_controller_ecu/generated/tests/test_did_e502.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e502.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE502  (MC_TorqueScalingFactor_01pct)
 # Access    : read + write

--- a/examples/motor_controller_ecu/generated/tests/test_did_e503.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e503.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xE503  (MC_CurrentSensorTrim_100uA)
 # Access    : read + write

--- a/examples/motor_controller_ecu/generated/tests/test_did_f187.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_f187.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xF187  (VehicleManufacturerSparePartNumber)
 # Access    : read + write

--- a/examples/motor_controller_ecu/generated/tests/test_did_f189.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_f189.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xF189  (ECUSoftwareVersionNumber)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_f18c.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xF18C  (ECUSerialNumber)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_f190.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xF190  (VehicleIdentificationNumber)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_firmware_services.py
+++ b/examples/motor_controller_ecu/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/motor_controller_ecu/generated/tests/test_routine_cc00.py
+++ b/examples/motor_controller_ecu/generated/tests/test_routine_cc00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xCC00  (MC_SelfTest)
 # Session   : extended (ordinal 3)

--- a/examples/motor_controller_ecu/generated/tests/test_routine_cc01.py
+++ b/examples/motor_controller_ecu/generated/tests/test_routine_cc01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xCC01  (MC_PhaseBalanceTest)
 # Session   : extended (ordinal 3)

--- a/examples/motor_controller_ecu/generated/tests/test_routine_cc02.py
+++ b/examples/motor_controller_ecu/generated/tests/test_routine_cc02.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xCC02  (MC_GateDriverFunctionalTest)
 # Session   : extended (ordinal 3)

--- a/examples/motor_controller_ecu/generated/tests/test_routine_cc10.py
+++ b/examples/motor_controller_ecu/generated/tests/test_routine_cc10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xCC10  (MC_ResolverOffsetCalibration)
 # Session   : programming (ordinal 2)

--- a/examples/motor_controller_ecu/generated/tests/test_routine_cc11.py
+++ b/examples/motor_controller_ecu/generated/tests/test_routine_cc11.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xCC11  (MC_ForceMotorInhibit)
 # Session   : extended (ordinal 3)

--- a/examples/motor_controller_ecu/generated/tests/test_routine_cc12.py
+++ b/examples/motor_controller_ecu/generated/tests/test_routine_cc12.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xCC12  (MC_ClearFaultHistory)
 # Session   : programming (ordinal 2)

--- a/examples/motor_controller_ecu/generated/uds_init.c
+++ b/examples/motor_controller_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -350,11 +350,22 @@ uds_status_t uds_generated_init(
      * DTC codes without corrupting the mirror.
      *
      * Soft-degrade behaviour:
-     *   UDS_STATUS_ERR_NOT_INITIALIZED → NVM not ready (first boot or NVM
+     *   UDS_STATUS_ERR_NOT_INITIALIZED  → NVM not ready (first boot or NVM
      *     subsystem failure). Treated as non-fatal: stack continues with all
      *     DTC status bytes at 0x00.
-     *   UDS_STATUS_ERR_PLATFORM        → NVM read error. Non-fatal: same
+     *   UDS_STATUS_ERR_PLATFORM         → NVM read error. Non-fatal: same
      *     degraded behaviour as first boot.
+     *   UDS_STATUS_ERR_NVM_DATA_CORRUPT → the persisted mirror record failed
+     *     an integrity check (bad tag/length/checksum — see dtc_mirror_load()).
+     *     Deliberately treated the same as "mirror absent" rather than as a
+     *     fatal boot error: the blast radius of trusting nothing from a
+     *     corrupt record is identical to the NOT_INITIALIZED case (DTC
+     *     history is lost, all status bytes stay at 0x00), which is the same
+     *     blast radius the original DTC-history-loss defect had. Aborting
+     *     uds_stack_init() over it would let a corrupted NVM record take down
+     *     the entire diagnostic stack, a materially larger failure than the
+     *     data loss it is guarding against. This is an explicit decision,
+     *     not an oversight — see Xaloqi/EDS#124.
      *
      * TRACEABILITY: REQ-DTC-NVM-01
      */
@@ -362,11 +373,14 @@ uds_status_t uds_generated_init(
         uds_status_t mirror_rc = dtc_mirror_load();
         if ((mirror_rc != UDS_STATUS_OK) &&
             (mirror_rc != UDS_STATUS_ERR_NOT_INITIALIZED) &&
-            (mirror_rc != UDS_STATUS_ERR_PLATFORM)) {
+            (mirror_rc != UDS_STATUS_ERR_PLATFORM) &&
+            (mirror_rc != UDS_STATUS_ERR_NVM_DATA_CORRUPT)) {
             /* Unexpected error — propagate to caller. */
             return mirror_rc;
         }
-        /* Soft-degrade: NOT_INITIALIZED and PLATFORM errors are non-fatal. */
+        /* Soft-degrade: NOT_INITIALIZED, PLATFORM, and NVM_DATA_CORRUPT
+         * errors are all non-fatal — the corrupted/unavailable mirror is
+         * discarded and boot continues with default (0x00) DTC status. */
     }
 
     /* ── Step 5.6: Register generated routine handlers ──────────────────────

--- a/examples/motor_controller_ecu/generated/uds_init.h
+++ b/examples/motor_controller_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/robot_joint_controller_ecu/generated/did_handlers.c
+++ b/examples/robot_joint_controller_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/robot_joint_controller_ecu/generated/did_handlers.h
+++ b/examples/robot_joint_controller_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/robot_joint_controller_ecu/generated/did_safety_wrappers.c
+++ b/examples/robot_joint_controller_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/robot_joint_controller_ecu/generated/did_safety_wrappers.h
+++ b/examples/robot_joint_controller_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/robot_joint_controller_ecu/generated/generated_config.h
+++ b/examples/robot_joint_controller_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "RobotJointController"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:45Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:04Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/robot_joint_controller_ecu/generated/generated_files_phase3.json
+++ b/examples/robot_joint_controller_ecu/generated/generated_files_phase3.json
@@ -1,8 +1,8 @@
 {
   "phase": "Phase 3",
-  "generated_at": "2026-04-30T08:05:13Z",
-  "config_source": "/workspaces/EDS/examples/robot_joint_controller_ecu/diagnostics_config.yaml",
-  "output_dir": "/workspaces/EDS-toolchain/examples/robot_joint_controller_ecu/generated",
+  "generated_at": "2026-08-30T11:15:04Z",
+  "config_source": "/home/raul/EDS-wt-124-regen/examples/robot_joint_controller_ecu/diagnostics_config.yaml",
+  "output_dir": "/home/raul/EDS-wt-124-regen/examples/robot_joint_controller_ecu/generated",
   "safety_wrappers": true,
   "asil_level": "B",
   "files": [
@@ -37,5 +37,5 @@
     "examples/robot_joint_controller_ecu/generated/tests/requirements_testgen.txt",
     "examples/robot_joint_controller_ecu/generated/tests/README.md"
   ],
-  "generator": "/workspaces/EDS/tools/codegen.py"
+  "generator": "/home/raul/EDS-wt-124-regen/tools/codegen.py"
 }

--- a/examples/robot_joint_controller_ecu/generated/routine_handlers.c
+++ b/examples/robot_joint_controller_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: RobotJointController  v1.0.0  Generated: 2026-08-29T11:04:45Z
+// ECU: RobotJointController  v1.0.0  Generated: 2026-08-30T11:15:04Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/robot_joint_controller_ecu/generated/routine_handlers.h
+++ b/examples/robot_joint_controller_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: RobotJointController  v1.0.0  Generated: 2026-08-29T11:04:45Z
+// ECU: RobotJointController  v1.0.0  Generated: 2026-08-30T11:15:04Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/robot_joint_controller_ecu/generated/safety_config.h
+++ b/examples/robot_joint_controller_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/robot_joint_controller_ecu/generated/tests/README.md
+++ b/examples/robot_joint_controller_ecu/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-05-20T07:21:49Z by tools/testgen.py*
+*Generated 2026-08-30T11:15:04Z by tools/testgen.py*

--- a/examples/robot_joint_controller_ecu/generated/tests/conftest.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/robot_joint_controller_ecu/generated/tests/conftest_firmware.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_a000.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_a000.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xA000  (Axis0Position)
 # Access    : read

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_a001.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_a001.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xA001  (Axis0Velocity)
 # Access    : read

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_a002.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_a002.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xA002  (Axis0Torque)
 # Access    : read

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_a003.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_a003.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xA003  (Axis0MotorTemperature)
 # Access    : read

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_a004.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_a004.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xA004  (Axis0StatusBitmask)
 # Access    : read

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_a010.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_a010.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xA010  (Axis0PositionOffset)
 # Access    : read + write

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_a011.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_a011.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xA011  (Axis0SoftLimitPositive)
 # Access    : read + write

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_a012.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_a012.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xA012  (Axis0SoftLimitNegative)
 # Access    : read + write

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_f18c.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xF18C  (ControllerSerialNumber)
 # Access    : read

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_f190.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # DID       : 0xF190  (RobotSerialNumber)
 # Access    : read

--- a/examples/robot_joint_controller_ecu/generated/tests/test_firmware_services.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/robot_joint_controller_ecu/generated/tests/test_routine_ff00.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xFF00  (HomeAxis0)
 # Session   : extended (ordinal 3)

--- a/examples/robot_joint_controller_ecu/generated/tests/test_routine_ff01.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xFF01  (ApplyCalibration)
 # Session   : extended (ordinal 3)

--- a/examples/robot_joint_controller_ecu/generated/tests/test_routine_ff02.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_routine_ff02.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T11:15:04Z
 #
 # Routine   : 0xFF02  (ClearFaultHistory)
 # Session   : extended (ordinal 3)

--- a/examples/robot_joint_controller_ecu/generated/uds_init.c
+++ b/examples/robot_joint_controller_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -305,11 +305,22 @@ uds_status_t uds_generated_init(
      * DTC codes without corrupting the mirror.
      *
      * Soft-degrade behaviour:
-     *   UDS_STATUS_ERR_NOT_INITIALIZED → NVM not ready (first boot or NVM
+     *   UDS_STATUS_ERR_NOT_INITIALIZED  → NVM not ready (first boot or NVM
      *     subsystem failure). Treated as non-fatal: stack continues with all
      *     DTC status bytes at 0x00.
-     *   UDS_STATUS_ERR_PLATFORM        → NVM read error. Non-fatal: same
+     *   UDS_STATUS_ERR_PLATFORM         → NVM read error. Non-fatal: same
      *     degraded behaviour as first boot.
+     *   UDS_STATUS_ERR_NVM_DATA_CORRUPT → the persisted mirror record failed
+     *     an integrity check (bad tag/length/checksum — see dtc_mirror_load()).
+     *     Deliberately treated the same as "mirror absent" rather than as a
+     *     fatal boot error: the blast radius of trusting nothing from a
+     *     corrupt record is identical to the NOT_INITIALIZED case (DTC
+     *     history is lost, all status bytes stay at 0x00), which is the same
+     *     blast radius the original DTC-history-loss defect had. Aborting
+     *     uds_stack_init() over it would let a corrupted NVM record take down
+     *     the entire diagnostic stack, a materially larger failure than the
+     *     data loss it is guarding against. This is an explicit decision,
+     *     not an oversight — see Xaloqi/EDS#124.
      *
      * TRACEABILITY: REQ-DTC-NVM-01
      */
@@ -317,11 +328,14 @@ uds_status_t uds_generated_init(
         uds_status_t mirror_rc = dtc_mirror_load();
         if ((mirror_rc != UDS_STATUS_OK) &&
             (mirror_rc != UDS_STATUS_ERR_NOT_INITIALIZED) &&
-            (mirror_rc != UDS_STATUS_ERR_PLATFORM)) {
+            (mirror_rc != UDS_STATUS_ERR_PLATFORM) &&
+            (mirror_rc != UDS_STATUS_ERR_NVM_DATA_CORRUPT)) {
             /* Unexpected error — propagate to caller. */
             return mirror_rc;
         }
-        /* Soft-degrade: NOT_INITIALIZED and PLATFORM errors are non-fatal. */
+        /* Soft-degrade: NOT_INITIALIZED, PLATFORM, and NVM_DATA_CORRUPT
+         * errors are all non-fatal — the corrupted/unavailable mirror is
+         * discarded and boot continues with default (0x00) DTC status. */
     }
 
     /* ── Step 5.6: Register generated routine handlers ──────────────────────

--- a/examples/robot_joint_controller_ecu/generated/uds_init.h
+++ b/examples/robot_joint_controller_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:04Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/safeboot_ecu/generated/did_handlers.c
+++ b/examples/safeboot_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/safeboot_ecu/generated/did_handlers.h
+++ b/examples/safeboot_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/safeboot_ecu/generated/did_safety_wrappers.c
+++ b/examples/safeboot_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:05Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/safeboot_ecu/generated/did_safety_wrappers.h
+++ b/examples/safeboot_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:05Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/safeboot_ecu/generated/generated_config.h
+++ b/examples/safeboot_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "SafeBootECU"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:45Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:05Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/safeboot_ecu/generated/routine_handlers.c
+++ b/examples/safeboot_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: SafeBootECU  v1.0.0  Generated: 2026-08-29T11:04:45Z
+// ECU: SafeBootECU  v1.0.0  Generated: 2026-08-30T11:15:05Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/safeboot_ecu/generated/routine_handlers.h
+++ b/examples/safeboot_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: SafeBootECU  v1.0.0  Generated: 2026-08-29T11:04:45Z
+// ECU: SafeBootECU  v1.0.0  Generated: 2026-08-30T11:15:05Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/safeboot_ecu/generated/safety_config.h
+++ b/examples/safeboot_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:05Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/safeboot_ecu/generated/tests/README.md
+++ b/examples/safeboot_ecu/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-05-20T07:21:49Z by tools/testgen.py*
+*Generated 2026-08-30T11:15:05Z by tools/testgen.py*

--- a/examples/safeboot_ecu/generated/tests/conftest.py
+++ b/examples/safeboot_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/safeboot_ecu/generated/tests/conftest_firmware.py
+++ b/examples/safeboot_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/safeboot_ecu/generated/tests/test_did_f181.py
+++ b/examples/safeboot_ecu/generated/tests/test_did_f181.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xF181  (ApplicationSoftwareIdentification)
 # Access    : read

--- a/examples/safeboot_ecu/generated/tests/test_did_f186.py
+++ b/examples/safeboot_ecu/generated/tests/test_did_f186.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xF186  (ActiveDiagnosticSession)
 # Access    : read

--- a/examples/safeboot_ecu/generated/tests/test_did_f18a.py
+++ b/examples/safeboot_ecu/generated/tests/test_did_f18a.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xF18A  (SystemSupplierIdentifier)
 # Access    : read

--- a/examples/safeboot_ecu/generated/tests/test_did_f18c.py
+++ b/examples/safeboot_ecu/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xF18C  (ECUSerialNumber)
 # Access    : read

--- a/examples/safeboot_ecu/generated/tests/test_did_f190.py
+++ b/examples/safeboot_ecu/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xF190  (VehicleIdentificationNumber)
 # Access    : read

--- a/examples/safeboot_ecu/generated/tests/test_firmware_services.py
+++ b/examples/safeboot_ecu/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/safeboot_ecu/generated/tests/test_routine_ff00.py
+++ b/examples/safeboot_ecu/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # Routine   : 0xFF00  (CheckProgrammingPreconditions)
 # Session   : extended (ordinal 3)

--- a/examples/safeboot_ecu/generated/tests/test_routine_ff01.py
+++ b/examples/safeboot_ecu/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # Routine   : 0xFF01  (VerifyBootloaderIntegrity)
 # Session   : programming (ordinal 2)

--- a/examples/safeboot_ecu/generated/uds_init.c
+++ b/examples/safeboot_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -289,11 +289,22 @@ uds_status_t uds_generated_init(
      * DTC codes without corrupting the mirror.
      *
      * Soft-degrade behaviour:
-     *   UDS_STATUS_ERR_NOT_INITIALIZED → NVM not ready (first boot or NVM
+     *   UDS_STATUS_ERR_NOT_INITIALIZED  → NVM not ready (first boot or NVM
      *     subsystem failure). Treated as non-fatal: stack continues with all
      *     DTC status bytes at 0x00.
-     *   UDS_STATUS_ERR_PLATFORM        → NVM read error. Non-fatal: same
+     *   UDS_STATUS_ERR_PLATFORM         → NVM read error. Non-fatal: same
      *     degraded behaviour as first boot.
+     *   UDS_STATUS_ERR_NVM_DATA_CORRUPT → the persisted mirror record failed
+     *     an integrity check (bad tag/length/checksum — see dtc_mirror_load()).
+     *     Deliberately treated the same as "mirror absent" rather than as a
+     *     fatal boot error: the blast radius of trusting nothing from a
+     *     corrupt record is identical to the NOT_INITIALIZED case (DTC
+     *     history is lost, all status bytes stay at 0x00), which is the same
+     *     blast radius the original DTC-history-loss defect had. Aborting
+     *     uds_stack_init() over it would let a corrupted NVM record take down
+     *     the entire diagnostic stack, a materially larger failure than the
+     *     data loss it is guarding against. This is an explicit decision,
+     *     not an oversight — see Xaloqi/EDS#124.
      *
      * TRACEABILITY: REQ-DTC-NVM-01
      */
@@ -301,11 +312,14 @@ uds_status_t uds_generated_init(
         uds_status_t mirror_rc = dtc_mirror_load();
         if ((mirror_rc != UDS_STATUS_OK) &&
             (mirror_rc != UDS_STATUS_ERR_NOT_INITIALIZED) &&
-            (mirror_rc != UDS_STATUS_ERR_PLATFORM)) {
+            (mirror_rc != UDS_STATUS_ERR_PLATFORM) &&
+            (mirror_rc != UDS_STATUS_ERR_NVM_DATA_CORRUPT)) {
             /* Unexpected error — propagate to caller. */
             return mirror_rc;
         }
-        /* Soft-degrade: NOT_INITIALIZED and PLATFORM errors are non-fatal. */
+        /* Soft-degrade: NOT_INITIALIZED, PLATFORM, and NVM_DATA_CORRUPT
+         * errors are all non-fatal — the corrupted/unavailable mirror is
+         * discarded and boot continues with default (0x00) DTC status. */
     }
 
     /* ── Step 5.6: Register generated routine handlers ──────────────────────

--- a/examples/safeboot_ecu/generated/uds_init.h
+++ b/examples/safeboot_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:45Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/safeboot_freertos_ecu/generated/did_handlers.c
+++ b/examples/safeboot_freertos_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootFreeRTOSECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/safeboot_freertos_ecu/generated/did_handlers.h
+++ b/examples/safeboot_freertos_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootFreeRTOSECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/safeboot_freertos_ecu/generated/did_safety_wrappers.c
+++ b/examples/safeboot_freertos_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootFreeRTOSECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/safeboot_freertos_ecu/generated/did_safety_wrappers.h
+++ b/examples/safeboot_freertos_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootFreeRTOSECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/safeboot_freertos_ecu/generated/generated_config.h
+++ b/examples/safeboot_freertos_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootFreeRTOSECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "SafeBootFreeRTOSECU"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:46Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:05Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/safeboot_freertos_ecu/generated/routine_handlers.c
+++ b/examples/safeboot_freertos_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: SafeBootFreeRTOSECU  v1.0.0  Generated: 2026-08-29T11:04:46Z
+// ECU: SafeBootFreeRTOSECU  v1.0.0  Generated: 2026-08-30T11:15:05Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/safeboot_freertos_ecu/generated/routine_handlers.h
+++ b/examples/safeboot_freertos_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: SafeBootFreeRTOSECU  v1.0.0  Generated: 2026-08-29T11:04:46Z
+// ECU: SafeBootFreeRTOSECU  v1.0.0  Generated: 2026-08-30T11:15:05Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/safeboot_freertos_ecu/generated/safety_config.h
+++ b/examples/safeboot_freertos_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootFreeRTOSECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/safeboot_freertos_ecu/generated/uds_init.c
+++ b/examples/safeboot_freertos_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootFreeRTOSECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -289,11 +289,22 @@ uds_status_t uds_generated_init(
      * DTC codes without corrupting the mirror.
      *
      * Soft-degrade behaviour:
-     *   UDS_STATUS_ERR_NOT_INITIALIZED → NVM not ready (first boot or NVM
+     *   UDS_STATUS_ERR_NOT_INITIALIZED  → NVM not ready (first boot or NVM
      *     subsystem failure). Treated as non-fatal: stack continues with all
      *     DTC status bytes at 0x00.
-     *   UDS_STATUS_ERR_PLATFORM        → NVM read error. Non-fatal: same
+     *   UDS_STATUS_ERR_PLATFORM         → NVM read error. Non-fatal: same
      *     degraded behaviour as first boot.
+     *   UDS_STATUS_ERR_NVM_DATA_CORRUPT → the persisted mirror record failed
+     *     an integrity check (bad tag/length/checksum — see dtc_mirror_load()).
+     *     Deliberately treated the same as "mirror absent" rather than as a
+     *     fatal boot error: the blast radius of trusting nothing from a
+     *     corrupt record is identical to the NOT_INITIALIZED case (DTC
+     *     history is lost, all status bytes stay at 0x00), which is the same
+     *     blast radius the original DTC-history-loss defect had. Aborting
+     *     uds_stack_init() over it would let a corrupted NVM record take down
+     *     the entire diagnostic stack, a materially larger failure than the
+     *     data loss it is guarding against. This is an explicit decision,
+     *     not an oversight — see Xaloqi/EDS#124.
      *
      * TRACEABILITY: REQ-DTC-NVM-01
      */
@@ -301,11 +312,14 @@ uds_status_t uds_generated_init(
         uds_status_t mirror_rc = dtc_mirror_load();
         if ((mirror_rc != UDS_STATUS_OK) &&
             (mirror_rc != UDS_STATUS_ERR_NOT_INITIALIZED) &&
-            (mirror_rc != UDS_STATUS_ERR_PLATFORM)) {
+            (mirror_rc != UDS_STATUS_ERR_PLATFORM) &&
+            (mirror_rc != UDS_STATUS_ERR_NVM_DATA_CORRUPT)) {
             /* Unexpected error — propagate to caller. */
             return mirror_rc;
         }
-        /* Soft-degrade: NOT_INITIALIZED and PLATFORM errors are non-fatal. */
+        /* Soft-degrade: NOT_INITIALIZED, PLATFORM, and NVM_DATA_CORRUPT
+         * errors are all non-fatal — the corrupted/unavailable mirror is
+         * discarded and boot continues with default (0x00) DTC status. */
     }
 
     /* ── Step 5.6: Register generated routine handlers ──────────────────────

--- a/examples/safeboot_freertos_ecu/generated/uds_init.h
+++ b/examples/safeboot_freertos_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootFreeRTOSECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/sensor_ecu/generated/did_handlers.c
+++ b/examples/sensor_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/sensor_ecu/generated/did_handlers.h
+++ b/examples/sensor_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/sensor_ecu/generated/did_safety_wrappers.c
+++ b/examples/sensor_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/sensor_ecu/generated/did_safety_wrappers.h
+++ b/examples/sensor_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/sensor_ecu/generated/generated_config.h
+++ b/examples/sensor_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "SensorECU"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:46Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:05Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/sensor_ecu/generated/generated_files_phase3.json
+++ b/examples/sensor_ecu/generated/generated_files_phase3.json
@@ -1,8 +1,8 @@
 {
   "phase": "Phase 3",
-  "generated_at": "2026-04-30T12:10:34Z",
-  "config_source": "/workspaces/EDS-toolchain/examples/sensor_ecu/diagnostics_config.yaml",
-  "output_dir": "/workspaces/EDS-toolchain/examples/sensor_ecu/generated",
+  "generated_at": "2026-08-30T11:15:05Z",
+  "config_source": "/home/raul/EDS-wt-124-regen/examples/sensor_ecu/diagnostics_config.yaml",
+  "output_dir": "/home/raul/EDS-wt-124-regen/examples/sensor_ecu/generated",
   "safety_wrappers": true,
   "asil_level": "B",
   "files": [
@@ -33,5 +33,5 @@
     "examples/sensor_ecu/generated/tests/requirements_testgen.txt",
     "examples/sensor_ecu/generated/tests/README.md"
   ],
-  "generator": "/workspaces/EDS/tools/codegen.py"
+  "generator": "/home/raul/EDS-wt-124-regen/tools/codegen.py"
 }

--- a/examples/sensor_ecu/generated/routine_handlers.c
+++ b/examples/sensor_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: SensorECU  v1.0.0  Generated: 2026-08-29T11:04:46Z
+// ECU: SensorECU  v1.0.0  Generated: 2026-08-30T11:15:05Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/sensor_ecu/generated/routine_handlers.h
+++ b/examples/sensor_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: SensorECU  v1.0.0  Generated: 2026-08-29T11:04:46Z
+// ECU: SensorECU  v1.0.0  Generated: 2026-08-30T11:15:05Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/sensor_ecu/generated/safety_config.h
+++ b/examples/sensor_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/sensor_ecu/generated/tests/README.md
+++ b/examples/sensor_ecu/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-05-20T07:21:49Z by tools/testgen.py*
+*Generated 2026-08-30T11:15:05Z by tools/testgen.py*

--- a/examples/sensor_ecu/generated/tests/conftest.py
+++ b/examples/sensor_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/sensor_ecu/generated/tests/conftest_firmware.py
+++ b/examples/sensor_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/sensor_ecu/generated/tests/test_did_d001.py
+++ b/examples/sensor_ecu/generated/tests/test_did_d001.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xD001  (AmbientTemperature)
 # Access    : read

--- a/examples/sensor_ecu/generated/tests/test_did_d002.py
+++ b/examples/sensor_ecu/generated/tests/test_did_d002.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xD002  (SupplyVoltage)
 # Access    : read

--- a/examples/sensor_ecu/generated/tests/test_did_d003.py
+++ b/examples/sensor_ecu/generated/tests/test_did_d003.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xD003  (SensorStatusBitmask)
 # Access    : read

--- a/examples/sensor_ecu/generated/tests/test_did_d010.py
+++ b/examples/sensor_ecu/generated/tests/test_did_d010.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xD010  (TemperatureThresholdHigh)
 # Access    : read + write

--- a/examples/sensor_ecu/generated/tests/test_did_d011.py
+++ b/examples/sensor_ecu/generated/tests/test_did_d011.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xD011  (TemperatureThresholdLow)
 # Access    : read + write

--- a/examples/sensor_ecu/generated/tests/test_did_f18c.py
+++ b/examples/sensor_ecu/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xF18C  (ECUSerialNumber)
 # Access    : read

--- a/examples/sensor_ecu/generated/tests/test_did_f190.py
+++ b/examples/sensor_ecu/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xF190  (VehicleIdentificationNumber)
 # Access    : read

--- a/examples/sensor_ecu/generated/tests/test_firmware_services.py
+++ b/examples/sensor_ecu/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/sensor_ecu/generated/tests/test_routine_ff00.py
+++ b/examples/sensor_ecu/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # Routine   : 0xFF00  (ResetSensorCalibration)
 # Session   : extended (ordinal 3)

--- a/examples/sensor_ecu/generated/tests/test_routine_ff01.py
+++ b/examples/sensor_ecu/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # Routine   : 0xFF01  (SensorSelfTest)
 # Session   : extended (ordinal 3)

--- a/examples/sensor_ecu/generated/uds_init.c
+++ b/examples/sensor_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -296,11 +296,22 @@ uds_status_t uds_generated_init(
      * DTC codes without corrupting the mirror.
      *
      * Soft-degrade behaviour:
-     *   UDS_STATUS_ERR_NOT_INITIALIZED → NVM not ready (first boot or NVM
+     *   UDS_STATUS_ERR_NOT_INITIALIZED  → NVM not ready (first boot or NVM
      *     subsystem failure). Treated as non-fatal: stack continues with all
      *     DTC status bytes at 0x00.
-     *   UDS_STATUS_ERR_PLATFORM        → NVM read error. Non-fatal: same
+     *   UDS_STATUS_ERR_PLATFORM         → NVM read error. Non-fatal: same
      *     degraded behaviour as first boot.
+     *   UDS_STATUS_ERR_NVM_DATA_CORRUPT → the persisted mirror record failed
+     *     an integrity check (bad tag/length/checksum — see dtc_mirror_load()).
+     *     Deliberately treated the same as "mirror absent" rather than as a
+     *     fatal boot error: the blast radius of trusting nothing from a
+     *     corrupt record is identical to the NOT_INITIALIZED case (DTC
+     *     history is lost, all status bytes stay at 0x00), which is the same
+     *     blast radius the original DTC-history-loss defect had. Aborting
+     *     uds_stack_init() over it would let a corrupted NVM record take down
+     *     the entire diagnostic stack, a materially larger failure than the
+     *     data loss it is guarding against. This is an explicit decision,
+     *     not an oversight — see Xaloqi/EDS#124.
      *
      * TRACEABILITY: REQ-DTC-NVM-01
      */
@@ -308,11 +319,14 @@ uds_status_t uds_generated_init(
         uds_status_t mirror_rc = dtc_mirror_load();
         if ((mirror_rc != UDS_STATUS_OK) &&
             (mirror_rc != UDS_STATUS_ERR_NOT_INITIALIZED) &&
-            (mirror_rc != UDS_STATUS_ERR_PLATFORM)) {
+            (mirror_rc != UDS_STATUS_ERR_PLATFORM) &&
+            (mirror_rc != UDS_STATUS_ERR_NVM_DATA_CORRUPT)) {
             /* Unexpected error — propagate to caller. */
             return mirror_rc;
         }
-        /* Soft-degrade: NOT_INITIALIZED and PLATFORM errors are non-fatal. */
+        /* Soft-degrade: NOT_INITIALIZED, PLATFORM, and NVM_DATA_CORRUPT
+         * errors are all non-fatal — the corrupted/unavailable mirror is
+         * discarded and boot continues with default (0x00) DTC status. */
     }
 
     /* ── Step 5.6: Register generated routine handlers ──────────────────────

--- a/examples/sensor_ecu/generated/uds_init.h
+++ b/examples/sensor_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/sensor_ecu_freertos/generated/did_handlers.c
+++ b/examples/sensor_ecu_freertos/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/sensor_ecu_freertos/generated/did_handlers.h
+++ b/examples/sensor_ecu_freertos/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/sensor_ecu_freertos/generated/did_safety_wrappers.c
+++ b/examples/sensor_ecu_freertos/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/sensor_ecu_freertos/generated/did_safety_wrappers.h
+++ b/examples/sensor_ecu_freertos/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/sensor_ecu_freertos/generated/generated_config.h
+++ b/examples/sensor_ecu_freertos/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "SensorECU"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-29T11:04:46Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:05Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/sensor_ecu_freertos/generated/generated_files_phase3.json
+++ b/examples/sensor_ecu_freertos/generated/generated_files_phase3.json
@@ -1,8 +1,8 @@
 {
   "phase": "Phase 3",
-  "generated_at": "2026-04-30T08:05:13Z",
-  "config_source": "/workspaces/EDS/examples/sensor_ecu_freertos/diagnostics_config.yaml",
-  "output_dir": "/workspaces/EDS-toolchain/examples/sensor_ecu_freertos/generated",
+  "generated_at": "2026-08-30T11:15:05Z",
+  "config_source": "/home/raul/EDS-wt-124-regen/examples/sensor_ecu_freertos/diagnostics_config.yaml",
+  "output_dir": "/home/raul/EDS-wt-124-regen/examples/sensor_ecu_freertos/generated",
   "safety_wrappers": true,
   "asil_level": "B",
   "files": [
@@ -33,5 +33,5 @@
     "examples/sensor_ecu_freertos/generated/tests/requirements_testgen.txt",
     "examples/sensor_ecu_freertos/generated/tests/README.md"
   ],
-  "generator": "/workspaces/EDS/tools/codegen.py"
+  "generator": "/home/raul/EDS-wt-124-regen/tools/codegen.py"
 }

--- a/examples/sensor_ecu_freertos/generated/routine_handlers.c
+++ b/examples/sensor_ecu_freertos/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: SensorECU  v1.0.0  Generated: 2026-08-29T11:04:46Z
+// ECU: SensorECU  v1.0.0  Generated: 2026-08-30T11:15:05Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/sensor_ecu_freertos/generated/routine_handlers.h
+++ b/examples/sensor_ecu_freertos/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: SensorECU  v1.0.0  Generated: 2026-08-29T11:04:46Z
+// ECU: SensorECU  v1.0.0  Generated: 2026-08-30T11:15:05Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/sensor_ecu_freertos/generated/safety_config.h
+++ b/examples/sensor_ecu_freertos/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/sensor_ecu_freertos/generated/tests/README.md
+++ b/examples/sensor_ecu_freertos/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-05-20T07:21:49Z by tools/testgen.py*
+*Generated 2026-08-30T11:15:05Z by tools/testgen.py*

--- a/examples/sensor_ecu_freertos/generated/tests/conftest.py
+++ b/examples/sensor_ecu_freertos/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/sensor_ecu_freertos/generated/tests/conftest_firmware.py
+++ b/examples/sensor_ecu_freertos/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/sensor_ecu_freertos/generated/tests/test_did_d001.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_did_d001.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xD001  (AmbientTemperature)
 # Access    : read

--- a/examples/sensor_ecu_freertos/generated/tests/test_did_d002.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_did_d002.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xD002  (SupplyVoltage)
 # Access    : read

--- a/examples/sensor_ecu_freertos/generated/tests/test_did_d003.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_did_d003.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xD003  (SensorStatusBitmask)
 # Access    : read

--- a/examples/sensor_ecu_freertos/generated/tests/test_did_d010.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_did_d010.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xD010  (TemperatureThresholdHigh)
 # Access    : read + write

--- a/examples/sensor_ecu_freertos/generated/tests/test_did_d011.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_did_d011.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xD011  (TemperatureThresholdLow)
 # Access    : read + write

--- a/examples/sensor_ecu_freertos/generated/tests/test_did_f18c.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xF18C  (ECUSerialNumber)
 # Access    : read

--- a/examples/sensor_ecu_freertos/generated/tests/test_did_f190.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # DID       : 0xF190  (VehicleIdentificationNumber)
 # Access    : read

--- a/examples/sensor_ecu_freertos/generated/tests/test_firmware_services.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/sensor_ecu_freertos/generated/tests/test_routine_ff00.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # Routine   : 0xFF00  (ResetSensorCalibration)
 # Session   : extended (ordinal 3)

--- a/examples/sensor_ecu_freertos/generated/tests/test_routine_ff01.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T11:15:05Z
 #
 # Routine   : 0xFF01  (SensorSelfTest)
 # Session   : extended (ordinal 3)

--- a/examples/sensor_ecu_freertos/generated/uds_init.c
+++ b/examples/sensor_ecu_freertos/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.
@@ -296,11 +296,22 @@ uds_status_t uds_generated_init(
      * DTC codes without corrupting the mirror.
      *
      * Soft-degrade behaviour:
-     *   UDS_STATUS_ERR_NOT_INITIALIZED → NVM not ready (first boot or NVM
+     *   UDS_STATUS_ERR_NOT_INITIALIZED  → NVM not ready (first boot or NVM
      *     subsystem failure). Treated as non-fatal: stack continues with all
      *     DTC status bytes at 0x00.
-     *   UDS_STATUS_ERR_PLATFORM        → NVM read error. Non-fatal: same
+     *   UDS_STATUS_ERR_PLATFORM         → NVM read error. Non-fatal: same
      *     degraded behaviour as first boot.
+     *   UDS_STATUS_ERR_NVM_DATA_CORRUPT → the persisted mirror record failed
+     *     an integrity check (bad tag/length/checksum — see dtc_mirror_load()).
+     *     Deliberately treated the same as "mirror absent" rather than as a
+     *     fatal boot error: the blast radius of trusting nothing from a
+     *     corrupt record is identical to the NOT_INITIALIZED case (DTC
+     *     history is lost, all status bytes stay at 0x00), which is the same
+     *     blast radius the original DTC-history-loss defect had. Aborting
+     *     uds_stack_init() over it would let a corrupted NVM record take down
+     *     the entire diagnostic stack, a materially larger failure than the
+     *     data loss it is guarding against. This is an explicit decision,
+     *     not an oversight — see Xaloqi/EDS#124.
      *
      * TRACEABILITY: REQ-DTC-NVM-01
      */
@@ -308,11 +319,14 @@ uds_status_t uds_generated_init(
         uds_status_t mirror_rc = dtc_mirror_load();
         if ((mirror_rc != UDS_STATUS_OK) &&
             (mirror_rc != UDS_STATUS_ERR_NOT_INITIALIZED) &&
-            (mirror_rc != UDS_STATUS_ERR_PLATFORM)) {
+            (mirror_rc != UDS_STATUS_ERR_PLATFORM) &&
+            (mirror_rc != UDS_STATUS_ERR_NVM_DATA_CORRUPT)) {
             /* Unexpected error — propagate to caller. */
             return mirror_rc;
         }
-        /* Soft-degrade: NOT_INITIALIZED and PLATFORM errors are non-fatal. */
+        /* Soft-degrade: NOT_INITIALIZED, PLATFORM, and NVM_DATA_CORRUPT
+         * errors are all non-fatal — the corrupted/unavailable mirror is
+         * discarded and boot continues with default (0x00) DTC status. */
     }
 
     /* ── Step 5.6: Register generated routine handlers ──────────────────────

--- a/examples/sensor_ecu_freertos/generated/uds_init.h
+++ b/examples/sensor_ecu_freertos/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-29T11:04:46Z
+ * Generated : 2026-08-30T11:15:05Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *


### PR DESCRIPTION
Closes #124

## Decision (founder, explicit — not re-litigated here)

A corrupted DTC mirror must **soft-degrade** at boot (boot continues with default DTC status
and a logged/documented fault), not abort `uds_stack_init()`.

## Root cause

Every `examples/*/generated/uds_init.c` Step 5.5 block treats exactly
`{UDS_STATUS_OK, UDS_STATUS_ERR_NOT_INITIALIZED, UDS_STATUS_ERR_PLATFORM}` as non-fatal
after `dtc_mirror_load()` and propagates anything else as a fatal `uds_stack_init()` failure.
#114/#118 added `UDS_STATUS_ERR_NVM_DATA_CORRUPT` as a new return from `dtc_mirror_load()`
for a corrupted mirror, and deliberately left it off that allowlist pending this decision
(logged as O-35 in the review ledger). The consequence: a corrupted DTC mirror aborted the
whole diagnostic stack's boot on every bundled example — a materially larger blast radius
than the original #114 bug (silent DTC-history loss only).

## Fix

Template-only, in the private EDS-toolchain repo:
**Xaloqi/EDS-toolchain#57** (branch `fix/124-dtc-mirror-boot-softdegrade`, open, not merged).
`UDS_STATUS_ERR_NVM_DATA_CORRUPT` is added to the Step 5.5 non-fatal allowlist: a corrupt
mirror is now discarded exactly like an absent one — boot continues with all DTC status
bytes at 0x00.

**This PR** regenerates all 12 `examples/*/generated/uds_init.c` from that fixed template to
bring `main`'s committed `generated/` output back in sync — same pattern as #99/#101 (O-27/
O-28).

## Regeneration methodology (following #99 exactly)

1. Repointed this worktree's gitignored `tools/templates` symlink at the fixed
   EDS-toolchain branch (`fix/124-dtc-mirror-boot-softdegrade`) instead of `main`, for the
   duration of the regen. Also symlinked `tools/testgen.py` (also gitignored, previously
   absent from this worktree) from the same fixed branch, since 11 of the 12 examples'
   committed output was originally produced with `--test-gen` and reproducing that needs it.
2. Ran `python3 tools/codegen.py` **in place** for all 12 examples, `--safety-wrappers
   --asil-level B` plus per-example `--test-gen`/`--no-manifest` matched to what each
   example's existing committed output implied was last used (checked before assuming
   uniformity):
   - 9 examples: `--test-gen --no-manifest`
   - `safeboot_freertos_ecu`: neither `--test-gen` nor a manifest (no committed `tests/` dir)
   - `robot_joint_controller_ecu`, `sensor_ecu`, `sensor_ecu_freertos`: `--test-gen`, manifest
     kept (these 3 already carry a committed `generated_files_phase3.json`)
3. **Diffed every regenerated file against the committed version before staging anything.**
   Wrote an automated sweep over all 351 initially-touched files that strips known-expected
   fields (the `Generated:` timestamp header, `GEN_GENERATED_TIMESTAMP`, and the manifest's
   `generated_at`/`config_source`/`output_dir`/`generator` — the latter three are
   this-machine absolute paths, the same class of expected environmental drift as the
   timestamp, exactly as #99 treated it) and reports anything left over.
   - **All 12 `uds_init.c`**: only the intended Step 5.5 allowlist change remained.
   - **Every other touched file**: nothing remained — timestamp/path fields only.
4. **Found and excluded one real, unrelated drift, rather than silently absorbing it:**
   `tools/templates/test_services.py.j2` gained two new `ReadDTCInformation` sub-function
   tests (sub `0x0B`, sub `0x19`) in EDS-toolchain commit `2efba87`, added after the last
   regeneration of 11 of the 12 examples' `generated/tests/test_services.py`. Reverted that
   file's regeneration in every example (`git checkout -- '*/tests/test_services.py'`) before
   staging — out of scope here. **Filed separately: O-37 in
   `xaloqi-knowledge/reviews/FINDINGS.md`, tracking issue
   [EDS#127](https://github.com/Xaloqi/EDS/issues/127).**
5. `tests/capl/` (present only in `ardep_ecu`) was never at risk: `codegen.py --test-gen`
   never calls `testgen.py`'s CAPL generator (that's a separate `testgen.py --capl` CLI
   invocation, not part of the documented `codegen.py` flow), and generation wrote files in
   place rather than replacing the `tests/` directory wholesale — confirmed `capl/` is
   untouched (`git status` shows no change under it).

## Regression verification

Generated-code-only change (no `core/`/`transport/`/`config/` source touched directly) — the
"test" is the diff review above plus the full gate suite passing unchanged, matching #99's own
verification approach (no new unit test added for a pure regeneration):

- `bash build_tests.sh` → **44 passed, 0 failed** (baseline: 44/0, unchanged)
- `bash build_harness.sh --run` → **68/68 PASS** (baseline: 68/68, unchanged)
- `python3 misra_analysis.py --out misra.json` → **41 files, 1 finding, 0 OPEN, 1 justified →
  PASS** (baseline unchanged; GCC-only locally, cppcheck not installed — CI runs `--strict` +
  cppcheck)
- No-malloc grep (`core/`, `transport/`, `config/`, `examples/basic_ecu/generated/`) → empty,
  as required
- `python3 scripts/verify_doc_counts.py` → **PASS**
- Belt-and-suspenders: `grep -c UDS_STATUS_ERR_NVM_DATA_CORRUPT examples/*/generated/uds_init.c`
  → **2 per file, all 12 examples** — present and compiles cleanly as part of `build_tests.sh`
  (`examples/basic_ecu/generated/` is part of the compiled unit-test sources).

## New findings logged

- **O-37** (`xaloqi-knowledge/reviews/FINDINGS.md`): `test_services.py.j2` template drift
  described above. Tracking issue: [EDS#127](https://github.com/Xaloqi/EDS/issues/127).
- **O-35** marked fixed in the same ledger update (this PR + EDS-toolchain#57 close it).

## CHANGELOG.md

Added under the existing `[Unreleased]` → `### Fixed` header (not a new header).

Companion template PR: https://github.com/Xaloqi/EDS-toolchain/pull/57

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>
