### PR TITLE
fix: send FC after every BS consecutive frames on ISO-TP RX (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,34 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **ISO-TP RX: the receiver advertised a BlockSize it never honoured — any
+  `isotp_cfg_t.block_size > 0` stalled every inbound multi-frame transfer.**
+  (#121) `isotp_init()` stored `cfg->block_size` into `ctx->local_block_size`
+  and the First Frame handler sent exactly one FC CTS carrying it, but the
+  Consecutive Frame branch never called `isotp_send_fc()` at all — both call
+  sites were inside the FF handler (the initial CTS and the OVERFLOW
+  rejection). ISO 15765-2 §9.6.5 requires the receiver to send a *further* FC
+  after every BS consecutive frames before the sender may continue, so a
+  tester that honoured the advertised BS sent BS frames, stopped, and waited
+  for an FC the ECU would never transmit: the transfer stalled until the
+  tester's own N_Bs expired while the ECU sat in `ISOTP_STATE_RX_WAIT_CF`
+  until N_Cr (150 ms) fired. Latent only because `ISOTP_DEFAULT_BLOCK_SIZE` is
+  0 (unlimited) and every bundled example leaves it there — it became a hard
+  interop failure the moment an integrator set a non-zero block size, which is
+  the normal configuration for flow-controlled bulk transfers (e.g. 0x36
+  TransferData over a constrained RX path), precisely the case BlockSize
+  exists to serve. The CF branch now tracks CFs per block in a new
+  `rx_blocks_received` context field and emits a fresh FC CTS through the
+  existing `isotp_send_fc()` once the count reaches `local_block_size`,
+  mirroring the TX side's `tx_block_size`/`tx_blocks_sent` handling in
+  `isotp_tx_pump()`. No FC follows the final CF — the PDU is already complete
+  and the sender has nothing left to send. `block_size == 0` (unlimited)
+  remains a no-op path, so the default configuration's emitted frame sequence
+  is byte-for-byte unchanged; a dedicated non-regression test asserts exactly
+  one FC frame for a five-CF transfer at BS=0, alongside a BS=2 test that
+  byte-checks each follow-up FC (FS=CTS, BS and STmin echoed) and the
+  reassembled payload.
+
 - **A corrupted DTC mirror no longer aborts `uds_stack_init()` — boot now
   soft-degrades instead.** (#124) `dtc_mirror_load()`'s
   `UDS_STATUS_ERR_NVM_DATA_CORRUPT` return (added in #114/#118 for a

--- a/tests/unit_runnable/test_isotp.c
+++ b/tests/unit_runnable/test_isotp.c
@@ -157,6 +157,25 @@ static uds_status_t init_isotp(isotp_ctx_t *ctx)
     return isotp_init(ctx, &cfg);
 }
 
+/**
+ * Initialise a fresh isotp_ctx_t advertising a non-zero BlockSize / STmin
+ * (Classic CAN).  [#121] Used by the RX block-size regression tests.
+ */
+static uds_status_t init_isotp_bs(isotp_ctx_t *ctx, uint8_t block_size, uint8_t stmin_ms)
+{
+    isotp_cfg_t cfg;
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.rx_can_id   = 0x7DFU;
+    cfg.tx_can_id   = 0x7E8U;
+    cfg.block_size  = block_size;
+    cfg.stmin_ms    = stmin_ms;
+#if ISOTP_ENABLE_CAN_FD
+    cfg.use_fd      = false;
+#endif
+    cfg.can         = &g_mock_can;
+    return isotp_init(ctx, &cfg);
+}
+
 #if ISOTP_ENABLE_CAN_FD
 /** Initialise a fresh isotp_ctx_t in CAN FD mode. */
 static uds_status_t init_isotp_fd(isotp_ctx_t *ctx)
@@ -449,6 +468,178 @@ ZTEST(test_isotp_rx_multi, test_cf_without_ff)
     zassert_equal(rc, UDS_STATUS_ERR_TP_UNEXPECTED_PDU,
                   "CF in IDLE state must be rejected");
     zassert_false(g_rx_cb_called, "Callback must not fire for unexpected CF");
+}
+
+/*
+ * Shared fixture for the block-size regression tests below.
+ *
+ * A 37-byte inbound PDU: the FF carries 6 bytes, CF1..CF4 carry 7 bytes each
+ * and CF5 carries the trailing 3 bytes.  Five CFs is the smallest transfer
+ * that exercises TWO complete blocks at BS = 2 and therefore proves the
+ * per-block counter is RESET, not merely fired once.
+ */
+#define ISOTP_BS_TEST_PDU_LEN  (37U)
+
+/** Fill @p out with the deterministic 37-byte reference payload. */
+static void bs_test_make_payload(uint8_t *out)
+{
+    uint8_t i;
+    for (i = 0U; i < (uint8_t)ISOTP_BS_TEST_PDU_LEN; i++) {
+        out[i] = (uint8_t)(0x01U + i);
+    }
+}
+
+/** Feed the FF (6 payload bytes) of the shared fixture into @p ctx. */
+static uds_status_t bs_test_send_ff(isotp_ctx_t *ctx, const uint8_t *payload)
+{
+    uint8_t ff[8];
+    uds_can_frame_t f;
+
+    ff[0] = 0x10U;                              /* FF, FF_DL hi nibble = 0 */
+    ff[1] = (uint8_t)ISOTP_BS_TEST_PDU_LEN;     /* FF_DL lo = 37           */
+    memcpy(&ff[2], &payload[0], 6U);
+    f = make_can_frame(0x7DFU, ff, 8U);
+    return isotp_process_rx_frame(ctx, &f, rx_complete_cb, NULL);
+}
+
+/**
+ * Feed CF number @p sn (1-based) of the shared fixture into @p ctx.
+ * CF1..CF4 carry 7 bytes; CF5 carries the final 3.
+ */
+static uds_status_t bs_test_send_cf(isotp_ctx_t *ctx, const uint8_t *payload, uint8_t sn)
+{
+    uint8_t cf[8];
+    uds_can_frame_t f;
+    uint8_t  n      = (sn == 5U) ? 3U : 7U;
+    uint32_t offset = 6U + ((uint32_t)(sn - 1U) * 7U);
+
+    cf[0] = (uint8_t)(0x20U | (sn & 0x0FU));
+    memcpy(&cf[1], &payload[offset], (size_t)n);
+    f = make_can_frame(0x7DFU, cf, (uint8_t)(n + 1U));
+    return isotp_process_rx_frame(ctx, &f, rx_complete_cb, NULL);
+}
+
+/** Byte-check that @p f is a well-formed FC CTS echoing @p bs / @p stmin. */
+static void bs_test_assert_fc_cts(const uds_can_frame_t *f, uint8_t bs, uint8_t stmin,
+                                  const char *what)
+{
+    zassert_equal(f->id, 0x7E8U, "%s: FC must go out on the TX CAN ID", what);
+    zassert_equal((f->data[0] >> 4U), (uint8_t)ISOTP_FRAME_TYPE_FC,
+                  "%s: PCI type nibble must be FC (3)", what);
+    zassert_equal((f->data[0] & 0x0FU), (uint8_t)ISOTP_FC_STATUS_CONTINUE_TO_SEND,
+                  "%s: FlowStatus must be CTS (0)", what);
+    zassert_equal(f->data[1], bs, "%s: FC must echo the configured BlockSize", what);
+    zassert_equal(f->data[2], stmin, "%s: FC must echo the configured STmin", what);
+#if !ISOTP_TX_PADDING
+    zassert_equal(f->dlc, 3U, "%s: unpadded FC is 3 bytes", what);
+#endif
+}
+
+/**
+ * TC-ISTP-RX-MF-005 [#121]: with a non-zero advertised BlockSize the receiver
+ * must send a further FC CTS after every BS consecutive frames
+ * (ISO 15765-2 §9.6.5).
+ *
+ * BS = 2, STmin = 10 ms, 37-byte PDU (FF + 5 CFs).  Expected FC frames:
+ *   [0] immediately after the FF,
+ *   [1] after CF2  — closes block 1,
+ *   [2] after CF4  — closes block 2,
+ *   none after CF5 — the PDU is complete, the sender has nothing left to send.
+ *
+ * Before the fix the CF branch never called isotp_send_fc(), so only the
+ * FF's CTS was ever emitted and a BS-honouring tester stalled at CF2 until
+ * its own N_Bs expired.
+ */
+ZTEST(test_isotp_rx_multi, test_rx_block_size_periodic_fc)
+{
+    uint8_t payload[ISOTP_BS_TEST_PDU_LEN];
+    isotp_ctx_t ctx;
+    isotp_state_t state;
+
+    mock_can_reset();
+    rx_cb_reset();
+    memset(&ctx, 0, sizeof(ctx));
+    bs_test_make_payload(payload);
+    zassert_equal(init_isotp_bs(&ctx, 2U, 10U), UDS_STATUS_OK, "init failed");
+
+    /* FF → initial CTS. */
+    zassert_equal(bs_test_send_ff(&ctx, payload), UDS_STATUS_OK, "FF rejected");
+    zassert_equal(g_mock_tx_count, 1U, "FF must trigger exactly one FC");
+    bs_test_assert_fc_cts(&g_mock_tx_frames[0], 2U, 10U, "FC after FF");
+
+    /* CF1 — mid-block, no FC. */
+    zassert_equal(bs_test_send_cf(&ctx, payload, 1U), UDS_STATUS_OK, "CF1 rejected");
+    zassert_equal(g_mock_tx_count, 1U, "No FC may be sent mid-block (after CF1)");
+
+    /* CF2 — closes block 1, a further FC CTS is required. */
+    zassert_equal(bs_test_send_cf(&ctx, payload, 2U), UDS_STATUS_OK, "CF2 rejected");
+    zassert_equal(g_mock_tx_count, 2U,
+                  "ISO 15765-2 9.6.5: a further FC is required after BS=2 CFs");
+    bs_test_assert_fc_cts(&g_mock_tx_frames[1], 2U, 10U, "FC after CF2");
+    zassert_false(g_rx_cb_called, "PDU is not complete yet");
+
+    /* CF3 — mid-block, no FC (proves the counter reset, not a latch). */
+    zassert_equal(bs_test_send_cf(&ctx, payload, 3U), UDS_STATUS_OK, "CF3 rejected");
+    zassert_equal(g_mock_tx_count, 2U, "No FC may be sent mid-block (after CF3)");
+
+    /* CF4 — closes block 2. */
+    zassert_equal(bs_test_send_cf(&ctx, payload, 4U), UDS_STATUS_OK, "CF4 rejected");
+    zassert_equal(g_mock_tx_count, 3U, "A third FC is required after the 2nd block");
+    bs_test_assert_fc_cts(&g_mock_tx_frames[2], 2U, 10U, "FC after CF4");
+
+    /* CF5 — completes the PDU; no trailing FC. */
+    zassert_equal(bs_test_send_cf(&ctx, payload, 5U), UDS_STATUS_OK, "CF5 rejected");
+    zassert_equal(g_mock_tx_count, 3U,
+                  "No FC may follow the final CF — the PDU is complete");
+
+    zassert_true(g_rx_cb_called, "Callback must fire once the PDU is complete");
+    zassert_equal(g_rx_cb_len, (uint32_t)ISOTP_BS_TEST_PDU_LEN,
+                  "Reassembled length must be 37");
+    zassert_equal(memcmp(g_rx_cb_data, payload, (size_t)ISOTP_BS_TEST_PDU_LEN), 0,
+                  "Reassembled payload must be byte-identical to what was sent");
+
+    zassert_equal(isotp_get_state(&ctx, &state), UDS_STATUS_OK, "get_state failed");
+    zassert_equal(state, ISOTP_STATE_IDLE, "RX must return to IDLE");
+}
+
+/**
+ * TC-ISTP-RX-MF-006 [#121] non-regression: BlockSize 0 means "unlimited", so
+ * the receiver must send exactly ONE FC (the FF's CTS) for the whole PDU and
+ * behave byte-for-byte as it did before the #121 fix.  This is the default
+ * configuration (ISOTP_DEFAULT_BLOCK_SIZE == 0) used by every bundled example.
+ *
+ * Same 37-byte / 5-CF transfer as TC-ISTP-RX-MF-005, so the two tests differ
+ * only in the advertised BlockSize.
+ */
+ZTEST(test_isotp_rx_multi, test_rx_block_size_zero_single_fc)
+{
+    uint8_t payload[ISOTP_BS_TEST_PDU_LEN];
+    isotp_ctx_t ctx;
+    uint8_t sn;
+
+    mock_can_reset();
+    rx_cb_reset();
+    memset(&ctx, 0, sizeof(ctx));
+    bs_test_make_payload(payload);
+    /* init_isotp() is the shared BS=0 / STmin=0 default helper. */
+    zassert_equal(init_isotp(&ctx), UDS_STATUS_OK, "init failed");
+
+    zassert_equal(bs_test_send_ff(&ctx, payload), UDS_STATUS_OK, "FF rejected");
+    zassert_equal(g_mock_tx_count, 1U, "FF must trigger exactly one FC");
+    bs_test_assert_fc_cts(&g_mock_tx_frames[0], 0U, 0U, "FC after FF (BS=0)");
+
+    for (sn = 1U; sn <= 5U; sn++) {
+        zassert_equal(bs_test_send_cf(&ctx, payload, sn), UDS_STATUS_OK,
+                      "CF rejected");
+        zassert_equal(g_mock_tx_count, 1U,
+                      "BS=0 is unlimited: no further FC may ever be sent");
+    }
+
+    zassert_true(g_rx_cb_called, "Callback must fire once the PDU is complete");
+    zassert_equal(g_rx_cb_len, (uint32_t)ISOTP_BS_TEST_PDU_LEN,
+                  "Reassembled length must be 37");
+    zassert_equal(memcmp(g_rx_cb_data, payload, (size_t)ISOTP_BS_TEST_PDU_LEN), 0,
+                  "Reassembled payload must be byte-identical to what was sent");
 }
 
 #if ISOTP_ENABLE_CAN_FD
@@ -1218,6 +1409,8 @@ extern void test_isotp_rx_single__test_sf_seven_bytes(void);
 extern void test_isotp_rx_multi__test_first_frame_triggers_fc(void);
 extern void test_isotp_rx_multi__test_ff_cf_complete(void);
 extern void test_isotp_rx_multi__test_cf_without_ff(void);
+extern void test_isotp_rx_multi__test_rx_block_size_periodic_fc(void);
+extern void test_isotp_rx_multi__test_rx_block_size_zero_single_fc(void);
 #if ISOTP_ENABLE_CAN_FD
 extern void test_isotp_rx_multi__test_ff_overflow(void);
 extern void test_isotp_canfd__test_fd_sf_rx_10_bytes(void);
@@ -1269,6 +1462,8 @@ void run_all_tests(void)
     RUN_TEST(test_isotp_rx_multi__test_first_frame_triggers_fc);
     RUN_TEST(test_isotp_rx_multi__test_ff_cf_complete);
     RUN_TEST(test_isotp_rx_multi__test_cf_without_ff);
+    RUN_TEST(test_isotp_rx_multi__test_rx_block_size_periodic_fc);
+    RUN_TEST(test_isotp_rx_multi__test_rx_block_size_zero_single_fc);
 #if ISOTP_ENABLE_CAN_FD
     RUN_TEST(test_isotp_rx_multi__test_ff_overflow);
     RUN_TEST(test_isotp_canfd__test_fd_sf_rx_10_bytes);

--- a/transport/isotp.c
+++ b/transport/isotp.c
@@ -282,11 +282,12 @@ uds_status_t isotp_process_rx_frame(
 
             (void)memcpy(ctx->rx_buf, &frame->data[ff_data_offset], (size_t)ff_data_bytes);
 
-            ctx->rx_expected_len = ff_dl;
-            ctx->rx_received_len = (uint32_t)ff_data_bytes;
-            ctx->rx_expected_sn  = (uint8_t)1U;
-            ctx->rx_cr_timer_ms  = (uint32_t)ISOTP_TIMEOUT_CR_MS;
-            ctx->rx_state        = ISOTP_STATE_RX_WAIT_CF;
+            ctx->rx_expected_len    = ff_dl;
+            ctx->rx_received_len    = (uint32_t)ff_data_bytes;
+            ctx->rx_expected_sn     = (uint8_t)1U;
+            ctx->rx_blocks_received = (uint8_t)0U;  /* [#121] new block starts here */
+            ctx->rx_cr_timer_ms     = (uint32_t)ISOTP_TIMEOUT_CR_MS;
+            ctx->rx_state           = ISOTP_STATE_RX_WAIT_CF;
 
             /* Send FC CTS — best-effort; ignore transmit errors. */
             (void)isotp_send_fc(ctx,
@@ -338,12 +339,47 @@ uds_status_t isotp_process_rx_frame(
             ctx->rx_received_len = ctx->rx_received_len + copy_len;
             ctx->rx_expected_sn  = (uint8_t)(ctx->rx_expected_sn + (uint8_t)1U);
 
-            /* Reset Cr timer on each received CF. */
+            /* Reset Cr timer on each received CF.  This assignment also
+             * re-arms N_Cr for the block-boundary FC emitted below: sending
+             * an FC is a liveness event exactly like receiving a CF, so the
+             * next block gets a full N_Cr window. */
             ctx->rx_cr_timer_ms = (uint32_t)ISOTP_TIMEOUT_CR_MS;
 
             if (ctx->rx_received_len >= ctx->rx_expected_len) {
-                ctx->rx_state = ISOTP_STATE_IDLE;
+                ctx->rx_state           = ISOTP_STATE_IDLE;
+                ctx->rx_blocks_received = (uint8_t)0U;
                 rx_cb(ctx->rx_buf, ctx->rx_expected_len, rx_cb_arg);
+            } else {
+                /* [#121][P2-TP-05] RX-side block-size handling, the mirror of
+                 * isotp_tx_pump()'s tx_block_size / tx_blocks_sent tracking.
+                 *
+                 * ISO 15765-2 §9.6.5: a receiver that advertised BlockSize
+                 * BS != 0 must send a further FC CTS after every BS
+                 * consecutive frames; the sender is not permitted to continue
+                 * until it arrives.  Without this the sender stalls at the end
+                 * of the first block until its own N_Bs expires.
+                 *
+                 * BS == 0 means "unlimited" (ISOTP_DEFAULT_BLOCK_SIZE, and the
+                 * configuration every bundled example uses): no further FC is
+                 * ever sent, so this path is a no-op and the emitted frame
+                 * sequence is unchanged.
+                 *
+                 * No FC is emitted after the final CF — the branch above has
+                 * already completed the PDU and the sender has nothing left
+                 * to send. */
+                if (ctx->local_block_size != (uint8_t)0U) {
+                    ctx->rx_blocks_received =
+                        (uint8_t)(ctx->rx_blocks_received + (uint8_t)1U);
+
+                    if (ctx->rx_blocks_received >= ctx->local_block_size) {
+                        ctx->rx_blocks_received = (uint8_t)0U;
+                        /* Best-effort, mirroring the FF handler's CTS. */
+                        (void)isotp_send_fc(ctx,
+                                            (uint8_t)ISOTP_FC_STATUS_CONTINUE_TO_SEND,
+                                            ctx->local_block_size,
+                                            ctx->local_stmin_ms);
+                    }
+                }
             }
 
             return UDS_STATUS_OK;
@@ -693,22 +729,23 @@ uds_status_t isotp_reset(isotp_ctx_t *ctx)
         return UDS_STATUS_ERR_NOT_INITIALIZED;
     }
 
-    ctx->rx_state          = ISOTP_STATE_IDLE;
-    ctx->tx_state          = ISOTP_STATE_IDLE;
-    ctx->rx_expected_len   = (uint32_t)0U;
-    ctx->rx_received_len   = (uint32_t)0U;
-    ctx->rx_expected_sn    = (uint8_t)0U;
-    ctx->rx_cr_timer_ms    = 0U;
-    ctx->tx_data           = NULL;
-    ctx->tx_total_len      = (uint32_t)0U;
-    ctx->tx_sent_len       = (uint32_t)0U;
-    ctx->tx_sn             = (uint8_t)0U;
-    ctx->tx_block_size     = (uint8_t)0U;
-    ctx->tx_stmin_ms       = (uint8_t)0U;
-    ctx->tx_stmin_timer_ms = 0U;
-    ctx->tx_bs_timer_ms    = 0U;
-    ctx->tx_as_timer_ms    = 0U;
-    ctx->tx_blocks_sent    = (uint8_t)0U;
+    ctx->rx_state           = ISOTP_STATE_IDLE;
+    ctx->tx_state           = ISOTP_STATE_IDLE;
+    ctx->rx_expected_len    = (uint32_t)0U;
+    ctx->rx_received_len    = (uint32_t)0U;
+    ctx->rx_expected_sn     = (uint8_t)0U;
+    ctx->rx_blocks_received = (uint8_t)0U;
+    ctx->rx_cr_timer_ms     = 0U;
+    ctx->tx_data            = NULL;
+    ctx->tx_total_len       = (uint32_t)0U;
+    ctx->tx_sent_len        = (uint32_t)0U;
+    ctx->tx_sn              = (uint8_t)0U;
+    ctx->tx_block_size      = (uint8_t)0U;
+    ctx->tx_stmin_ms        = (uint8_t)0U;
+    ctx->tx_stmin_timer_ms  = 0U;
+    ctx->tx_bs_timer_ms     = 0U;
+    ctx->tx_as_timer_ms     = 0U;
+    ctx->tx_blocks_sent     = (uint8_t)0U;
 
     return UDS_STATUS_OK;
 }

--- a/transport/isotp.h
+++ b/transport/isotp.h
@@ -195,6 +195,7 @@ typedef struct isotp_ctx {
     uint32_t         rx_expected_len;                   /**< Total expected message length. */
     uint32_t         rx_received_len;                   /**< Bytes received so far. */
     uint8_t          rx_expected_sn;                    /**< Expected consecutive frame SN. */
+    uint8_t          rx_blocks_received;                /**< [#121] CFs received in current block. */
     uint32_t         rx_cr_timer_ms;                    /**< Cr timeout countdown (ms). */
 
     /* TX state */


### PR DESCRIPTION
Closes #121

## Root cause

`isotp_init()` stores `cfg->block_size` into `ctx->local_block_size` and the First Frame handler sends exactly one FC CTS carrying it — but the Consecutive Frame branch never called `isotp_send_fc()` at all. Both call sites were inside the FF handler (the initial CTS, and the OVERFLOW rejection).

ISO 15765-2 §9.6.5 requires the receiver to send a *further* FC after every BS consecutive frames before the sender may continue. A tester that honoured the advertised BS therefore sent BS frames, stopped, and waited for an FC the ECU would never transmit: the transfer stalled until the tester's own N_Bs expired, while the ECU sat in `ISOTP_STATE_RX_WAIT_CF` until N_Cr (150 ms) fired.

Latent only because `ISOTP_DEFAULT_BLOCK_SIZE` is 0 (unlimited) and every bundled example leaves it there. It becomes a hard interop failure the moment an integrator sets a non-zero block size — the normal configuration for flow-controlled bulk transfers (e.g. 0x36 TransferData over a constrained RX path), precisely the case BlockSize exists to serve.

## The fix

RX-side block-size tracking, mirrored from the TX side's `tx_block_size` / `tx_blocks_sent` handling in `isotp_tx_pump()`:

- New `isotp_ctx_t.rx_blocks_received` counts CFs accepted in the current block. Zeroed at FF reception (a new transfer starts a new block), on PDU completion, and in `isotp_reset()`.
- The CF branch increments it and, once it reaches `local_block_size`, resets it and emits a fresh FC CTS via the existing `isotp_send_fc()` — no duplicated frame-build logic, so `ISOTP_TX_PADDING` and the TX CAN ID are handled identically to the FF path, and the send stays best-effort (`(void)`) exactly like the FF handler's CTS.
- N_Cr is re-armed for the next block by the CF branch's existing `rx_cr_timer_ms` assignment, which now also covers the block-boundary FC (sending an FC is a liveness event exactly like receiving a CF). Documented in a comment rather than written twice, to avoid a redundant assignment.
- No FC follows the final CF: the completion branch runs first, the PDU is done and the sender has nothing left to send.
- `block_size == 0` (unlimited) is entirely inside the `!= 0` guard — no counter write, no FC, no timer change. The default configuration's emitted frame sequence is byte-for-byte unchanged.

## Regression tests

Both added to the existing `test_isotp_rx_multi` suite in `tests/unit_runnable/test_isotp.c` (no new test module, so the module count stays 44). Shared fixture: a 37-byte inbound PDU — FF carries 6 bytes, CF1–CF4 carry 7 each, CF5 carries the trailing 3. Five CFs is the smallest transfer that exercises **two complete blocks** at BS=2 and so proves the counter is *reset*, not merely fired once.

- **`test_rx_block_size_periodic_fc`** — BS=2, STmin=10 ms. Asserts FC frames appear after the FF, after CF2 and after CF4, none mid-block (CF1, CF3), and none after the final CF5; each FC is byte-checked (TX CAN ID, PCI type nibble = FC, FlowStatus = CTS, BS and STmin echoed, DLC 3 when unpadded); the reassembled 37-byte payload is `memcmp`-identical and RX returns to IDLE.
- **`test_rx_block_size_zero_single_fc`** — non-regression for the default path. Same transfer at BS=0: exactly **one** FC frame total for the whole five-CF PDU, byte-checked as CTS with BS=0/STmin=0, payload byte-identical.

### Before/after proof

Against **unmodified** `transport/isotp.c` (tests added, source fix not yet applied):

```
[FAIL] test_isotp_rx_multi__test_rx_block_size_periodic_fc
  tests/unit_runnable/test_isotp.c:576: Expected 1 but got 2 ((2U))
[PASS] test_isotp_rx_multi__test_rx_block_size_zero_single_fc
Tests run: 44  passed: 43  failed: 1
=== Unit Test Summary: 43 passed, 1 failed ===
```

Only one FC was ever emitted where §9.6.5 requires a second after CF2 — the stall, reproduced. The BS=0 test already passes pre-fix, which is exactly what makes it a valid non-regression baseline.

With the fix applied:

```
[PASS] test_isotp_rx_multi__test_rx_block_size_periodic_fc
[PASS] test_isotp_rx_multi__test_rx_block_size_zero_single_fc
Tests run: 44  passed: 44  failed: 0
=== Unit Test Summary: 44 passed, 0 failed ===
```

## Gate results

| Gate | Result |
|---|---|
| `bash build_tests.sh` | **44 passed, 0 failed** (baseline 44/0 held) |
| `bash build_harness.sh --run` | **68 / 68 PASS** |
| `python3 misra_analysis.py --out misra.json` | 41 files, 1 finding, **0 OPEN**, 1 justified → PASS |
| No-malloc grep (CI mirror) | no output |
| `python3 scripts/verify_doc_counts.py` | PASS (agrees with real count 44) |

`cppcheck` is not installed on the dev host, so the MISRA run above is **GCC-only** (`[2/2] cppcheck skipped`); CI runs it with `--strict` + cppcheck.

## Self-review (heightened review — `transport/isotp.c`)

- **§9.6.5 semantics.** FC sent after exactly BS accepted CFs since the last FC; counter starts at 0 at FF; `>=` comparison mirrors the TX side. FC re-advertises the configured BS/STmin — the conservative, spec-conformant choice.
- **Rejected CFs never trigger an FC.** The bad-SN, short-DLC and buffer-overflow paths all return before the new code and set `ISOTP_STATE_ERROR`, so an FC never acknowledges a frame that was not accepted. The branch is also only reachable in `RX_WAIT_CF`, guarded at the top of the case.
- **OVERFLOW / WAIT paths.** The FF handler's OVFLW rejection returns before `rx_state` becomes `RX_WAIT_CF`, so the counter is untouched and is zeroed by the next valid FF. This implementation never emits FS=WAIT; unchanged.
- **No counter overflow.** Incremented only when BS != 0 and reset on reaching BS (max 255), so it cannot exceed 255.
- **Struct layout.** `rx_blocks_received` is placed between `rx_expected_sn` (uint8_t) and `rx_cr_timer_ms` (uint32_t), consuming one byte of pre-existing alignment padding, so `sizeof(isotp_ctx_t)` is unchanged on any ABI that aligns `uint32_t` to 4 bytes. `isotp_ctx_t` is caller-allocated and already documented "caller must not modify fields directly".
- **MISRA / house rules.** No malloc, VLA or recursion added (`isotp_send_fc()` does not re-enter `isotp_process_rx_frame()`). Explicit `U` suffixes and explicit `(uint8_t)` casts on the arithmetic, matching the `tx_blocks_sent` line verbatim; both comparison operands are `uint8_t`; ignored return is `(void)`-cast; all bodies braced. The construct is a two-way `if`/`else` with plain nested `if`s, not an `if`–`else if` chain, so MISRA 15.7's terminating-`else` requirement does not apply. MISRA gate reports 0 open violations.
- **Concurrency.** Per-context state only; `test_isotp_concurrent` passes.

Reviewed-by: Xaloqi <contact@xaloqi.com>
