### PR TITLE
fix: propagate ISO-TP Flow Control transmit failures and add N_Ar (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,44 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **ISO-TP: every Flow Control transmit failure was discarded, and there was no
+  N_Ar timer at all.** (#122) Both `isotp_send_fc()` call sites in
+  `transport/isotp.c` threw the return value away with `(void)` — the comment at
+  the CTS site said so outright ("best-effort; ignore transmit errors"). If the
+  CAN controller rejected the FC (bus-off, full TX mailbox, arbitration loss
+  past the driver's own timeout), the receiver still transitioned to
+  `ISOTP_STATE_RX_WAIT_CF` and returned `UDS_STATUS_OK` as though flow control
+  had been granted. The sender never saw the FC and failed on its own N_Bs,
+  while the ECU silently burned its full N_Cr (150 ms) waiting for consecutive
+  frames that could not come — and the actual fault, a failed local transmit the
+  platform layer *did* report, was visible nowhere. Separately, ISO 15765-2
+  Table 5's **N_Ar** — the receiver-side mirror of N_As, the confirmation window
+  for the FC the receiver transmits, budgeted at 25 ms — did not exist in any
+  form: no `ISOTP_TIMEOUT_AR_MS`, no timer field. Both call sites now propagate
+  the status: a rejected FC drives the RX channel to `ISOTP_STATE_ERROR` and
+  returns `UDS_STATUS_ERR_TP_TX_FAILED`, matching how this file already handles
+  an RX fault that has mutated context (the CF handler's SN, DLC and overflow
+  paths) and how the TX path handles a failed `can_transport_transmit()` in
+  `isotp_tx_pump()`. At the OVERFLOW site the transmit failure now takes
+  precedence over `ERR_TP_OVERFLOW`, which would have reported the peer's
+  protocol condition while hiding our own hardware fault. New
+  `ISOTP_TIMEOUT_AR_MS` (25 ms) and `isotp_ctx_t.rx_ar_timer_ms` scope N_Ar to
+  the single FC transmit exactly as #111 scoped N_As: armed immediately before
+  `can_transport_transmit()`, stopped on its return, with a tick-handler branch
+  (new `UDS_STATUS_ERR_TP_TIMEOUT_AR`, 0x38) as the enforcement point for ports
+  whose transmit blocks — the Zephyr port blocks in `can_send()` for up to
+  `K_MSEC(25)`. The window after the FC is N_Cr, never N_Ar. Found in the same
+  pass as #111; the opposite defect class — #111 invented a spurious error on a
+  valid exchange, this one suppressed a genuine one. **Rebase note:** #121
+  (merged first) added a *third* `isotp_send_fc()` call site — the periodic
+  block-boundary FC the CF branch sends once BlockSize handling is in place —
+  which still discarded its status with `(void)` and an explicitly stale
+  comment claiming to mirror the FF handler's (by-then-fixed) CTS. Brought to
+  the same standard as the other two sites while reconciling the two branches,
+  with its own regression test
+  (`test_periodic_block_boundary_fc_tx_failure_is_reported`) proven to fail
+  against the unreconciled code and pass after.
+
 - **ISO-TP RX: the receiver advertised a BlockSize it never honoured — any
   `isotp_cfg_t.block_size > 0` stalled every inbound multi-frame transfer.**
   (#121) `isotp_init()` stored `cfg->block_size` into `ctx->local_block_size`

--- a/core/uds_types.h
+++ b/core/uds_types.h
@@ -127,6 +127,7 @@ typedef enum uds_status {
     UDS_STATUS_ERR_TP_TX_FAILED          = 0x35, /**< ISO-TP frame transmission failed. */
     UDS_STATUS_ERR_TP_UNEXPECTED_PDU     = 0x36, /**< Unexpected PDU type in current state. */
     UDS_STATUS_ERR_TP_TIMEOUT_BS         = 0x37, /**< ISO-TP Bs timeout expired (no FC received). */
+    UDS_STATUS_ERR_TP_TIMEOUT_AR         = 0x38, /**< ISO-TP Ar timeout expired (FC transmission confirmation). */
 
     /* --- CAN layer errors --- */
     UDS_STATUS_ERR_CAN_TX_FAILED         = 0x40, /**< CAN frame transmission failed. */

--- a/tests/unit_runnable/test_isotp.c
+++ b/tests/unit_runnable/test_isotp.c
@@ -48,12 +48,40 @@ static uds_can_frame_t  g_mock_tx_frames[16];
 static uint8_t          g_mock_tx_count;
 static uds_status_t     g_mock_tx_return;
 
+/*
+ * [#122] Flow-Control-specific transmit failure injection.
+ *
+ * g_mock_tx_return fails every frame indiscriminately, which cannot separate
+ * a rejected FC from a rejected SF/FF/CF. These hooks reject ONLY frames whose
+ * N_PCItype is FC, so the receiver-side FC transmit path can be exercised in
+ * isolation.
+ *
+ * g_mock_observed_ctx additionally samples ctx->rx_ar_timer_ms from *inside*
+ * the transmit call — i.e. within the N_Ar confirmation window — which is the
+ * only point at which an armed N_Ar is observable.
+ */
+static bool               g_mock_fail_on_fc;
+static const isotp_ctx_t *g_mock_observed_ctx;
+static uint32_t           g_mock_ar_timer_during_fc;
+static bool               g_mock_fc_observed;
+
 static uds_status_t mock_can_transmit(can_transport_t *self, const uds_can_frame_t *frame)
 {
     (void)self;
     if (g_mock_tx_count < 16U) {
         g_mock_tx_frames[g_mock_tx_count++] = *frame;
     }
+
+    if ((uint8_t)((frame->data[0] >> 4U) & 0x0FU) == (uint8_t)ISOTP_FRAME_TYPE_FC) {
+        if (g_mock_observed_ctx != NULL) {
+            g_mock_ar_timer_during_fc = g_mock_observed_ctx->rx_ar_timer_ms;
+            g_mock_fc_observed        = true;
+        }
+        if (g_mock_fail_on_fc) {
+            return UDS_STATUS_ERR_CAN_TX_FAILED;
+        }
+    }
+
     return g_mock_tx_return;
 }
 
@@ -109,6 +137,11 @@ static void mock_can_reset(void)
     memset(g_mock_tx_frames, 0, sizeof(g_mock_tx_frames));
     g_mock_tx_count  = 0U;
     g_mock_tx_return = UDS_STATUS_OK;
+    /* [#122] */
+    g_mock_fail_on_fc         = false;
+    g_mock_observed_ctx       = NULL;
+    g_mock_ar_timer_during_fc = 0U;
+    g_mock_fc_observed        = false;
 }
 
 static void rx_cb_reset(void)
@@ -642,6 +675,172 @@ ZTEST(test_isotp_rx_multi, test_rx_block_size_zero_single_fc)
                   "Reassembled payload must be byte-identical to what was sent");
 }
 
+/**
+ * TC-ISTP-RX-MF-005 [#122]: FF whose FC CTS transmit is rejected by the CAN
+ *                            controller must NOT be reported as success.
+ *
+ * ISO 15765-2 Table 5 gives the receiver an N_Ar window for the Flow Control
+ * frame it transmits. If the data link layer rejects that frame (bus-off, full
+ * TX mailbox, arbitration loss past the driver's own timeout), flow control was
+ * never granted: the sender never saw an FC and will never send a CF.
+ *
+ * Returning UDS_STATUS_OK and entering ISOTP_STATE_RX_WAIT_CF makes the ECU
+ * burn its full N_Cr (150 ms) waiting for consecutive frames that cannot come,
+ * while the real fault -- a local transmit failure the platform layer DID
+ * report -- is visible nowhere.
+ */
+ZTEST(test_isotp_rx_multi, test_ff_fc_cts_tx_failure_is_reported)
+{
+    mock_can_reset();
+    rx_cb_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp(&ctx), UDS_STATUS_OK, "init failed");
+
+    /* Reject ONLY the Flow Control frame; SF/FF/CF transmits still succeed. */
+    g_mock_fail_on_fc = true;
+
+    /* FF: total_len = 10 bytes, first 6 bytes = 0x01..0x06 */
+    uint8_t ff_payload[] = { 0x10U, 0x0AU, 0x01U, 0x02U, 0x03U, 0x04U, 0x05U, 0x06U };
+    uds_can_frame_t ff = make_can_frame(0x7DFU, ff_payload, 8U);
+    uds_status_t rc = isotp_process_rx_frame(&ctx, &ff, rx_complete_cb, NULL);
+
+    /* The FC must genuinely have been attempted -- otherwise this test is vacuous. */
+    zassert_true(g_mock_tx_count >= 1U, "FC CTS must be attempted after an FF");
+    zassert_equal((g_mock_tx_frames[0].data[0] >> 4U), (uint8_t)ISOTP_FRAME_TYPE_FC,
+                  "Attempted frame must be of FC type");
+
+    zassert_not_equal(rc, UDS_STATUS_OK,
+                      "A rejected FC transmit must not be reported as success");
+    zassert_equal(rc, UDS_STATUS_ERR_TP_TX_FAILED,
+                  "FC transmit failure must surface as ERR_TP_TX_FAILED");
+
+    isotp_state_t state;
+    zassert_equal(isotp_get_state(&ctx, &state), UDS_STATUS_OK, "get_state failed");
+    zassert_not_equal(state, ISOTP_STATE_RX_WAIT_CF,
+                      "Must not await CFs that flow control never authorised");
+    zassert_equal(state, ISOTP_STATE_ERROR,
+                  "RX channel must go to ERROR after a failed FC transmit");
+    zassert_false(g_rx_cb_called, "No callback for an aborted reassembly");
+}
+
+/**
+ * TC-ISTP-RX-MF-006 [#122]: control case -- the FC failure injection used by
+ * TC-ISTP-RX-MF-005 is specific to Flow Control frames.
+ *
+ * A Single Frame reception transmits nothing at all, so it must be completely
+ * unaffected while g_mock_fail_on_fc is set. This pins the injection to the FC
+ * path and rules out a blanket "all transmits fail" reading of MF-005.
+ */
+ZTEST(test_isotp_rx_multi, test_fc_tx_failure_injection_is_fc_specific)
+{
+    mock_can_reset();
+    rx_cb_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp(&ctx), UDS_STATUS_OK, "init failed");
+
+    g_mock_fail_on_fc = true;
+
+    uint8_t sf_payload[] = { 0x03U, 0xAAU, 0xBBU, 0xCCU, 0x00U, 0x00U, 0x00U, 0x00U };
+    uds_can_frame_t sf = make_can_frame(0x7DFU, sf_payload, 8U);
+    uds_status_t rc = isotp_process_rx_frame(&ctx, &sf, rx_complete_cb, NULL);
+
+    zassert_equal(rc, UDS_STATUS_OK, "SF RX sends no FC and must still succeed");
+    zassert_true(g_rx_cb_called, "SF callback must fire");
+    zassert_equal(g_rx_cb_len, 3U, "SF payload length mismatch");
+    zassert_equal(g_mock_tx_count, 0U, "SF RX must not transmit any frame");
+}
+
+/**
+ * TC-ISTP-RX-MF-007 [#122]: N_Ar is armed across the FC transmit and stopped on
+ *                            its confirmation -- and never leaks into N_Cr.
+ *
+ * N_Ar (ISO 15765-2 Table 5, 25 ms) is the receiver-side mirror of N_As: it
+ * measures ONE frame's request-to-confirmation window, here the FC the receiver
+ * transmits. The timer is only observable from inside can_transport_transmit(),
+ * which is where the mock samples it; after the call returns it must be zero,
+ * and the wait that follows belongs to N_Cr, not N_Ar.
+ */
+ZTEST(test_isotp_rx_multi, test_n_ar_armed_across_fc_transmit_only)
+{
+    mock_can_reset();
+    rx_cb_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp(&ctx), UDS_STATUS_OK, "init failed");
+
+    g_mock_observed_ctx = &ctx;
+
+    uint8_t ff_payload[] = { 0x10U, 0x0AU, 0x01U, 0x02U, 0x03U, 0x04U, 0x05U, 0x06U };
+    uds_can_frame_t ff = make_can_frame(0x7DFU, ff_payload, 8U);
+    zassert_equal(isotp_process_rx_frame(&ctx, &ff, rx_complete_cb, NULL),
+                  UDS_STATUS_OK, "FF with a successful FC must succeed");
+
+    zassert_true(g_mock_fc_observed, "FC transmit must have been observed");
+    zassert_equal(g_mock_ar_timer_during_fc, (uint32_t)ISOTP_TIMEOUT_AR_MS,
+                  "N_Ar must be armed for the duration of the FC transmit");
+    zassert_equal(ctx.rx_ar_timer_ms, 0U,
+                  "N_Ar must stop on the FC transmission confirmation");
+
+    /* The window that follows is N_Cr, not N_Ar -- ticking must not fire N_Ar. */
+    zassert_equal(isotp_tick_1ms(&ctx), UDS_STATUS_OK,
+                  "Tick in RX_WAIT_CF must not report an N_Ar timeout");
+    zassert_equal(ctx.rx_ar_timer_ms, 0U, "N_Ar must stay stopped in RX_WAIT_CF");
+}
+
+/**
+ * TC-ISTP-RX-MF-007 [#121 x #122 reconciliation]: the periodic block-boundary
+ * FC that BlockSize handling (#121) sends from the CF branch is a THIRD
+ * isotp_send_fc() call site, alongside the two the FF handler already covers
+ * (TC-ISTP-RX-MF-005/006 above). It must be held to the same standard: a
+ * rejected transmit must not be silently absorbed.
+ *
+ * Uses the BS=2 fixture from the block-size regression tests: FF, CF1 (no FC
+ * -- block not yet full), then CF2, which crosses the BS=2 boundary and must
+ * trigger a fresh FC CTS. Only THAT FC is made to fail -- the FF's initial
+ * CTS must still succeed, or this test would not isolate the third call site.
+ */
+ZTEST(test_isotp_rx_multi, test_periodic_block_boundary_fc_tx_failure_is_reported)
+{
+    mock_can_reset();
+    rx_cb_reset();
+    isotp_ctx_t ctx;
+    uint8_t     payload[ISOTP_BS_TEST_PDU_LEN];
+    memset(&ctx, 0, sizeof(ctx));
+    bs_test_make_payload(payload);
+    zassert_equal(init_isotp_bs(&ctx, 2U, 0U), UDS_STATUS_OK, "init failed");
+
+    zassert_equal(bs_test_send_ff(&ctx, payload), UDS_STATUS_OK,
+                  "FF with a successful FC must succeed");
+    zassert_equal(g_mock_tx_count, 1U, "FF's FC must be the only frame sent so far");
+
+    zassert_equal(bs_test_send_cf(&ctx, payload, 1U), UDS_STATUS_OK,
+                  "CF1 must be accepted; block not yet full at BS=2");
+    zassert_equal(g_mock_tx_count, 1U, "CF1 alone must not yet trigger a block FC");
+
+    /* Reject only the FC that CF2 is about to trigger. */
+    g_mock_fail_on_fc = true;
+
+    uds_status_t rc = bs_test_send_cf(&ctx, payload, 2U);
+
+    zassert_equal(g_mock_tx_count, 2U,
+                  "The block-boundary FC must genuinely have been attempted");
+    zassert_equal((g_mock_tx_frames[1].data[0] >> 4U), (uint8_t)ISOTP_FRAME_TYPE_FC,
+                  "The second attempted frame must be of FC type");
+
+    zassert_not_equal(rc, UDS_STATUS_OK,
+                      "A rejected block-boundary FC must not be reported as success");
+    zassert_equal(rc, UDS_STATUS_ERR_TP_TX_FAILED,
+                  "Block-boundary FC transmit failure must surface as ERR_TP_TX_FAILED");
+
+    isotp_state_t state;
+    zassert_equal(isotp_get_state(&ctx, &state), UDS_STATUS_OK, "get_state failed");
+    zassert_equal(state, ISOTP_STATE_ERROR,
+                  "RX channel must go to ERROR after a failed block-boundary FC transmit");
+    zassert_false(g_rx_cb_called, "No callback for an aborted reassembly");
+}
+
 #if ISOTP_ENABLE_CAN_FD
 /**
  * TC-ISTP-RX-MF-004: CAN FD FF escape sequence with FF_DL > ISOTP_RX_BUF_LEN
@@ -673,6 +872,48 @@ ZTEST(test_isotp_rx_multi, test_ff_overflow)
                   "Transmitted frame must be FC type");
     zassert_equal((g_mock_tx_frames[0].data[0] & 0x0FU), (uint8_t)ISOTP_FC_STATUS_OVERFLOW,
                   "FC status must be OVERFLOW");
+}
+
+/**
+ * TC-ISTP-RX-MF-008 [#122]: FF_DL overflow whose FC OVFLW transmit is itself
+ *                            rejected must report the transmit failure.
+ *
+ * Reachable only under CAN FD: on Classic CAN the 12-bit FF_DL cannot exceed
+ * ISOTP_RX_BUF_LEN (4095), so the OVERFLOW branch is dead there.
+ *
+ * A rejected FC transmit means the local CAN link is down (bus-off / mailbox
+ * full), which invalidates the channel -- not merely this one PDU. Returning
+ * ERR_TP_OVERFLOW would report the peer's protocol condition while hiding our
+ * own hardware fault, which is the exact inversion #122 is about.
+ */
+ZTEST(test_isotp_rx_multi, test_ff_overflow_fc_tx_failure_is_reported)
+{
+    mock_can_reset();
+    rx_cb_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp_fd(&ctx), UDS_STATUS_OK, "init failed");
+
+    g_mock_fail_on_fc = true;
+
+    uint8_t ff_payload[] = {
+        0x10U, 0x00U,               /* FF type, escape sequence trigger */
+        0x00U, 0x00U, 0x13U, 0x88U, /* FF_DL = 5000 (big-endian) */
+        0x01U, 0x02U, 0x03U, 0x04U, 0x05U, 0x06U
+    };
+    uds_can_frame_t ff = make_fd_frame(0x7DFU, ff_payload, 12U);
+    uds_status_t rc = isotp_process_rx_frame(&ctx, &ff, rx_complete_cb, NULL);
+
+    zassert_true(g_mock_tx_count >= 1U, "FC OVFLW must be attempted");
+    zassert_equal((g_mock_tx_frames[0].data[0] & 0x0FU), (uint8_t)ISOTP_FC_STATUS_OVERFLOW,
+                  "Attempted FC must carry OVFLW");
+    zassert_equal(rc, UDS_STATUS_ERR_TP_TX_FAILED,
+                  "A rejected FC OVFLW transmit must surface as ERR_TP_TX_FAILED");
+
+    isotp_state_t state;
+    zassert_equal(isotp_get_state(&ctx, &state), UDS_STATUS_OK, "get_state failed");
+    zassert_equal(state, ISOTP_STATE_ERROR,
+                  "RX channel must go to ERROR after a failed FC transmit");
 }
 #endif /* ISOTP_ENABLE_CAN_FD — test_ff_overflow */
 
@@ -1411,8 +1652,13 @@ extern void test_isotp_rx_multi__test_ff_cf_complete(void);
 extern void test_isotp_rx_multi__test_cf_without_ff(void);
 extern void test_isotp_rx_multi__test_rx_block_size_periodic_fc(void);
 extern void test_isotp_rx_multi__test_rx_block_size_zero_single_fc(void);
+extern void test_isotp_rx_multi__test_ff_fc_cts_tx_failure_is_reported(void);
+extern void test_isotp_rx_multi__test_fc_tx_failure_injection_is_fc_specific(void);
+extern void test_isotp_rx_multi__test_n_ar_armed_across_fc_transmit_only(void);
+extern void test_isotp_rx_multi__test_periodic_block_boundary_fc_tx_failure_is_reported(void);
 #if ISOTP_ENABLE_CAN_FD
 extern void test_isotp_rx_multi__test_ff_overflow(void);
+extern void test_isotp_rx_multi__test_ff_overflow_fc_tx_failure_is_reported(void);
 extern void test_isotp_canfd__test_fd_sf_rx_10_bytes(void);
 extern void test_isotp_canfd__test_fd_sf_rx_62_bytes(void);
 extern void test_isotp_canfd__test_fd_sf_rx_zero_dl(void);
@@ -1464,8 +1710,13 @@ void run_all_tests(void)
     RUN_TEST(test_isotp_rx_multi__test_cf_without_ff);
     RUN_TEST(test_isotp_rx_multi__test_rx_block_size_periodic_fc);
     RUN_TEST(test_isotp_rx_multi__test_rx_block_size_zero_single_fc);
+    RUN_TEST(test_isotp_rx_multi__test_ff_fc_cts_tx_failure_is_reported);
+    RUN_TEST(test_isotp_rx_multi__test_fc_tx_failure_injection_is_fc_specific);
+    RUN_TEST(test_isotp_rx_multi__test_n_ar_armed_across_fc_transmit_only);
+    RUN_TEST(test_isotp_rx_multi__test_periodic_block_boundary_fc_tx_failure_is_reported);
 #if ISOTP_ENABLE_CAN_FD
     RUN_TEST(test_isotp_rx_multi__test_ff_overflow);
+    RUN_TEST(test_isotp_rx_multi__test_ff_overflow_fc_tx_failure_is_reported);
     RUN_TEST(test_isotp_canfd__test_fd_sf_rx_10_bytes);
     RUN_TEST(test_isotp_canfd__test_fd_sf_rx_62_bytes);
     RUN_TEST(test_isotp_canfd__test_fd_sf_rx_zero_dl);

--- a/transport/isotp.c
+++ b/transport/isotp.c
@@ -12,7 +12,7 @@
  *   [P2-TP-02] FF reception and FC transmission — fully implemented.
  *   [P2-TP-03] CF reception and reassembly — fully implemented.
  *   [P2-TP-04] FC reception and segmented TX state machine — fully implemented.
- *   [P2-TP-05] As/Bs/Cr timeout enforcement in isotp_tick_1ms.
+ *   [P2-TP-05] As/Ar/Bs/Cr timeout enforcement in isotp_tick_1ms.
  *   [P2-TP-06] STmin inter-frame delay for TX consecutive frames.
  *   [P2-TP-07] CAN FD SF and FF encoding added (ISO 15765-2 §9.8):
  *              SF RX/TX: byte 0 = 0x00, byte 1 = SF_DL (1-62) when frame->is_fd.
@@ -221,9 +221,10 @@ uds_status_t isotp_process_rx_frame(
          *            bytes 2-5 = 32-bit big-endian FF_DL.
          * ---------------------------------------------------------------- */
         case (uint8_t)ISOTP_FRAME_TYPE_FF: {
-            uint32_t ff_dl;
-            uint8_t  ff_data_bytes;
-            uint8_t  ff_data_offset;
+            uint32_t     ff_dl;
+            uint8_t      ff_data_bytes;
+            uint8_t      ff_data_offset;
+            uds_status_t fc_rc;
 
             /* FF_DL: 12 bits from (byte0 & 0x0F) << 8 | byte1. */
             ff_dl = (uint32_t)(((uint32_t)(frame->data[0] & (uint8_t)0x0FU) << 8U)
@@ -263,10 +264,23 @@ uds_status_t isotp_process_rx_frame(
 
             /* Reject if assembled PDU exceeds the static RX buffer. */
             if (ff_dl > (uint32_t)ISOTP_RX_BUF_LEN) {
-                (void)isotp_send_fc(ctx,
-                                    (uint8_t)ISOTP_FC_STATUS_OVERFLOW,
-                                    (uint8_t)0U,
-                                    (uint8_t)0U);
+                fc_rc = isotp_send_fc(ctx,
+                                      (uint8_t)ISOTP_FC_STATUS_OVERFLOW,
+                                      (uint8_t)0U,
+                                      (uint8_t)0U);
+                /*
+                 * [#122] A rejected FC transmit is a local data link fault
+                 * (bus-off, full TX mailbox, arbitration loss past the
+                 * driver's own timeout) that invalidates the whole RX channel,
+                 * not just this PDU. Reporting ERR_TP_OVERFLOW here would
+                 * surface the peer's protocol condition while hiding our own
+                 * hardware fault, which is the more severe and the more
+                 * actionable of the two.
+                 */
+                if (fc_rc != UDS_STATUS_OK) {
+                    ctx->rx_state = ISOTP_STATE_ERROR;
+                    return UDS_STATUS_ERR_TP_TX_FAILED;
+                }
                 return UDS_STATUS_ERR_TP_OVERFLOW;
             }
 
@@ -289,11 +303,30 @@ uds_status_t isotp_process_rx_frame(
             ctx->rx_cr_timer_ms     = (uint32_t)ISOTP_TIMEOUT_CR_MS;
             ctx->rx_state           = ISOTP_STATE_RX_WAIT_CF;
 
-            /* Send FC CTS — best-effort; ignore transmit errors. */
-            (void)isotp_send_fc(ctx,
-                                (uint8_t)ISOTP_FC_STATUS_CONTINUE_TO_SEND,
-                                ctx->local_block_size,
-                                ctx->local_stmin_ms);
+            /*
+             * [#122] Send FC CTS. The status is NOT best-effort: if the data
+             * link layer rejects the FC, flow control was never granted. The
+             * sender never saw an FC, so no consecutive frame can ever arrive,
+             * and staying in ISOTP_STATE_RX_WAIT_CF would silently burn the
+             * full N_Cr (150 ms) on a transfer that cannot progress while the
+             * genuine fault — a local transmit failure the platform layer DID
+             * report — went unreported.
+             *
+             * ISOTP_STATE_ERROR + the returned status matches how this file
+             * already handles an RX fault that has mutated context (see the CF
+             * handler's SN, DLC and overflow paths) and how the TX path handles
+             * a failed can_transport_transmit() in isotp_tx_pump(). Recovery is
+             * via isotp_reset(), as for every other RX error.
+             */
+            fc_rc = isotp_send_fc(ctx,
+                                  (uint8_t)ISOTP_FC_STATUS_CONTINUE_TO_SEND,
+                                  ctx->local_block_size,
+                                  ctx->local_stmin_ms);
+            if (fc_rc != UDS_STATUS_OK) {
+                ctx->rx_state       = ISOTP_STATE_ERROR;
+                ctx->rx_cr_timer_ms = 0U;  /* no CF can arrive — disarm N_Cr */
+                return UDS_STATUS_ERR_TP_TX_FAILED;
+            }
 
             return UDS_STATUS_OK;
         }
@@ -302,10 +335,11 @@ uds_status_t isotp_process_rx_frame(
          * [P2-TP-03] Consecutive Frame (CF) reception
          * ---------------------------------------------------------------- */
         case (uint8_t)ISOTP_FRAME_TYPE_CF: {
-            uint8_t  sn;
-            uint32_t remaining;
-            uint8_t  cf_data;
-            uint32_t copy_len;
+            uint8_t      sn;
+            uint32_t     remaining;
+            uint8_t      cf_data;
+            uint32_t     copy_len;
+            uds_status_t fc_rc;
 
             if (ctx->rx_state != ISOTP_STATE_RX_WAIT_CF) {
                 return UDS_STATUS_ERR_TP_UNEXPECTED_PDU;
@@ -373,11 +407,24 @@ uds_status_t isotp_process_rx_frame(
 
                     if (ctx->rx_blocks_received >= ctx->local_block_size) {
                         ctx->rx_blocks_received = (uint8_t)0U;
-                        /* Best-effort, mirroring the FF handler's CTS. */
-                        (void)isotp_send_fc(ctx,
-                                            (uint8_t)ISOTP_FC_STATUS_CONTINUE_TO_SEND,
-                                            ctx->local_block_size,
-                                            ctx->local_stmin_ms);
+                        /*
+                         * [#122] NOT best-effort — same reasoning as the FF
+                         * handler's CTS just below in this same file: a
+                         * rejected FC here means the sender never sees
+                         * permission to continue and no further CF can
+                         * arrive, so silently proceeding would burn the full
+                         * N_Cr on a transfer that cannot progress while the
+                         * genuine local transmit fault goes unreported.
+                         */
+                        fc_rc = isotp_send_fc(ctx,
+                                              (uint8_t)ISOTP_FC_STATUS_CONTINUE_TO_SEND,
+                                              ctx->local_block_size,
+                                              ctx->local_stmin_ms);
+                        if (fc_rc != UDS_STATUS_OK) {
+                            ctx->rx_state       = ISOTP_STATE_ERROR;
+                            ctx->rx_cr_timer_ms = 0U;  /* no CF can arrive */
+                            return UDS_STATUS_ERR_TP_TX_FAILED;
+                        }
                     }
                 }
             }
@@ -670,6 +717,27 @@ uds_status_t isotp_tick_1ms(isotp_ctx_t *ctx)
         }
     }
 
+    /* --- RX Ar timer (FC transmission confirmation) ---
+     *
+     * [#122] N_Ar mirrors N_As on the receiver side. isotp_send_fc() arms it
+     * immediately before can_transport_transmit() and stops it on that call's
+     * return, so under the single diagnostics-task model used by every
+     * reference integration it is never still armed when a tick lands and this
+     * branch cannot fire. It is the enforcement point should an FC confirmation
+     * ever be left outstanding across a tick boundary — can_transport_transmit()
+     * is permitted to block (the Zephyr port blocks in can_send() for up to
+     * K_MSEC(25)), so an integration that drives isotp_tick_1ms() from an
+     * independent timer context can observe the window and must not be left
+     * without a bound on it.
+     */
+    if (ctx->rx_ar_timer_ms > 0U) {
+        ctx->rx_ar_timer_ms--;
+        if (ctx->rx_ar_timer_ms == 0U) {
+            ctx->rx_state = ISOTP_STATE_ERROR;
+            return UDS_STATUS_ERR_TP_TIMEOUT_AR;
+        }
+    }
+
     /* --- TX As timer (single-frame transmission confirmation) ---
      *
      * [#111] N_As guards ONE frame's request-to-confirmation window, not the
@@ -736,6 +804,7 @@ uds_status_t isotp_reset(isotp_ctx_t *ctx)
     ctx->rx_expected_sn     = (uint8_t)0U;
     ctx->rx_blocks_received = (uint8_t)0U;
     ctx->rx_cr_timer_ms     = 0U;
+    ctx->rx_ar_timer_ms     = 0U;
     ctx->tx_data            = NULL;
     ctx->tx_total_len       = (uint32_t)0U;
     ctx->tx_sent_len        = (uint32_t)0U;
@@ -787,6 +856,7 @@ static uds_status_t isotp_send_fc(
     uint8_t      stmin)
 {
     uds_can_frame_t fc_frame;
+    uds_status_t    tx_rc;
 
     if (ctx == NULL) {
         return UDS_STATUS_ERR_NULL_PTR;
@@ -806,7 +876,23 @@ static uds_status_t isotp_send_fc(
     isotp_pad_frame(fc_frame.data, (uint8_t)3U, (uint8_t)8U);
 #endif
 
-    return can_transport_transmit(ctx->can, &fc_frame);
+    /*
+     * [#122] N_Ar (ISO 15765-2 Table 5) is the receiver-side mirror of N_As:
+     * the confirmation window of the ONE frame the receiver transmits, the FC.
+     * It is armed immediately before the N_PDU is handed to the data link
+     * layer and stopped on that frame's transmission confirmation, which at
+     * this layer is can_transport_transmit()'s return — exactly as the TX path
+     * scopes N_As since #111. The window that follows the FC is N_Cr, never
+     * N_Ar, so the timer must not stay armed past this call.
+     *
+     * The status is returned, never discarded: a rejected FC means flow
+     * control was not granted and the reassembly cannot proceed.
+     */
+    ctx->rx_ar_timer_ms = (uint32_t)ISOTP_TIMEOUT_AR_MS;
+    tx_rc               = can_transport_transmit(ctx->can, &fc_frame);
+    ctx->rx_ar_timer_ms = 0U;
+
+    return tx_rc;
 }
 
 #if ISOTP_TX_PADDING

--- a/transport/isotp.h
+++ b/transport/isotp.h
@@ -45,6 +45,21 @@ extern "C" {
 #define ISOTP_TIMEOUT_AS_MS   (25U)
 #endif
 
+/**
+ * Ar: Receiver side timeout for the transmission confirmation of a SINGLE
+ * CAN frame (ISO 15765-2:2016 Table 5) — the exact receiver-side mirror of
+ * N_As, and budgeted identically at 25 ms.
+ *
+ * The only frame the receiver transmits during a reassembly is the Flow
+ * Control frame, so N_Ar is the confirmation window of that FC. It starts
+ * when the FC N_PDU is passed to the data link layer and stops on that
+ * frame's transmission confirmation. It is NOT the wait for consecutive
+ * frames — that window is ISOTP_TIMEOUT_CR_MS.
+ */
+#ifndef ISOTP_TIMEOUT_AR_MS
+#define ISOTP_TIMEOUT_AR_MS   (25U)
+#endif
+
 /** Bs: Sender side timeout to receive a Flow Control frame. */
 #ifndef ISOTP_TIMEOUT_BS_MS
 #define ISOTP_TIMEOUT_BS_MS   (75U)
@@ -197,6 +212,7 @@ typedef struct isotp_ctx {
     uint8_t          rx_expected_sn;                    /**< Expected consecutive frame SN. */
     uint8_t          rx_blocks_received;                /**< [#121] CFs received in current block. */
     uint32_t         rx_cr_timer_ms;                    /**< Cr timeout countdown (ms). */
+    uint32_t         rx_ar_timer_ms;                    /**< Ar timeout countdown (ms) — armed only across the FC frame's transmission confirmation. */
 
     /* TX state */
     isotp_state_t    tx_state;                          /**< Current TX state. */
@@ -296,6 +312,9 @@ uds_status_t isotp_init(isotp_ctx_t *ctx, const isotp_cfg_t *cfg);
  * @return UDS_STATUS_ERR_TP_FRAME_INVALID if frame format is not recognized.
  * @return UDS_STATUS_ERR_TP_OVERFLOW if RX buffer would be exceeded.
  * @return UDS_STATUS_ERR_TP_UNEXPECTED_PDU if frame received in invalid state.
+ * @return UDS_STATUS_ERR_TP_TX_FAILED if the Flow Control frame this function
+ *         had to transmit was rejected by the data link layer. The RX channel
+ *         is left in ISOTP_STATE_ERROR and requires isotp_reset().
  *
  * @note TIMING: Must complete within CAN frame inter-arrival time.
  */
@@ -335,18 +354,23 @@ uds_status_t isotp_transmit(
 /**
  * @brief 1 ms periodic tick for ISO-TP timer management.
  *
- * Drives Cr, Bs, and As timeout timers. Transitions channel to
+ * Drives Cr, Ar, Bs, and As timeout timers. Transitions channel to
  * ISOTP_STATE_ERROR on timeout expiry.
  *
  * @note As is scoped to one frame's transmission confirmation and is stopped
  *       by the TX path as soon as can_transport_transmit() returns, so it does
  *       not bound the FC wait (Bs) or a multi-frame CF sequence (STmin).
+ * @note Ar is the receiver-side mirror of As, scoped to the Flow Control
+ *       frame's transmission confirmation and stopped by isotp_send_fc() as
+ *       soon as can_transport_transmit() returns. It does not bound the wait
+ *       for consecutive frames (Cr).
  *
  * @param[in] ctx  Initialized ISO-TP context.
  *
  * @return UDS_STATUS_OK if no timeout occurred.
  * @return UDS_STATUS_ERR_TP_TIMEOUT_CR if Cr timer expired.
  * @return UDS_STATUS_ERR_TP_TIMEOUT_AS if As timer expired.
+ * @return UDS_STATUS_ERR_TP_TIMEOUT_AR if Ar timer expired (FC confirmation).
  * @return UDS_STATUS_ERR_TP_TIMEOUT_BS if Bs timer expired (no FC received).
  * @return UDS_STATUS_ERR_NULL_PTR if ctx is NULL.
  *


### PR DESCRIPTION
## Root cause

Both `isotp_send_fc()` call sites in `transport/isotp.c` discarded the return value with `(void)` — the comment at the CTS site said so outright (*"best-effort; ignore transmit errors"*). Separately, ISO 15765-2 Table 5's **N_Ar** — the receiver-side mirror of N_As, the confirmation window for the FC frame the receiver transmits, budgeted at 25 ms — did not exist in any form: no `ISOTP_TIMEOUT_AR_MS`, no timer field.

If the CAN controller rejected the FC (bus-off, full TX mailbox, arbitration loss past the driver's own timeout), the receiver nonetheless transitioned to `ISOTP_STATE_RX_WAIT_CF` and returned `UDS_STATUS_OK` as though flow control had been granted. The sender never saw the FC and failed on its own N_Bs, while the ECU silently burned its full N_Cr (150 ms) waiting for consecutive frames that could not come. The actual fault — a failed local transmit that the platform layer **did** report — was visible nowhere.

Opposite defect class to #111: that one invented a spurious error on a valid exchange; this one suppressed a genuine one.

## The fix

### 1. Status propagation (both call sites)

Both sites now capture `isotp_send_fc()`'s status. On failure the RX channel goes to `ISOTP_STATE_ERROR` **and** the function returns `UDS_STATUS_ERR_TP_TX_FAILED`.

**Why both, and not just one** — this is what the file already does for an RX fault that has mutated context. The CF handler's wrong-SN, short-DLC and mid-transfer-overflow paths each set `rx_state = ISOTP_STATE_ERROR` and then return a status. Checking the TX side for symmetry, as the issue asks: `isotp_tx_pump()` sets `ISOTP_STATE_ERROR` on a failed `can_transport_transmit()` (it is `void` and has no other channel); `isotp_transmit()`'s FF paths return `ERR_TP_TX_FAILED` *without* entering `TX_WAIT_FC`, and can afford to leave the state `IDLE` only because nothing has been mutated yet.

At the FF CTS site there is no such clean-abort option: the FF payload is already committed to `rx_buf` and `rx_state` has already advanced, so the reassembly is definitively unsatisfiable and the channel must say so. Recovery is `isotp_reset()`, as for every other RX error. N_Cr is disarmed on that path — no CF can arrive.

At the **OVERFLOW** site the transmit failure now takes precedence over the `ERR_TP_OVERFLOW` that would otherwise be returned. A rejected FC transmit is a local data-link fault that invalidates the whole RX channel, not just this PDU; returning `ERR_TP_OVERFLOW` would report the *peer's* protocol condition while hiding *our own* hardware fault — the exact inversion this issue is about. When the FC OVFLW transmit succeeds, behaviour is unchanged (the existing `test_ff_overflow` still passes untouched).

### 2. N_Ar

New `ISOTP_TIMEOUT_AR_MS` (`25U`, matching N_As's budget per Table 5) and `isotp_ctx_t.rx_ar_timer_ms`, scoped exactly as #111 scoped N_As: armed immediately before `can_transport_transmit()` inside `isotp_send_fc()`, stopped on its return — the transmission-confirmation point at this layer. The window that follows an FC is N_Cr, never N_Ar, so the timer cannot accumulate. A tick-handler branch returns the new `UDS_STATUS_ERR_TP_TIMEOUT_AR` (0x38) on expiry.

### Synchronous-vs-timer reasoning (issue item 4)

I re-derived this rather than assuming, and landed on #111's answer for the same underlying reason.

`isotp_send_fc()` calls the **identical** `can_transport_transmit()` that the TX path calls, and that call is **not uniformly synchronous across the ports**:

- **Zephyr** (`platform/zephyr/zephyr_can.c:184`) blocks in `can_send(plat->can_dev, &zf, K_MSEC(25), NULL, NULL)` — a real, blocking 25 ms window.
- **FreeRTOS** forwards to a customer-supplied `eds_can_send_fn_t`, whose contract in `transport/can_transport.h:55` is *"accepted for transmission"*, non-blocking preferred — i.e. an enqueue.

So "returns synchronously with a status in the same tick" is true of the *EDS layer's* contract but not of the underlying transmit. Under the single diagnostics-task model every reference integration uses (`examples/*/src/main.c`, `platform/freertos/freertos_platform_api.c:576` — `isotp_tick_1ms()` and `isotp_process_rx_frame()` are called sequentially from one loop), a tick cannot land between the arm and the stop, and the tick branch does not fire there. It is the enforcement point for an integration that drives `isotp_tick_1ms()` from a context independent of the RX path, where a blocking transmit leaves the window genuinely observable and otherwise unbounded.

The field is **not dead state**, and the tests prove it rather than asserting it: `TC-ISTP-RX-MF-007` samples `rx_ar_timer_ms` from *inside* the transmit call — the only point an armed N_Ar is observable — and asserts it equals `ISOTP_TIMEOUT_AR_MS` there and is zero on return.

Implementing N_Ar differently from its own mirror would also reintroduce precisely the kind of divergence between paired ISO 15765-2 timers that produced #111 in the first place.

## Regression test — before/after proof

Four cases added to `tests/unit_runnable/test_isotp.c`, alongside the existing ISO-TP RX tests, plus **FC-specific** transmit-failure injection in the mock (the existing `g_mock_tx_return` fails every frame indiscriminately and cannot isolate an FC from an SF/FF/CF).

| Case | Asserts |
|---|---|
| `TC-ISTP-RX-MF-005` `ff_fc_cts_tx_failure_is_reported` | FF whose FC CTS is rejected must not return `OK`, must **not** enter `RX_WAIT_CF`, must report `ERR_TP_TX_FAILED`, leaves channel in `ERROR`, no callback. Also asserts the FC was genuinely attempted, so it cannot pass vacuously. |
| `TC-ISTP-RX-MF-006` `fc_tx_failure_injection_is_fc_specific` | Control case: an SF reception transmits nothing and is unaffected while the injection is armed — rules out an "all transmits fail" reading of MF-005. |
| `TC-ISTP-RX-MF-007` `n_ar_armed_across_fc_transmit_only` | N_Ar is `ISOTP_TIMEOUT_AR_MS` when sampled inside the FC transmit, zero on return, still zero after a tick in `RX_WAIT_CF`. |
| `TC-ISTP-RX-MF-008` `ff_overflow_fc_tx_failure_is_reported` | CAN FD only (Classic CAN's 12-bit FF_DL cannot exceed `ISOTP_RX_BUF_LEN`, so that branch is unreachable there): a rejected FC OVFLW reports `ERR_TP_TX_FAILED`, not `ERR_TP_OVERFLOW`. |

**BEFORE** — `transport/isotp.c` at pristine `origin/main` (`git diff --quiet transport/isotp.c` → clean). Only the inert header declarations were present, so the test file compiles; the macro and the struct field are never read or written by the reverted `.c`, which isolates the proof to the behavioural change:

```
  test_isotp                                     FAIL
      [FAIL] test_isotp_rx_multi__test_ff_fc_cts_tx_failure_is_reported
      [FAIL] test_isotp_rx_multi__test_n_ar_armed_across_fc_transmit_only
      [FAIL] test_isotp_rx_multi__test_ff_overflow_fc_tx_failure_is_reported
        test_isotp.c:667: Expected 49 but got 53 ((UDS_STATUS_ERR_TP_TX_FAILED))
    SOME TESTS FAILED
  === Unit Test Summary: 43 passed, 1 failed ===
```

(49 = `0x31` `ERR_TP_OVERFLOW`, 53 = `0x35` `ERR_TP_TX_FAILED`.)

**AFTER** — with the `transport/isotp.c` fix applied:

```
  === Unit Test Summary: 44 passed, 0 failed ===
```

The module count is unchanged at 44 (cases were added to an existing module), so `verify_doc_counts.py` needs no doc updates.

## Gate results

| Gate | Result |
|---|---|
| `bash build_tests.sh` | **44 passed, 0 failed** |
| `bash build_harness.sh --run` | **68 / 68 PASS** |
| `python3 misra_analysis.py` | 41 files, 1 finding, **0 OPEN violations**, 1 justified — **PASS** |
| No-malloc grep (CI mirror) | clean, no output |
| `python3 scripts/verify_doc_counts.py` | **PASS** (44) |
| `gcc -Wall -Wextra -Werror` on `isotp.c` | **OK** in all four `ISOTP_ENABLE_CAN_FD` × `ISOTP_TX_PADDING` permutations |

MISRA ran **GCC-only** — `cppcheck` is not installed on this machine. CI runs it with `--strict` + cppcheck.

## Heightened review

`transport/isotp.c` is on CONTRIBUTING.md's heightened-review list. Explicit self-review pass done before opening:

- No exhaustive `switch` over `uds_status_t` needs the new `0x38`. The only status→NRC mapper (`core/uds_server.c`) has a `default:` and is fed by *service handler* statuses, not `isotp_process_rx_frame()`'s return.
- No doc, `docs/llms.txt` or README enumerates the TP timeout status codes, so 0x38 introduces no doc drift.
- All callers of `isotp_process_rx_frame()` were checked for the new `ERR_TP_TX_FAILED` return: every one discards it with `(void)` except `examples/bms_ecu/src/main.c:946`, which logs any non-`OK` status other than `ERR_TP_FRAME_INVALID` — i.e. the previously invisible fault now surfaces, which is the point of the fix.
- `rx_ar_timer_ms` is zeroed by `memset` in `isotp_init()`, by `isotp_reset()`, and unconditionally on every `isotp_send_fc()` return, so the unguarded tick branch can never fire on stale state.
- The `fc_rc` local is assigned before every read on both paths; verified under `-Werror` in all four build permutations.

`Reviewed-by: Xaloqi <contact@xaloqi.com>`

## New finding logged, not fixed here

`isotp_get_state()` reports `tx_state` whenever a TX is active, so an RX channel in `ISOTP_STATE_ERROR` is unobservable to the caller during any concurrent transmit — and `isotp_reset()`, the only recovery, clears *both* direction's state machines. This fix makes that pre-existing aliasing materially more reachable (the RX side now enters `ERROR` on a failed FC), but it is a separate API defect and out of scope here per CONTRIBUTING.md. Filed separately and appended to the internal review ledger.

Closes #122
