### PR TITLE
fix: cap DTC mirror persistence at what fits in NVM_MAX_RECORD_BYTES (#123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,39 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   clamp-and-continue behavior as correct has been rewritten to assert the
   reject-and-abort behavior instead.
 
+- **DTC NVM mirror could exceed the shared NVM record cap before
+  `UDS_MAX_DTC_COUNT` was reached — silent persistence loss at worst-case
+  fault load.** (#123) `config/dtc_mirror.h`'s `DTC_MIRROR_MAX_BYTES` was
+  sized from `UDS_MAX_DTC_COUNT` (128): `5 + 128*4 + 4 = 521` bytes, 9 bytes
+  over `platform/nvm_store.h`'s `NVM_MAX_RECORD_BYTES` (512) — a cap shared
+  with unrelated NVM consumers (security counters, session stats), so
+  widening it was out of scope (flagged but deliberately deferred when
+  #114 added the 9-byte integrity header/CRC that narrowed the safe
+  ceiling from 127 to 125). Once the live DTC table grew past 125 entries,
+  `nvm_store_write()`'s own length guard silently rejected the mirror
+  write with a non-OK status; both call sites already treat that as
+  best-effort/non-fatal, so nothing crashed — but ConfirmedDTC persistence
+  silently stopped updating exactly when a device was closest to its
+  worst-case fault load, the scenario #114's integrity metadata exists to
+  make trustworthy. Fixed by capping what the mirror promises to persist,
+  not by raising the shared NVM cap: new `DTC_MIRROR_MAX_PERSISTED_DTCS`
+  (125, the largest count that fits `NVM_MAX_RECORD_BYTES` alongside the
+  header and CRC trailer) now bounds both the serializer's iteration and
+  `DTC_MIRROR_MAX_BYTES`'s own derivation, enforced by a build-time
+  `_Static_assert` in `dtc_mirror.c` so any future change to the sizing
+  constants fails the build instead of failing silently at runtime.
+  `dtc_database` still holds up to `UDS_MAX_DTC_COUNT` (128) DTCs; entries
+  beyond the persisted cap are a documented limitation — simply not
+  written, never truncated or corrupted. New regression tests: filling to
+  exactly the new cap round-trips every entry through a flush/power-cycle/
+  load; filling to the full `UDS_MAX_DTC_COUNT` (128) still flushes OK,
+  with entries beyond the cap correctly absent (not corrupted) after
+  reload — this is the one that fails against unmodified pre-fix source
+  (`dtc_mirror_flush_all()` returns a non-OK status instead of OK); and a
+  standalone arithmetic test recomputes the old pre-#123 formula directly
+  from the raw wire-format constants to prove the defect was real,
+  independent of today's cap.
+
 ### Security
 
 - **BREAKING: UDS access-control table now fails CLOSED for any service_id

--- a/config/dtc_mirror.c
+++ b/config/dtc_mirror.c
@@ -31,6 +31,36 @@
 #include <stdint.h>
 
 /* --------------------------------------------------------------------------
+ * Build-time sizing guarantee (issue #123)
+ * -------------------------------------------------------------------------- */
+
+/*
+ * DTC_MIRROR_MAX_BYTES (computed FROM DTC_MIRROR_MAX_PERSISTED_DTCS, see
+ * dtc_mirror.h) must never exceed the platform's per-record NVM cap. This
+ * is what makes DTC_MIRROR_MAX_PERSISTED_DTCS a real guarantee rather than
+ * a comment: if a future change to any of the wire-format sizing constants
+ * (header bytes, entry bytes, the persisted-DTC cap) breaks the inequality,
+ * the BUILD fails here instead of nvm_store_write() silently rejecting the
+ * mirror write at runtime — the original issue #123 failure mode.
+ *
+ * MISRA_ANALYSIS guard: cppcheck's MISRA addon reports _Static_assert as
+ * "Rule N/A" (not covered by any MISRA rule), which would inflate the
+ * open-violation count. misra_analysis.py defines MISRA_ANALYSIS=1 during
+ * static analysis passes to exclude this assertion from that pass only;
+ * GCC and Clang always see it. Same pattern as core/uds_types.h.
+ */
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) && !defined(MISRA_ANALYSIS)
+_Static_assert(
+    DTC_MIRROR_MAX_BYTES <= NVM_MAX_RECORD_BYTES,
+    "DTC_MIRROR_MAX_BYTES exceeds NVM_MAX_RECORD_BYTES — the DTC mirror "
+    "would silently fail to persist at worst-case fault load (issue #123). "
+    "Lower DTC_MIRROR_MAX_PERSISTED_DTCS in dtc_mirror.h, or raise "
+    "NVM_MAX_RECORD_BYTES in platform/nvm_store.h after checking every "
+    "other NVM_KEY_* consumer of that shared cap."
+);
+#endif
+
+/* --------------------------------------------------------------------------
  * Internal state
  * -------------------------------------------------------------------------- */
 
@@ -90,9 +120,15 @@ static uds_status_t mirror_serialize_internal(bool force_status_zero, size_t *ou
 
     count = (uint16_t)0U;
 
-    /* Iterate using the dtc_database export accessor. */
+    /* Iterate using the dtc_database export accessor. Bounded by
+     * DTC_MIRROR_MAX_PERSISTED_DTCS (issue #123), not UDS_MAX_DTC_COUNT:
+     * dtc_database may hold more entries than the mirror can persist within
+     * NVM_MAX_RECORD_BYTES. Entries at index >= the cap are simply not
+     * written — the buffer-full break below is a redundant safety net,
+     * not the primary mechanism now that this loop bound already matches
+     * DTC_MIRROR_MAX_BYTES's derivation. */
     {
-        uint16_t max_dtcs = (uint16_t)UDS_MAX_DTC_COUNT;
+        uint16_t max_dtcs = (uint16_t)DTC_MIRROR_MAX_PERSISTED_DTCS;
         uint16_t idx;
 
         for (idx = (uint16_t)0U; idx < max_dtcs; idx++) {
@@ -225,9 +261,11 @@ uds_status_t dtc_mirror_load(void)
     count  = (uint16_t)((uint16_t)buf[3] << 8U);
     count |= (uint16_t)  buf[4];
 
-    if (count > (uint16_t)UDS_MAX_DTC_COUNT) {
-        /* Declared count exceeds the largest table this build could ever
-         * have written — cannot be a genuine record from this format. */
+    if (count > (uint16_t)DTC_MIRROR_MAX_PERSISTED_DTCS) {
+        /* Declared count exceeds the largest count this build could ever
+         * have WRITTEN (issue #123: the mirror now caps what it persists
+         * at DTC_MIRROR_MAX_PERSISTED_DTCS, not UDS_MAX_DTC_COUNT) —
+         * cannot be a genuine record from this format. */
         return UDS_STATUS_ERR_NVM_DATA_CORRUPT;
     }
 

--- a/config/dtc_mirror.h
+++ b/config/dtc_mirror.h
@@ -28,12 +28,22 @@
  *   Each entry: [dtc_code:3 big-endian][status_byte:1]
  *   magic   = 0x44,0x4D ("DM"). Identifies a v1-or-later record.
  *   version = DTC_MIRROR_FORMAT_VERSION. Bump on any layout change.
- *   count   = number of entries, big-endian.
+ *   count   = number of entries, big-endian. Bounded by
+ *             DTC_MIRROR_MAX_PERSISTED_DTCS (issue #123), NOT by
+ *             UDS_MAX_DTC_COUNT — see that constant's comment below.
  *   crc32   = CRC-32 (same polynomial/algorithm as the transfer-service
  *             helper in core/uds_transfer_ctx.c) computed over
  *             [version..last entry byte] (i.e. everything except the
  *             magic and the CRC field itself), big-endian.
- *   Maximum payload: 5 + 128 × 4 + 4 = 521 bytes.
+ *   Maximum payload: 5 + DTC_MIRROR_MAX_PERSISTED_DTCS(125) × 4 + 4 = 509 bytes.
+ *   This is DTC_MIRROR_MAX_BYTES, held by a build-time _Static_assert in
+ *   dtc_mirror.c to be <= platform/nvm_store.h's NVM_MAX_RECORD_BYTES (512).
+ *   Sizing this from UDS_MAX_DTC_COUNT (128) instead — 5+128×4+4 = 521 —
+ *   was the issue #123 bug: 9 bytes over the NVM cap, so nvm_store_write()
+ *   silently rejected the mirror write once the live DTC table grew past
+ *   125 entries. dtc_database itself still holds up to UDS_MAX_DTC_COUNT
+ *   (128) DTCs; entries at index >= DTC_MIRROR_MAX_PERSISTED_DTCS simply
+ *   are not persisted — a documented limitation, not a truncated write.
  *
  * INTEGRITY (issue #114 fix):
  *   Before this fix, the mirror was [count:2][entries...] with no way to
@@ -84,9 +94,36 @@ extern "C" {
 /** CRC-32 trailer appended after the last entry. */
 #define DTC_MIRROR_CRC_BYTES     (4U)
 
-/** Maximum mirror payload: header + max_entries × entry_size + CRC trailer. */
+/**
+ * Maximum number of DTC status entries the mirror will ever persist to NVM
+ * in a single record (issue #123).
+ *
+ * This is deliberately NOT UDS_MAX_DTC_COUNT (128): platform/nvm_store.h's
+ * NVM_MAX_RECORD_BYTES (512) is a hard per-record cap shared with unrelated
+ * NVM consumers (security counters, session stats), so widening it is out
+ * of scope for this module. Instead the mirror caps what IT promises to
+ * persist at the largest entry count that provably fits the existing
+ * 512-byte budget alongside the 5-byte header and 4-byte CRC trailer:
+ *
+ *     DTC_MIRROR_HEADER_BYTES + N * DTC_MIRROR_ENTRY_BYTES + DTC_MIRROR_CRC_BYTES
+ *         <= NVM_MAX_RECORD_BYTES
+ *     5 + N*4 + 4 <= 512  =>  N <= 125.75  =>  N = 125
+ *
+ * At N=125: 5 + 125*4 + 4 = 509 bytes (fits). At N=126: 513 bytes (does not).
+ * dtc_database can still register up to UDS_MAX_DTC_COUNT (128) DTCs — any
+ * entries at index >= DTC_MIRROR_MAX_PERSISTED_DTCS are simply not written
+ * to the NVM mirror (documented limitation, not a truncated/corrupt write).
+ *
+ * A build-time _Static_assert in dtc_mirror.c ties DTC_MIRROR_MAX_BYTES
+ * (derived from this constant, below) to NVM_MAX_RECORD_BYTES, so any
+ * future change to these sizing constants that breaks the inequality
+ * fails the build instead of failing silently at runtime.
+ */
+#define DTC_MIRROR_MAX_PERSISTED_DTCS ((uint16_t)125U)
+
+/** Maximum mirror payload: header + max_persisted_entries × entry_size + CRC trailer. */
 #define DTC_MIRROR_MAX_BYTES     ((uint16_t)(DTC_MIRROR_HEADER_BYTES + \
-                                  (UDS_MAX_DTC_COUNT * DTC_MIRROR_ENTRY_BYTES) + \
+                                  (DTC_MIRROR_MAX_PERSISTED_DTCS * DTC_MIRROR_ENTRY_BYTES) + \
                                   DTC_MIRROR_CRC_BYTES))
 
 /* --------------------------------------------------------------------------

--- a/platform/nvm_store.h
+++ b/platform/nvm_store.h
@@ -57,8 +57,13 @@ extern "C" {
  *  Persisting this prevents lockout bypass by power-cycling the ECU. */
 #define NVM_KEY_SEC_LOCKOUT_MS     ((uint16_t)0x0002U)
 
-/** DTC status-byte mirror: array of (dtc_code[3] + status_byte[1]) * count.
- *  Maximum size: UDS_MAX_DTC_COUNT * 4 bytes = 512 bytes. */
+/** DTC status-byte mirror: array of (dtc_code[3] + status_byte[1]) * count,
+ *  plus a 5-byte header and 4-byte CRC-32 trailer (see config/dtc_mirror.h).
+ *  Maximum size: DTC_MIRROR_MAX_BYTES = 509 bytes, deliberately capped
+ *  below NVM_MAX_RECORD_BYTES and enforced by a _Static_assert in
+ *  config/dtc_mirror.c — NOT simply UDS_MAX_DTC_COUNT * 4 (issue #123:
+ *  that naive formula, plus the header/CRC overhead, is 9 bytes over this
+ *  record's cap). */
 #define NVM_KEY_DTC_MIRROR         ((uint16_t)0x0003U)
 
 /** Session statistics block (nvm_session_stats_t, ~16 bytes). */

--- a/tests/unit_runnable/test_dtc_mirror.c
+++ b/tests/unit_runnable/test_dtc_mirror.c
@@ -66,6 +66,17 @@
  *     TC-MIRROR-027  Valid magic + unsupported version → load() reports
  *                    ERR_NVM_DATA_CORRUPT
  *
+ *   Mirror sizing vs. the NVM record cap (issue #123):
+ *     TC-MIRROR-028  DTC_MIRROR_MAX_BYTES (today's persisted-DTC cap) fits
+ *                    within NVM_MAX_RECORD_BYTES — the fix is internally
+ *                    consistent (the _Static_assert in dtc_mirror.c is the
+ *                    primary enforcement; this is a runtime cross-check).
+ *     TC-MIRROR-029  Proves issue #123 was a real bug, independent of
+ *                    TC-MIRROR-028: recomputes the OLD (pre-fix) sizing
+ *                    formula — header + UDS_MAX_DTC_COUNT entries + CRC —
+ *                    directly from the raw wire-format constants, and
+ *                    shows it exceeds NVM_MAX_RECORD_BYTES.
+ *
  * FRAMEWORK: Zephyr Ztest (via ztest_shim.h for host compilation)
  * NVM:       NVM_STORE_HOST_MOCK (RAM-backed mock, controlled via nvm_mock_reset /
  *            nvm_mock_deinit)
@@ -790,6 +801,50 @@ ZTEST(dtc_mirror, test_load_reports_corrupt_on_bad_version)
 }
 
 /* ==========================================================================
+ * Mirror sizing vs. the NVM record cap (issue #123)
+ * ========================================================================== */
+
+/* TC-MIRROR-028  DTC_MIRROR_MAX_BYTES (derived from today's
+ * DTC_MIRROR_MAX_PERSISTED_DTCS) fits within NVM_MAX_RECORD_BYTES.
+ *
+ * The build-time _Static_assert in dtc_mirror.c is the primary enforcement
+ * (it fails the BUILD, not just this test, if a future change to any
+ * sizing constant breaks the inequality) — this is a runtime cross-check
+ * of the same fact, and pins the exact byte counts so a silent change to
+ * either constant is caught here too. */
+ZTEST(dtc_mirror, test_mirror_max_bytes_fits_nvm_cap)
+{
+    zassert_equal(125U, (unsigned int)DTC_MIRROR_MAX_PERSISTED_DTCS,
+                  "issue #123 ceiling: 5 + N*4 + 4 <= 512 => N <= 125");
+    zassert_equal(509U, (unsigned int)DTC_MIRROR_MAX_BYTES,
+                  "DTC_MIRROR_MAX_BYTES must be 5 + 125*4 + 4 = 509");
+    zassert_true(DTC_MIRROR_MAX_BYTES <= NVM_MAX_RECORD_BYTES,
+                  "DTC_MIRROR_MAX_BYTES must fit within NVM_MAX_RECORD_BYTES");
+}
+
+/* TC-MIRROR-029  Proves issue #123 was a real bug: recompute the OLD
+ * (pre-fix) sizing formula directly from the raw wire-format constants —
+ * header + UDS_MAX_DTC_COUNT (128) entries + CRC trailer, exactly what
+ * DTC_MIRROR_MAX_BYTES used to expand to before this fix — and show it
+ * exceeds NVM_MAX_RECORD_BYTES. This is independent of
+ * DTC_MIRROR_MAX_PERSISTED_DTCS, so it proves the defect was real rather
+ * than merely that today's cap is internally consistent (TC-MIRROR-028). */
+ZTEST(dtc_mirror, test_old_full_table_sizing_would_have_exceeded_nvm_cap)
+{
+    size_t old_formula_bytes = (size_t)DTC_MIRROR_HEADER_BYTES
+                              + ((size_t)UDS_MAX_DTC_COUNT * (size_t)DTC_MIRROR_ENTRY_BYTES)
+                              + (size_t)DTC_MIRROR_CRC_BYTES;
+
+    zassert_equal((size_t)521U, old_formula_bytes,
+                  "pre-#123 formula: 5 + 128*4 + 4 = 521");
+    zassert_true(old_formula_bytes > (size_t)NVM_MAX_RECORD_BYTES,
+                  "issue #123: sizing the mirror from UDS_MAX_DTC_COUNT (128) "
+                  "overshoots NVM_MAX_RECORD_BYTES (512) by 9 bytes — this is "
+                  "the bug that made nvm_store_write() silently reject the "
+                  "mirror write once the live DTC table grew past 125 entries");
+}
+
+/* ==========================================================================
  * run_all_tests
  * ========================================================================== */
 
@@ -835,4 +890,8 @@ void run_all_tests(void)
     RUN_TEST(dtc_mirror__test_load_reports_corrupt_on_truncated_record);
     RUN_TEST(dtc_mirror__test_load_treats_legacy_record_as_no_mirror);
     RUN_TEST(dtc_mirror__test_load_reports_corrupt_on_bad_version);
+
+    /* Mirror sizing vs. the NVM record cap (issue #123) */
+    RUN_TEST(dtc_mirror__test_mirror_max_bytes_fits_nvm_cap);
+    RUN_TEST(dtc_mirror__test_old_full_table_sizing_would_have_exceeded_nvm_cap);
 }

--- a/tests/unit_runnable/test_phase3_nvm_dtc.c
+++ b/tests/unit_runnable/test_phase3_nvm_dtc.c
@@ -17,7 +17,18 @@
  *   Entries absent from database (firmware update removes DTC) skipped
  *   DTC with status 0x00 NOT lost on round-trip
  *
- * TEST COUNT: 13
+ * Also covers issue #123 (DTC mirror could exceed NVM_MAX_RECORD_BYTES
+ * before UDS_MAX_DTC_COUNT was reached):
+ *   Filling to DTC_MIRROR_MAX_PERSISTED_DTCS (today's persisted-DTC cap)
+ *     round-trips every entry through flush_all()/load().
+ *   Filling dtc_database to its full UDS_MAX_DTC_COUNT (128) capacity still
+ *     flushes OK (this is the regression check: on unmodified pre-#123
+ *     source, this flush_all() call returns ERR_INVALID_PARAM instead of
+ *     OK because the serialized record is 521 bytes against the 512-byte
+ *     NVM cap); entries beyond the persisted-DTC cap are documented as not
+ *     persisted, not corrupted.
+ *
+ * TEST COUNT: 15
  * =============================================================================
  */
 
@@ -301,6 +312,144 @@ void test_get_count_null_guard(void)
 }
 
 /* --------------------------------------------------------------------------
+ * Issue #123 — DTC mirror sizing vs. NVM_MAX_RECORD_BYTES
+ * -------------------------------------------------------------------------- */
+
+/*
+ * Deliberately a LITERAL, not config/dtc_mirror.h's DTC_MIRROR_MAX_PERSISTED_DTCS:
+ * these two tests must still compile against the unmodified pre-#123 source
+ * (which does not define that constant) so the regression check below fails
+ * at its runtime assertion — proving the actual behavioral bug — rather than
+ * failing to build and masking what's really being tested. TC-MIRROR-028 in
+ * test_dtc_mirror.c cross-checks this literal against the real
+ * DTC_MIRROR_MAX_PERSISTED_DTCS constant, so drift between the two is caught.
+ */
+#define TEST_EXPECTED_MIRROR_PERSISTED_CAP ((uint16_t)125U)
+
+/* Register `count` unique, nonzero DTC codes (0x010000 + i) with distinct
+ * status bytes ((i % 0xFF) + 1, always nonzero so "not persisted" is
+ * distinguishable from a genuine round-tripped 0x00 status). */
+static void register_n_dtcs_with_status(uint16_t count)
+{
+    uint16_t i;
+
+    for (i = 0U; i < count; i++) {
+        uint32_t dtc_code = 0x010000UL + (uint32_t)i;
+        uint8_t  status    = (uint8_t)((i % 0xFFU) + 1U);
+
+        TEST_ASSERT_EQUAL(UDS_STATUS_OK,
+            dtc_database_register(dtc_code, 0x00U, NULL));
+        TEST_ASSERT_EQUAL(UDS_STATUS_OK,
+            dtc_database_set_status(dtc_code, status));
+    }
+}
+
+/* 14. Filling to exactly TEST_EXPECTED_MIRROR_PERSISTED_CAP (today's cap,
+ * 125) must flush OK and every entry must round-trip through a
+ * power-cycle. */
+void test_flush_and_load_at_persisted_cap_round_trips_all(void)
+{
+    uint16_t i;
+
+    register_n_dtcs_with_status(TEST_EXPECTED_MIRROR_PERSISTED_CAP);
+
+    TEST_ASSERT_EQUAL(UDS_STATUS_OK, dtc_mirror_flush_all());
+
+    /* Power-cycle: preserve NVM data, re-init all modules cleanly. */
+    nvm_mock_deinit();
+    nvm_store_init(NULL);
+    dtc_database_test_reset();
+    dtc_database_init();
+    dtc_mirror_test_reset();
+    dtc_mirror_init();
+
+    /* Re-register (as stack init would), then load. */
+    for (i = 0U; i < TEST_EXPECTED_MIRROR_PERSISTED_CAP; i++) {
+        uint32_t dtc_code = 0x010000UL + (uint32_t)i;
+        TEST_ASSERT_EQUAL(UDS_STATUS_OK,
+            dtc_database_register(dtc_code, 0x00U, NULL));
+    }
+
+    TEST_ASSERT_EQUAL(UDS_STATUS_OK, dtc_mirror_load());
+
+    for (i = 0U; i < TEST_EXPECTED_MIRROR_PERSISTED_CAP; i++) {
+        uint32_t     dtc_code = 0x010000UL + (uint32_t)i;
+        uint8_t      expected = (uint8_t)((i % 0xFFU) + 1U);
+        dtc_entry_t *e        = dtc_database_find(dtc_code);
+
+        TEST_ASSERT_NOT_NULL(e);
+        TEST_ASSERT_EQUAL_UINT8(expected, e->status_byte);
+    }
+}
+
+/* 15. THE REGRESSION TEST (issue #123): filling dtc_database to its full
+ * UDS_MAX_DTC_COUNT (128) capacity — three more than the mirror's
+ * persisted cap — must still flush OK.
+ *
+ * On unmodified pre-#123 source this assertion FAILS: mirror_serialize()
+ * walks all 128 registered entries, producing a 521-byte record
+ * (5 + 128*4 + 4), and nvm_store_write() rejects anything over
+ * NVM_MAX_RECORD_BYTES (512) — dtc_mirror_flush_all() returns a non-OK
+ * status instead of UDS_STATUS_OK. This is the exact issue #123 failure
+ * mode: silent persistence loss at worst-case fault load.
+ *
+ * After the fix, the mirror only ever serializes the first
+ * TEST_EXPECTED_MIRROR_PERSISTED_CAP entries (509 bytes) and the write
+ * succeeds. Entries beyond the cap are a documented limitation, not a
+ * crash or a truncated/corrupt write: after a power-cycle and reload,
+ * DTCs within the cap round-trip exactly, and DTCs beyond it come back at
+ * their power-on default (0x00) rather than the (nonzero) status set
+ * before the flush — proving they were simply never written, not
+ * partially/incorrectly written. */
+void test_flush_at_full_dtc_database_capacity_still_succeeds(void)
+{
+    uint16_t i;
+
+    TEST_ASSERT_EQUAL((uint16_t)128U, (uint16_t)UDS_MAX_DTC_COUNT);
+    TEST_ASSERT_TRUE((uint16_t)UDS_MAX_DTC_COUNT > TEST_EXPECTED_MIRROR_PERSISTED_CAP);
+
+    register_n_dtcs_with_status((uint16_t)UDS_MAX_DTC_COUNT);
+
+    TEST_ASSERT_EQUAL(UDS_STATUS_OK, dtc_mirror_flush_all());
+
+    /* Power-cycle and reload. */
+    nvm_mock_deinit();
+    nvm_store_init(NULL);
+    dtc_database_test_reset();
+    dtc_database_init();
+    dtc_mirror_test_reset();
+    dtc_mirror_init();
+
+    for (i = 0U; i < (uint16_t)UDS_MAX_DTC_COUNT; i++) {
+        uint32_t dtc_code = 0x010000UL + (uint32_t)i;
+        TEST_ASSERT_EQUAL(UDS_STATUS_OK,
+            dtc_database_register(dtc_code, 0x00U, NULL));
+    }
+
+    TEST_ASSERT_EQUAL(UDS_STATUS_OK, dtc_mirror_load());
+
+    /* Within the persisted cap: exact round-trip. */
+    for (i = 0U; i < TEST_EXPECTED_MIRROR_PERSISTED_CAP; i++) {
+        uint32_t     dtc_code = 0x010000UL + (uint32_t)i;
+        uint8_t      expected = (uint8_t)((i % 0xFFU) + 1U);
+        dtc_entry_t *e        = dtc_database_find(dtc_code);
+
+        TEST_ASSERT_NOT_NULL(e);
+        TEST_ASSERT_EQUAL_UINT8(expected, e->status_byte);
+    }
+
+    /* Beyond the persisted cap: documented as not persisted -> default 0x00,
+     * NOT the nonzero status that was set (and never written) before flush. */
+    for (i = TEST_EXPECTED_MIRROR_PERSISTED_CAP; i < (uint16_t)UDS_MAX_DTC_COUNT; i++) {
+        uint32_t     dtc_code = 0x010000UL + (uint32_t)i;
+        dtc_entry_t *e        = dtc_database_find(dtc_code);
+
+        TEST_ASSERT_NOT_NULL(e);
+        TEST_ASSERT_EQUAL_UINT8(0x00U, e->status_byte);
+    }
+}
+
+/* --------------------------------------------------------------------------
  * Test runner
  * -------------------------------------------------------------------------- */
 void run_all_tests(void)
@@ -318,4 +467,6 @@ void run_all_tests(void)
     RUN_TEST(test_zero_status_round_trips);
     RUN_TEST(test_get_by_index_null_guard);
     RUN_TEST(test_get_count_null_guard);
+    RUN_TEST(test_flush_and_load_at_persisted_cap_round_trips_all);
+    RUN_TEST(test_flush_at_full_dtc_database_capacity_still_succeeds);
 }


### PR DESCRIPTION
Closes #123

## Root cause

`config/dtc_mirror.h`'s `DTC_MIRROR_MAX_BYTES` was sized from
`UDS_MAX_DTC_COUNT` (128): `5 + 128*4 + 4 = 521` bytes. That was never
checked against `platform/nvm_store.h`'s `NVM_MAX_RECORD_BYTES` (512), a
hard per-record cap **shared with unrelated NVM consumers** (security
attempt counter, lockout timer, session stats, lifecycle counter, schema
version — verified by grepping every `NVM_MAX_RECORD_BYTES` /
`nvm_store_write()` consumer). Recomputed against the current header:
same numbers as the issue. Once the live DTC table grew past 125
entries, `nvm_store_write()`'s own `len > NVM_MAX_RECORD_BYTES` guard
silently rejected the mirror write. Both call sites already treat that
as best-effort/non-fatal (matching `dtc_mirror_save_one()`'s own
PERFORMANCE note), so nothing crashed — but ConfirmedDTC persistence
silently stopped updating exactly at worst-case fault load, the scenario
#114's integrity metadata exists to make trustworthy.

## Fix chosen: (b) — cap what dtc_mirror persists, not the shared NVM cap

The issue offered two options. I went with **(b)**, not (a):

- **(a) raise `NVM_MAX_RECORD_BYTES`** — rejected. It's shared by
  unrelated consumers; it sizes fixed-size RAM buffers in the host mock
  (`platform/zephyr/nvm_store_mock.c`, 16 slots × the constant) and the
  FreeRTOS backend (`platform/freertos/freertos_platform_api.c`); and
  it's baked into the Zephyr NVS wear-leveling sector math documented in
  `platform/zephyr/nvm_store.c`'s comments. None of that is
  DTC-mirror-specific, and none of it is in scope for this fix — exactly
  why #118 deferred it.
- **(b) cap what dtc_mirror persists** — chosen. New
  `DTC_MIRROR_MAX_PERSISTED_DTCS` = **125** (the largest entry count that
  fits `NVM_MAX_RECORD_BYTES` alongside the 5-byte header and 4-byte CRC
  trailer: `5 + 125*4 + 4 = 509 <= 512`; 126 → 513 doesn't). It bounds
  both the serializer's iteration (`mirror_serialize_internal()`) and the
  `DTC_MIRROR_MAX_BYTES` macro's own derivation (was `UDS_MAX_DTC_COUNT`,
  now `DTC_MIRROR_MAX_PERSISTED_DTCS`). A build-time `_Static_assert` in
  `dtc_mirror.c` (MISRA_ANALYSIS-guarded, same pattern already used in
  `core/uds_types.h`) ties `DTC_MIRROR_MAX_BYTES <= NVM_MAX_RECORD_BYTES`,
  so a future change to any sizing constant fails the **build**, not a
  silent runtime write.

`dtc_database` still holds up to `UDS_MAX_DTC_COUNT` (128) DTCs — nothing
there changed. Entries at index ≥ 125 simply are **not written** to the
NVM mirror on flush; this is now a documented limitation (in both
`dtc_mirror.h`'s file header and the constant's own comment), not a
truncated or corrupted write. `dtc_mirror_load()`'s corruption guard was
also tightened from `count > UDS_MAX_DTC_COUNT` to
`count > DTC_MIRROR_MAX_PERSISTED_DTCS` — safe, because no build (old or
new) could ever have successfully *written* a record with more than 125
entries; `nvm_store_write()` always rejected larger attempts.

Also fixed the misleading comment on `NVM_KEY_DTC_MIRROR` in
`platform/nvm_store.h` ("Maximum size: UDS_MAX_DTC_COUNT * 4 bytes = 512
bytes") — that's the exact naive arithmetic (ignoring the header/CRC
overhead) that made the original bug look safe at a glance.

## Regression tests

**`tests/unit_runnable/test_phase3_nvm_dtc.c`** (13 → 15 tests):
- `test_flush_and_load_at_persisted_cap_round_trips_all` — fills to
  exactly the new persisted cap (125 DTCs), flushes, simulates a
  power-cycle, reloads, asserts every entry round-trips byte-exact.
- `test_flush_at_full_dtc_database_capacity_still_succeeds` — **the
  regression check**: fills `dtc_database` to its full
  `UDS_MAX_DTC_COUNT` (128) capacity and asserts `dtc_mirror_flush_all()`
  still returns `UDS_STATUS_OK`; after a power-cycle + reload, entries
  within the cap round-trip exactly and entries beyond it come back at
  their power-on default (0x00) rather than the nonzero status set
  before flush — proving they were never written, not
  partially/incorrectly written.

**`tests/unit_runnable/test_dtc_mirror.c`** (27 → 29 tests):
- `test_old_full_table_sizing_would_have_exceeded_nvm_cap` — a
  standalone proof the defect was real, independent of today's cap:
  recomputes the *old* pre-#123 formula directly from the raw
  wire-format constants (`DTC_MIRROR_HEADER_BYTES` +
  `UDS_MAX_DTC_COUNT * DTC_MIRROR_ENTRY_BYTES` + `DTC_MIRROR_CRC_BYTES`)
  and asserts it's `521`, which exceeds `NVM_MAX_RECORD_BYTES` (512).
- `test_mirror_max_bytes_fits_nvm_cap` — runtime cross-check of the
  build-time `_Static_assert`, pinning the exact byte counts (125 → 509).

### Before/after proof (mandatory)

`git stash push` on just the 3 source files (`dtc_mirror.c`,
`dtc_mirror.h`, `nvm_store.h`), keeping the test changes, then rebuilt:

- **Unmodified source (pre-fix): 42/44 test modules pass, 2 fail.**
  - `test_dtc_mirror` — build failure (`TC-MIRROR-028` references the
    new `DTC_MIRROR_MAX_PERSISTED_DTCS` constant, by design — that test
    validates the new constant's existence/value).
  - `test_phase3_nvm_dtc` — **genuine runtime assertion failure**:
    `Expected 0 but got 3 (dtc_mirror_flush_all())` at
    `test_flush_at_full_dtc_database_capacity_still_succeeds` — `3` is
    `UDS_STATUS_ERR_INVALID_PARAM`, exactly the issue #123 failure mode.
    (The 125-cap round-trip test correctly passed even pre-fix, since
    ≤125 entries never hit the bug — confirming it's an orthogonal
    check, not the regression proof itself. Deliberately used a literal
    `125U` there instead of the new constant so the file still compiles
    against pre-fix source and demonstrates the real runtime bug rather
    than a masking build error.)
- **Restored: 44/44 pass, clean.**

## Gate results (this worktree, origin/main @ 2372b8f base)

- `bash build_tests.sh` → **44 passed, 0 failed** (baseline 44; no new
  test module added, only new test cases in existing modules).
- `bash build_harness.sh --run` → **68 / 68 PASS** (unchanged).
- `python3 misra_analysis.py --out misra.json` → **41 files, 1 finding,
  0 OPEN, 1 justified → PASS** (identical to baseline; GCC-only locally,
  cppcheck not installed — CI runs `--strict` + cppcheck).
- No-malloc gate (CI mirror grep) → prints nothing.
- `python3 scripts/verify_doc_counts.py` → **PASS** (44, no dead paths).
- `git status` clean aside from the intended changes; scratch files
  (misra.json/txt/csv, build dirs) removed before commit.

## New findings

None. No new/unrelated defects found while investigating this issue.

## Heightened review

`config/dtc_mirror.c`/`.h` are on CONTRIBUTING.md's heightened-review
list ("any file under `config/` that defines DTC status persistence").
Did an explicit self-review pass of the full diff before opening this
PR (sizing arithmetic, MISRA-guard pattern, corruption-guard tightening,
and the "no build could ever have written >125 entries" backward-
compatibility argument).

Reviewed-by: Xaloqi <contact@xaloqi.com>
