### PR TITLE
fix: regenerate 11 examples' test_services.py (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,28 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **11 examples' `generated/tests/test_services.py` was missing ReadDTCInformation
+  sub `0x0B`/`0x19` coverage that the template gained months ago.** (#127)
+  `EDS-toolchain` commit `2efba87` added `test_report_fault_detection_counter_sub0b`
+  (ISO 14229-1 §11.3.11) and `test_report_dtc_permanent_status_sub19` (§11.3.25) to
+  `tools/templates/test_services.py.j2`, but the committed `generated/` output for
+  every example that carries a `tests/` directory (`ardep_ecu`, `basic_ecu`,
+  `basic_ecu_doip`, `basic_ecu_doip_freertos`, `basic_ecu_freertos`, `bms_ecu`,
+  `motor_controller_ecu`, `robot_joint_controller_ecu`, `safeboot_ecu`, `sensor_ecu`,
+  `sensor_ecu_freertos` — `safeboot_freertos_ecu` is generated without `--test-gen`
+  and was never affected) predated that commit. Not a functional defect — missing
+  test coverage only — first found and deliberately excluded from #124's regeneration
+  scope (logged as O-37) to keep that PR's diff to its actual subject. Regenerated all
+  11 examples' full `generated/` output via `tools/codegen.py --test-gen` (plus each
+  example's own `--safety-wrappers --asil-level B` / manifest flags, matched to what
+  was already committed) and diffed every touched file against the previously
+  committed version before staging: outside `test_services.py`, nothing changed but
+  the expected per-generation timestamp fields (`Generated:` headers,
+  `GEN_GENERATED_TIMESTAMP`, and — for the 3 examples that carry one — the manifest's
+  `generated_at`/`config_source`/`output_dir`/`generator`); inside `test_services.py`,
+  the only change in all 11 was the same timestamp line plus the two new test methods,
+  verbatim.
+
 - **ISO-TP: every Flow Control transmit failure was discarded, and there was no
   N_Ar timer at all.** (#122) Both `isotp_send_fc()` call sites in
   `transport/isotp.c` threw the return value away with `(void)` — the comment at

--- a/examples/ardep_ecu/generated/did_handlers.c
+++ b/examples/ardep_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:12:17Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/ardep_ecu/generated/did_handlers.h
+++ b/examples/ardep_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:12:17Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/ardep_ecu/generated/did_safety_wrappers.c
+++ b/examples/ardep_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:12:17Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/ardep_ecu/generated/did_safety_wrappers.h
+++ b/examples/ardep_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:12:17Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/ardep_ecu/generated/generated_config.h
+++ b/examples/ardep_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:12:17Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "ARDEP_IOController"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:03Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T13:12:17Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/ardep_ecu/generated/routine_handlers.c
+++ b/examples/ardep_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: ARDEP_IOController  v1.0.0  Generated: 2026-08-30T11:15:03Z
+// ECU: ARDEP_IOController  v1.0.0  Generated: 2026-08-30T13:12:17Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/ardep_ecu/generated/routine_handlers.h
+++ b/examples/ardep_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: ARDEP_IOController  v1.0.0  Generated: 2026-08-30T11:15:03Z
+// ECU: ARDEP_IOController  v1.0.0  Generated: 2026-08-30T13:12:17Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/ardep_ecu/generated/safety_config.h
+++ b/examples/ardep_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:12:17Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/ardep_ecu/generated/tests/README.md
+++ b/examples/ardep_ecu/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-08-30T11:15:03Z by tools/testgen.py*
+*Generated 2026-08-30T13:12:17Z by tools/testgen.py*

--- a/examples/ardep_ecu/generated/tests/conftest.py
+++ b/examples/ardep_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/ardep_ecu/generated/tests/conftest_firmware.py
+++ b/examples/ardep_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/ardep_ecu/generated/tests/test_did_2001.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2001.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2001  (PowerIO_OutputStateBitmask)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2002.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2002.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2002  (PowerIO_Output1_Current_mA)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2003.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2003.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2003  (PowerIO_Output2_Current_mA)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2004.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2004.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2004  (PowerIO_Output3_Current_mA)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2005.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2005.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2005  (PowerIO_Output4_Current_mA)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2006.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2006.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2006  (PowerIO_Output5_Current_mA)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2007.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2007.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2007  (PowerIO_Output6_Current_mA)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2010.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2010.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2010  (PowerIO_OutputControl)
 # Access    : read + write

--- a/examples/ardep_ecu/generated/tests/test_did_2101.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2101.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2101  (PowerIO_InputStateBitmask)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2102.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2102.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2102  (PowerIO_Input1_Voltage_mV)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2103.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2103.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2103  (PowerIO_Input2_Voltage_mV)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2104.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2104.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2104  (PowerIO_Input3_Voltage_mV)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2201.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2201.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2201  (CAN_BusStatus)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2202.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2202.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2202  (CAN_RxFrameCount)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2203.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2203.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2203  (CAN_TxFrameCount)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2211.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2211.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2211  (LIN_BusStatus)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2212.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2212.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2212  (LIN_SlaveCount)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2301.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2301.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2301  (ECU_SupplyVoltage_mV)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2302.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2302.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2302  (ECU_InternalTemperature_degC)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2303.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2303.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2303  (ECU_UptimeSeconds)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2304.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2304.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2304  (ECU_ResetCounter)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2305.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2305.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2305  (ECU_LastResetReason)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2306.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2306.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2306  (ECU_DiagnosticStackVersion)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2401.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2401.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2401  (CAN_BusBitrate_kbps)
 # Access    : read + write

--- a/examples/ardep_ecu/generated/tests/test_did_2402.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2402.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2402  (LIN_BusBaudrate_bps)
 # Access    : read + write

--- a/examples/ardep_ecu/generated/tests/test_did_2403.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2403.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2403  (PowerIO_OvercurrentThreshold_mA)
 # Access    : read + write

--- a/examples/ardep_ecu/generated/tests/test_did_2404.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2404.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2404  (WatchdogTimeout_ms)
 # Access    : read + write

--- a/examples/ardep_ecu/generated/tests/test_did_2501.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2501.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2501  (FirmwareVersion_Active)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2502.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2502.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2502  (FirmwareVersion_Pending)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_2503.py
+++ b/examples/ardep_ecu/generated/tests/test_did_2503.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0x2503  (FirmwareUpdateStatus)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_f187.py
+++ b/examples/ardep_ecu/generated/tests/test_did_f187.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0xF187  (VehicleManufacturerSparePartNumber)
 # Access    : read + write

--- a/examples/ardep_ecu/generated/tests/test_did_f189.py
+++ b/examples/ardep_ecu/generated/tests/test_did_f189.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0xF189  (ECUSoftwareVersionNumber)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_f18c.py
+++ b/examples/ardep_ecu/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0xF18C  (ECUSerialNumber)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_f190.py
+++ b/examples/ardep_ecu/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0xF190  (VehicleIdentificationNumber)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_did_f197.py
+++ b/examples/ardep_ecu/generated/tests/test_did_f197.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # DID       : 0xF197  (SystemSupplierIdentifierDataIdentifier)
 # Access    : read

--- a/examples/ardep_ecu/generated/tests/test_firmware_services.py
+++ b/examples/ardep_ecu/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/ardep_ecu/generated/tests/test_routine_ff00.py
+++ b/examples/ardep_ecu/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # Routine   : 0xFF00  (ECU_SelfTest)
 # Session   : extended (ordinal 3)

--- a/examples/ardep_ecu/generated/tests/test_routine_ff01.py
+++ b/examples/ardep_ecu/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # Routine   : 0xFF01  (ResetCalibrationToDefaults)
 # Session   : extended (ordinal 3)

--- a/examples/ardep_ecu/generated/tests/test_routine_ff10.py
+++ b/examples/ardep_ecu/generated/tests/test_routine_ff10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # Routine   : 0xFF10  (EraseApplicationFlash)
 # Session   : programming (ordinal 2)

--- a/examples/ardep_ecu/generated/tests/test_routine_ff11.py
+++ b/examples/ardep_ecu/generated/tests/test_routine_ff11.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # Routine   : 0xFF11  (VerifyApplicationImage)
 # Session   : programming (ordinal 2)

--- a/examples/ardep_ecu/generated/tests/test_routine_ff20.py
+++ b/examples/ardep_ecu/generated/tests/test_routine_ff20.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # Routine   : 0xFF20  (ActivateOutputChannel)
 # Session   : extended (ordinal 3)

--- a/examples/ardep_ecu/generated/tests/test_routine_ff21.py
+++ b/examples/ardep_ecu/generated/tests/test_routine_ff21.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # Routine   : 0xFF21  (MeasureSupplyVoltage)
 # Session   : extended (ordinal 3)

--- a/examples/ardep_ecu/generated/tests/test_services.py
+++ b/examples/ardep_ecu/generated/tests/test_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T13:12:17Z
 #
 # PURPOSE: UDS service-level and ISO-TP transport tests derived from
 #          diagnostics_config.yaml.
@@ -395,6 +395,45 @@ class TestReadDTCInformation:
         dtc_section_len = len(pdu) - 3
         assert dtc_section_len % 4 == 0, (
             f"DTC section length {dtc_section_len} is not a multiple of 4"
+        )
+
+    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
+        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 2, "response must be at least 2 bytes"
+        # No availability mask — DTC section starts at byte 2, stride 4
+        dtc_section_len = len(pdu) - 2
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4 "
+            f"(3-byte DTC code + 1-byte counter per record)"
+        )
+
+    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Empty list (3 bytes) is valid when no DTCs are marked permanent.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
+        # DTC section after availability mask byte
+        dtc_section_len = len(pdu) - 3
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4"
         )
 
     def test_invalid_subfunction_rejected(self, uds_bus: IsoTpTransport) -> None:

--- a/examples/ardep_ecu/generated/uds_init.c
+++ b/examples/ardep_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:12:17Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.

--- a/examples/ardep_ecu/generated/uds_init.h
+++ b/examples/ardep_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : ARDEP_IOController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:12:17Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/basic_ecu/generated/did_handlers.c
+++ b/examples/basic_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:12:55Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/basic_ecu/generated/did_handlers.h
+++ b/examples/basic_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:12:55Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/basic_ecu/generated/did_safety_wrappers.c
+++ b/examples/basic_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:12:55Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/basic_ecu/generated/did_safety_wrappers.h
+++ b/examples/basic_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:12:55Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/basic_ecu/generated/generated_config.h
+++ b/examples/basic_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:12:55Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "BasicECU"
 #define GEN_ECU_VERSION         "0.1.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:03Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T13:12:55Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/basic_ecu/generated/routine_handlers.c
+++ b/examples/basic_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU  v0.1.0  Generated: 2026-08-30T11:15:03Z
+// ECU: BasicECU  v0.1.0  Generated: 2026-08-30T13:12:55Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/basic_ecu/generated/routine_handlers.h
+++ b/examples/basic_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU  v0.1.0  Generated: 2026-08-30T11:15:03Z
+// ECU: BasicECU  v0.1.0  Generated: 2026-08-30T13:12:55Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/basic_ecu/generated/safety_config.h
+++ b/examples/basic_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:12:55Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/basic_ecu/generated/tests/README.md
+++ b/examples/basic_ecu/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-08-30T11:15:03Z by tools/testgen.py*
+*Generated 2026-08-30T13:12:55Z by tools/testgen.py*

--- a/examples/basic_ecu/generated/tests/conftest.py
+++ b/examples/basic_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:55Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/basic_ecu/generated/tests/conftest_firmware.py
+++ b/examples/basic_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:55Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/basic_ecu/generated/tests/test_did_0500.py
+++ b/examples/basic_ecu/generated/tests/test_did_0500.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:55Z
 #
 # DID       : 0x0500  (Coolant Temperature)
 # Access    : read

--- a/examples/basic_ecu/generated/tests/test_did_0c00.py
+++ b/examples/basic_ecu/generated/tests/test_did_0c00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:55Z
 #
 # DID       : 0x0C00  (Engine Speed)
 # Access    : read

--- a/examples/basic_ecu/generated/tests/test_did_f187.py
+++ b/examples/basic_ecu/generated/tests/test_did_f187.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:55Z
 #
 # DID       : 0xF187  (Vehicle Manufacturer Spare Part Number)
 # Access    : read + write

--- a/examples/basic_ecu/generated/tests/test_did_f18c.py
+++ b/examples/basic_ecu/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:55Z
 #
 # DID       : 0xF18C  (ECU Serial Number)
 # Access    : read

--- a/examples/basic_ecu/generated/tests/test_did_f190.py
+++ b/examples/basic_ecu/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:55Z
 #
 # DID       : 0xF190  (Vehicle Identification Number)
 # Access    : read

--- a/examples/basic_ecu/generated/tests/test_firmware_services.py
+++ b/examples/basic_ecu/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:55Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/basic_ecu/generated/tests/test_routine_ff00.py
+++ b/examples/basic_ecu/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:55Z
 #
 # Routine   : 0xFF00  (ECU_SelfTest)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu/generated/tests/test_routine_ff01.py
+++ b/examples/basic_ecu/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:55Z
 #
 # Routine   : 0xFF01  (ResetToFactoryDefaults)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu/generated/tests/test_routine_ff10.py
+++ b/examples/basic_ecu/generated/tests/test_routine_ff10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:12:55Z
 #
 # Routine   : 0xFF10  (EraseNVM)
 # Session   : programming (ordinal 2)

--- a/examples/basic_ecu/generated/tests/test_services.py
+++ b/examples/basic_ecu/generated/tests/test_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-19T17:30:37Z
+# Generated : 2026-08-30T13:12:55Z
 #
 # PURPOSE: UDS service-level and ISO-TP transport tests derived from
 #          diagnostics_config.yaml.
@@ -395,6 +395,45 @@ class TestReadDTCInformation:
         dtc_section_len = len(pdu) - 3
         assert dtc_section_len % 4 == 0, (
             f"DTC section length {dtc_section_len} is not a multiple of 4"
+        )
+
+    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
+        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 2, "response must be at least 2 bytes"
+        # No availability mask — DTC section starts at byte 2, stride 4
+        dtc_section_len = len(pdu) - 2
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4 "
+            f"(3-byte DTC code + 1-byte counter per record)"
+        )
+
+    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Empty list (3 bytes) is valid when no DTCs are marked permanent.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
+        # DTC section after availability mask byte
+        dtc_section_len = len(pdu) - 3
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4"
         )
 
     def test_invalid_subfunction_rejected(self, uds_bus: IsoTpTransport) -> None:

--- a/examples/basic_ecu/generated/uds_init.c
+++ b/examples/basic_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:12:55Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.

--- a/examples/basic_ecu/generated/uds_init.h
+++ b/examples/basic_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:12:55Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/basic_ecu_doip/generated/did_handlers.c
+++ b/examples/basic_ecu_doip/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:13:32Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/basic_ecu_doip/generated/did_handlers.h
+++ b/examples/basic_ecu_doip/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:13:32Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/basic_ecu_doip/generated/did_safety_wrappers.c
+++ b/examples/basic_ecu_doip/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:13:32Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/basic_ecu_doip/generated/did_safety_wrappers.h
+++ b/examples/basic_ecu_doip/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:13:32Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/basic_ecu_doip/generated/generated_config.h
+++ b/examples/basic_ecu_doip/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:13:32Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "BasicECU_DoIP"
 #define GEN_ECU_VERSION         "1.6.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:03Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T13:13:32Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/basic_ecu_doip/generated/routine_handlers.c
+++ b/examples/basic_ecu_doip/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU_DoIP  v1.6.0  Generated: 2026-08-30T11:15:03Z
+// ECU: BasicECU_DoIP  v1.6.0  Generated: 2026-08-30T13:13:32Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/basic_ecu_doip/generated/routine_handlers.h
+++ b/examples/basic_ecu_doip/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU_DoIP  v1.6.0  Generated: 2026-08-30T11:15:03Z
+// ECU: BasicECU_DoIP  v1.6.0  Generated: 2026-08-30T13:13:32Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/basic_ecu_doip/generated/safety_config.h
+++ b/examples/basic_ecu_doip/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:13:32Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/basic_ecu_doip/generated/tests/README.md
+++ b/examples/basic_ecu_doip/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-08-30T11:15:03Z by tools/testgen.py*
+*Generated 2026-08-30T13:13:32Z by tools/testgen.py*

--- a/examples/basic_ecu_doip/generated/tests/conftest.py
+++ b/examples/basic_ecu_doip/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:13:32Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/basic_ecu_doip/generated/tests/conftest_firmware.py
+++ b/examples/basic_ecu_doip/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:13:32Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/basic_ecu_doip/generated/tests/test_did_0500.py
+++ b/examples/basic_ecu_doip/generated/tests/test_did_0500.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:13:32Z
 #
 # DID       : 0x0500  (Coolant Temperature)
 # Access    : read

--- a/examples/basic_ecu_doip/generated/tests/test_did_0c00.py
+++ b/examples/basic_ecu_doip/generated/tests/test_did_0c00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:13:32Z
 #
 # DID       : 0x0C00  (Engine Speed)
 # Access    : read

--- a/examples/basic_ecu_doip/generated/tests/test_did_f187.py
+++ b/examples/basic_ecu_doip/generated/tests/test_did_f187.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:13:32Z
 #
 # DID       : 0xF187  (Vehicle Manufacturer Spare Part Number)
 # Access    : read + write

--- a/examples/basic_ecu_doip/generated/tests/test_did_f18c.py
+++ b/examples/basic_ecu_doip/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:13:32Z
 #
 # DID       : 0xF18C  (ECU Serial Number)
 # Access    : read

--- a/examples/basic_ecu_doip/generated/tests/test_did_f190.py
+++ b/examples/basic_ecu_doip/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:13:32Z
 #
 # DID       : 0xF190  (Vehicle Identification Number)
 # Access    : read

--- a/examples/basic_ecu_doip/generated/tests/test_firmware_services.py
+++ b/examples/basic_ecu_doip/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:13:32Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/basic_ecu_doip/generated/tests/test_routine_ff00.py
+++ b/examples/basic_ecu_doip/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:13:32Z
 #
 # Routine   : 0xFF00  (ECU_SelfTest)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu_doip/generated/tests/test_routine_ff01.py
+++ b/examples/basic_ecu_doip/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:13:32Z
 #
 # Routine   : 0xFF01  (ResetToFactoryDefaults)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu_doip/generated/tests/test_routine_ff10.py
+++ b/examples/basic_ecu_doip/generated/tests/test_routine_ff10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:03Z
+# Generated : 2026-08-30T13:13:32Z
 #
 # Routine   : 0xFF10  (EraseNVM)
 # Session   : programming (ordinal 2)

--- a/examples/basic_ecu_doip/generated/tests/test_services.py
+++ b/examples/basic_ecu_doip/generated/tests/test_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T13:13:32Z
 #
 # PURPOSE: UDS service-level and ISO-TP transport tests derived from
 #          diagnostics_config.yaml.
@@ -395,6 +395,45 @@ class TestReadDTCInformation:
         dtc_section_len = len(pdu) - 3
         assert dtc_section_len % 4 == 0, (
             f"DTC section length {dtc_section_len} is not a multiple of 4"
+        )
+
+    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
+        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 2, "response must be at least 2 bytes"
+        # No availability mask — DTC section starts at byte 2, stride 4
+        dtc_section_len = len(pdu) - 2
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4 "
+            f"(3-byte DTC code + 1-byte counter per record)"
+        )
+
+    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Empty list (3 bytes) is valid when no DTCs are marked permanent.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
+        # DTC section after availability mask byte
+        dtc_section_len = len(pdu) - 3
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4"
         )
 
     def test_invalid_subfunction_rejected(self, uds_bus: IsoTpTransport) -> None:

--- a/examples/basic_ecu_doip/generated/uds_init.c
+++ b/examples/basic_ecu_doip/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:13:32Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.

--- a/examples/basic_ecu_doip/generated/uds_init.h
+++ b/examples/basic_ecu_doip/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP
  * Version   : 1.6.0
- * Generated : 2026-08-30T11:15:03Z
+ * Generated : 2026-08-30T13:13:32Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/basic_ecu_doip_freertos/generated/did_handlers.c
+++ b/examples/basic_ecu_doip_freertos/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:14:20Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/basic_ecu_doip_freertos/generated/did_handlers.h
+++ b/examples/basic_ecu_doip_freertos/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:14:20Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/basic_ecu_doip_freertos/generated/did_safety_wrappers.c
+++ b/examples/basic_ecu_doip_freertos/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:14:20Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/basic_ecu_doip_freertos/generated/did_safety_wrappers.h
+++ b/examples/basic_ecu_doip_freertos/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:14:20Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/basic_ecu_doip_freertos/generated/generated_config.h
+++ b/examples/basic_ecu_doip_freertos/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:14:20Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "BasicECU_DoIP_FreeRTOS"
 #define GEN_ECU_VERSION         "1.6.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:04Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T13:14:20Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/basic_ecu_doip_freertos/generated/routine_handlers.c
+++ b/examples/basic_ecu_doip_freertos/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU_DoIP_FreeRTOS  v1.6.0  Generated: 2026-08-30T11:15:04Z
+// ECU: BasicECU_DoIP_FreeRTOS  v1.6.0  Generated: 2026-08-30T13:14:20Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/basic_ecu_doip_freertos/generated/routine_handlers.h
+++ b/examples/basic_ecu_doip_freertos/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU_DoIP_FreeRTOS  v1.6.0  Generated: 2026-08-30T11:15:04Z
+// ECU: BasicECU_DoIP_FreeRTOS  v1.6.0  Generated: 2026-08-30T13:14:20Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/basic_ecu_doip_freertos/generated/safety_config.h
+++ b/examples/basic_ecu_doip_freertos/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:14:20Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/basic_ecu_doip_freertos/generated/tests/README.md
+++ b/examples/basic_ecu_doip_freertos/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-08-30T11:15:04Z by tools/testgen.py*
+*Generated 2026-08-30T13:14:20Z by tools/testgen.py*

--- a/examples/basic_ecu_doip_freertos/generated/tests/conftest.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:14:20Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/basic_ecu_doip_freertos/generated/tests/conftest_firmware.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:14:20Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_did_0500.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_did_0500.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:14:20Z
 #
 # DID       : 0x0500  (Coolant Temperature)
 # Access    : read

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_did_0c00.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_did_0c00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:14:20Z
 #
 # DID       : 0x0C00  (Engine Speed)
 # Access    : read

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_did_f187.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_did_f187.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:14:20Z
 #
 # DID       : 0xF187  (Vehicle Manufacturer Spare Part Number)
 # Access    : read + write

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_did_f18c.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:14:20Z
 #
 # DID       : 0xF18C  (ECU Serial Number)
 # Access    : read

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_did_f190.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:14:20Z
 #
 # DID       : 0xF190  (Vehicle Identification Number)
 # Access    : read

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_firmware_services.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:14:20Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_routine_ff00.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:14:20Z
 #
 # Routine   : 0xFF00  (ECU_SelfTest)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_routine_ff01.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:14:20Z
 #
 # Routine   : 0xFF01  (ResetToFactoryDefaults)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_routine_ff10.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_routine_ff10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:14:20Z
 #
 # Routine   : 0xFF10  (EraseNVM)
 # Session   : programming (ordinal 2)

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_services.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-05-20T07:21:47Z
+# Generated : 2026-08-30T13:14:20Z
 #
 # PURPOSE: UDS service-level and ISO-TP transport tests derived from
 #          diagnostics_config.yaml.
@@ -395,6 +395,45 @@ class TestReadDTCInformation:
         dtc_section_len = len(pdu) - 3
         assert dtc_section_len % 4 == 0, (
             f"DTC section length {dtc_section_len} is not a multiple of 4"
+        )
+
+    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
+        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 2, "response must be at least 2 bytes"
+        # No availability mask — DTC section starts at byte 2, stride 4
+        dtc_section_len = len(pdu) - 2
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4 "
+            f"(3-byte DTC code + 1-byte counter per record)"
+        )
+
+    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Empty list (3 bytes) is valid when no DTCs are marked permanent.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
+        # DTC section after availability mask byte
+        dtc_section_len = len(pdu) - 3
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4"
         )
 
     def test_invalid_subfunction_rejected(self, uds_bus: IsoTpTransport) -> None:

--- a/examples/basic_ecu_doip_freertos/generated/uds_init.c
+++ b/examples/basic_ecu_doip_freertos/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:14:20Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.

--- a/examples/basic_ecu_doip_freertos/generated/uds_init.h
+++ b/examples/basic_ecu_doip_freertos/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU_DoIP_FreeRTOS
  * Version   : 1.6.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:14:20Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/basic_ecu_freertos/generated/did_handlers.c
+++ b/examples/basic_ecu_freertos/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:18Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/basic_ecu_freertos/generated/did_handlers.h
+++ b/examples/basic_ecu_freertos/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:18Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/basic_ecu_freertos/generated/did_safety_wrappers.c
+++ b/examples/basic_ecu_freertos/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:18Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/basic_ecu_freertos/generated/did_safety_wrappers.h
+++ b/examples/basic_ecu_freertos/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:18Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/basic_ecu_freertos/generated/generated_config.h
+++ b/examples/basic_ecu_freertos/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:18Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "BasicECU"
 #define GEN_ECU_VERSION         "0.1.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:04Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T13:15:18Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/basic_ecu_freertos/generated/routine_handlers.c
+++ b/examples/basic_ecu_freertos/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU  v0.1.0  Generated: 2026-08-30T11:15:04Z
+// ECU: BasicECU  v0.1.0  Generated: 2026-08-30T13:15:18Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/basic_ecu_freertos/generated/routine_handlers.h
+++ b/examples/basic_ecu_freertos/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: BasicECU  v0.1.0  Generated: 2026-08-30T11:15:04Z
+// ECU: BasicECU  v0.1.0  Generated: 2026-08-30T13:15:18Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/basic_ecu_freertos/generated/safety_config.h
+++ b/examples/basic_ecu_freertos/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:18Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/basic_ecu_freertos/generated/tests/README.md
+++ b/examples/basic_ecu_freertos/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-08-30T11:15:04Z by tools/testgen.py*
+*Generated 2026-08-30T13:15:18Z by tools/testgen.py*

--- a/examples/basic_ecu_freertos/generated/tests/conftest.py
+++ b/examples/basic_ecu_freertos/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:18Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/basic_ecu_freertos/generated/tests/conftest_firmware.py
+++ b/examples/basic_ecu_freertos/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:18Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/basic_ecu_freertos/generated/tests/test_did_0500.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_did_0500.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:18Z
 #
 # DID       : 0x0500  (Coolant Temperature)
 # Access    : read

--- a/examples/basic_ecu_freertos/generated/tests/test_did_0c00.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_did_0c00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:18Z
 #
 # DID       : 0x0C00  (Engine Speed)
 # Access    : read

--- a/examples/basic_ecu_freertos/generated/tests/test_did_f187.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_did_f187.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:18Z
 #
 # DID       : 0xF187  (Vehicle Manufacturer Spare Part Number)
 # Access    : read + write

--- a/examples/basic_ecu_freertos/generated/tests/test_did_f18c.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:18Z
 #
 # DID       : 0xF18C  (ECU Serial Number)
 # Access    : read

--- a/examples/basic_ecu_freertos/generated/tests/test_did_f190.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:18Z
 #
 # DID       : 0xF190  (Vehicle Identification Number)
 # Access    : read

--- a/examples/basic_ecu_freertos/generated/tests/test_firmware_services.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:18Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/basic_ecu_freertos/generated/tests/test_routine_ff00.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:18Z
 #
 # Routine   : 0xFF00  (ECU_SelfTest)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu_freertos/generated/tests/test_routine_ff01.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:18Z
 #
 # Routine   : 0xFF01  (ResetToFactoryDefaults)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu_freertos/generated/tests/test_routine_ff10.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_routine_ff10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:18Z
 #
 # Routine   : 0xFF10  (EraseNVM)
 # Session   : programming (ordinal 2)

--- a/examples/basic_ecu_freertos/generated/tests/test_services.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T13:15:18Z
 #
 # PURPOSE: UDS service-level and ISO-TP transport tests derived from
 #          diagnostics_config.yaml.
@@ -395,6 +395,45 @@ class TestReadDTCInformation:
         dtc_section_len = len(pdu) - 3
         assert dtc_section_len % 4 == 0, (
             f"DTC section length {dtc_section_len} is not a multiple of 4"
+        )
+
+    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
+        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 2, "response must be at least 2 bytes"
+        # No availability mask — DTC section starts at byte 2, stride 4
+        dtc_section_len = len(pdu) - 2
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4 "
+            f"(3-byte DTC code + 1-byte counter per record)"
+        )
+
+    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Empty list (3 bytes) is valid when no DTCs are marked permanent.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
+        # DTC section after availability mask byte
+        dtc_section_len = len(pdu) - 3
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4"
         )
 
     def test_invalid_subfunction_rejected(self, uds_bus: IsoTpTransport) -> None:

--- a/examples/basic_ecu_freertos/generated/uds_init.c
+++ b/examples/basic_ecu_freertos/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:18Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.

--- a/examples/basic_ecu_freertos/generated/uds_init.h
+++ b/examples/basic_ecu_freertos/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BasicECU
  * Version   : 0.1.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:18Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/bms_ecu/generated/did_handlers.c
+++ b/examples/bms_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:22Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/bms_ecu/generated/did_handlers.h
+++ b/examples/bms_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:22Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/bms_ecu/generated/did_safety_wrappers.c
+++ b/examples/bms_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:22Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/bms_ecu/generated/did_safety_wrappers.h
+++ b/examples/bms_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:22Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/bms_ecu/generated/generated_config.h
+++ b/examples/bms_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:22Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "BMS_MainController"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:04Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T13:15:22Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/bms_ecu/generated/routine_handlers.c
+++ b/examples/bms_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: BMS_MainController  v1.0.0  Generated: 2026-08-30T11:15:04Z
+// ECU: BMS_MainController  v1.0.0  Generated: 2026-08-30T13:15:22Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/bms_ecu/generated/routine_handlers.h
+++ b/examples/bms_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: BMS_MainController  v1.0.0  Generated: 2026-08-30T11:15:04Z
+// ECU: BMS_MainController  v1.0.0  Generated: 2026-08-30T13:15:22Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/bms_ecu/generated/safety_config.h
+++ b/examples/bms_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:22Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/bms_ecu/generated/tests/README.md
+++ b/examples/bms_ecu/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-08-30T11:15:04Z by tools/testgen.py*
+*Generated 2026-08-30T13:15:22Z by tools/testgen.py*

--- a/examples/bms_ecu/generated/tests/conftest.py
+++ b/examples/bms_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/bms_ecu/generated/tests/conftest_firmware.py
+++ b/examples/bms_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/bms_ecu/generated/tests/test_did_d900.py
+++ b/examples/bms_ecu/generated/tests/test_did_d900.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xD900  (BMS_FaultFlagsBitmask)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_d901.py
+++ b/examples/bms_ecu/generated/tests/test_did_d901.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xD901  (BMS_FullChargeCapacity_Wh)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_d910.py
+++ b/examples/bms_ecu/generated/tests/test_did_d910.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xD910  (BMS_OVThreshold_mV)
 # Access    : read + write

--- a/examples/bms_ecu/generated/tests/test_did_d911.py
+++ b/examples/bms_ecu/generated/tests/test_did_d911.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xD911  (BMS_UVThreshold_mV)
 # Access    : read + write

--- a/examples/bms_ecu/generated/tests/test_did_db00.py
+++ b/examples/bms_ecu/generated/tests/test_did_db00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xDB00  (BMS_PackVoltage_mV)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_db01.py
+++ b/examples/bms_ecu/generated/tests/test_did_db01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xDB01  (BMS_PackCurrent_100mA)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_db02.py
+++ b/examples/bms_ecu/generated/tests/test_did_db02.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xDB02  (BMS_PackPower_10W)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_db03.py
+++ b/examples/bms_ecu/generated/tests/test_did_db03.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xDB03  (BMS_ContactorState)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_db04.py
+++ b/examples/bms_ecu/generated/tests/test_did_db04.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xDB04  (BMS_InsulationResistance_kOhm)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_dc01.py
+++ b/examples/bms_ecu/generated/tests/test_did_dc01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xDC01  (BMS_CellGroup1_Voltage_mV)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_dc02.py
+++ b/examples/bms_ecu/generated/tests/test_did_dc02.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xDC02  (BMS_CellGroup2_Voltage_mV)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_dc03.py
+++ b/examples/bms_ecu/generated/tests/test_did_dc03.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xDC03  (BMS_CellGroup3_Voltage_mV)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_dc04.py
+++ b/examples/bms_ecu/generated/tests/test_did_dc04.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xDC04  (BMS_CellGroup4_Voltage_mV)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_dd00.py
+++ b/examples/bms_ecu/generated/tests/test_did_dd00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xDD00  (BMS_MaxCellTemperature_degC)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_dd01.py
+++ b/examples/bms_ecu/generated/tests/test_did_dd01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xDD01  (BMS_MinCellTemperature_degC)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_dd02.py
+++ b/examples/bms_ecu/generated/tests/test_did_dd02.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xDD02  (BMS_CoolantInletTemperature_degC)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_dd03.py
+++ b/examples/bms_ecu/generated/tests/test_did_dd03.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xDD03  (BMS_BMSBoardTemperature_degC)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_de00.py
+++ b/examples/bms_ecu/generated/tests/test_did_de00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xDE00  (BMS_StateOfCharge_04pct)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_de01.py
+++ b/examples/bms_ecu/generated/tests/test_did_de01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xDE01  (BMS_StateOfHealth_04pct)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_de02.py
+++ b/examples/bms_ecu/generated/tests/test_did_de02.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xDE02  (BMS_BalancingStateBitmask)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_f187.py
+++ b/examples/bms_ecu/generated/tests/test_did_f187.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xF187  (VehicleManufacturerSparePartNumber)
 # Access    : read + write

--- a/examples/bms_ecu/generated/tests/test_did_f189.py
+++ b/examples/bms_ecu/generated/tests/test_did_f189.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xF189  (ECUSoftwareVersionNumber)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_f18c.py
+++ b/examples/bms_ecu/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xF18C  (ECUSerialNumber)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_did_f190.py
+++ b/examples/bms_ecu/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # DID       : 0xF190  (VehicleIdentificationNumber)
 # Access    : read

--- a/examples/bms_ecu/generated/tests/test_firmware_services.py
+++ b/examples/bms_ecu/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/bms_ecu/generated/tests/test_routine_bb00.py
+++ b/examples/bms_ecu/generated/tests/test_routine_bb00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # Routine   : 0xBB00  (BMS_SelfTest)
 # Session   : extended (ordinal 3)

--- a/examples/bms_ecu/generated/tests/test_routine_bb01.py
+++ b/examples/bms_ecu/generated/tests/test_routine_bb01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # Routine   : 0xBB01  (BMS_ForcePassiveBalance)
 # Session   : extended (ordinal 3)

--- a/examples/bms_ecu/generated/tests/test_routine_bb02.py
+++ b/examples/bms_ecu/generated/tests/test_routine_bb02.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # Routine   : 0xBB02  (BMS_ContactorFunctionalTest)
 # Session   : extended (ordinal 3)

--- a/examples/bms_ecu/generated/tests/test_routine_bb10.py
+++ b/examples/bms_ecu/generated/tests/test_routine_bb10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # Routine   : 0xBB10  (BMS_ResetSoCToFullCharge)
 # Session   : programming (ordinal 2)

--- a/examples/bms_ecu/generated/tests/test_routine_bb11.py
+++ b/examples/bms_ecu/generated/tests/test_routine_bb11.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # Routine   : 0xBB11  (BMS_ClearFaultHistory)
 # Session   : programming (ordinal 2)

--- a/examples/bms_ecu/generated/tests/test_services.py
+++ b/examples/bms_ecu/generated/tests/test_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T13:15:22Z
 #
 # PURPOSE: UDS service-level and ISO-TP transport tests derived from
 #          diagnostics_config.yaml.
@@ -395,6 +395,45 @@ class TestReadDTCInformation:
         dtc_section_len = len(pdu) - 3
         assert dtc_section_len % 4 == 0, (
             f"DTC section length {dtc_section_len} is not a multiple of 4"
+        )
+
+    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
+        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 2, "response must be at least 2 bytes"
+        # No availability mask — DTC section starts at byte 2, stride 4
+        dtc_section_len = len(pdu) - 2
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4 "
+            f"(3-byte DTC code + 1-byte counter per record)"
+        )
+
+    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Empty list (3 bytes) is valid when no DTCs are marked permanent.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
+        # DTC section after availability mask byte
+        dtc_section_len = len(pdu) - 3
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4"
         )
 
     def test_invalid_subfunction_rejected(self, uds_bus: IsoTpTransport) -> None:

--- a/examples/bms_ecu/generated/uds_init.c
+++ b/examples/bms_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:22Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.

--- a/examples/bms_ecu/generated/uds_init.h
+++ b/examples/bms_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : BMS_MainController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:22Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/motor_controller_ecu/generated/did_handlers.c
+++ b/examples/motor_controller_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:27Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/motor_controller_ecu/generated/did_handlers.h
+++ b/examples/motor_controller_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:26Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/motor_controller_ecu/generated/did_safety_wrappers.c
+++ b/examples/motor_controller_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:27Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/motor_controller_ecu/generated/did_safety_wrappers.h
+++ b/examples/motor_controller_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:27Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/motor_controller_ecu/generated/generated_config.h
+++ b/examples/motor_controller_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:26Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "MotorController_Inverter"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:04Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T13:15:26Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/motor_controller_ecu/generated/routine_handlers.c
+++ b/examples/motor_controller_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: MotorController_Inverter  v1.0.0  Generated: 2026-08-30T11:15:04Z
+// ECU: MotorController_Inverter  v1.0.0  Generated: 2026-08-30T13:15:27Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/motor_controller_ecu/generated/routine_handlers.h
+++ b/examples/motor_controller_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: MotorController_Inverter  v1.0.0  Generated: 2026-08-30T11:15:04Z
+// ECU: MotorController_Inverter  v1.0.0  Generated: 2026-08-30T13:15:27Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/motor_controller_ecu/generated/safety_config.h
+++ b/examples/motor_controller_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:27Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/motor_controller_ecu/generated/tests/README.md
+++ b/examples/motor_controller_ecu/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-08-30T11:15:04Z by tools/testgen.py*
+*Generated 2026-08-30T13:15:27Z by tools/testgen.py*

--- a/examples/motor_controller_ecu/generated/tests/conftest.py
+++ b/examples/motor_controller_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/motor_controller_ecu/generated/tests/conftest_firmware.py
+++ b/examples/motor_controller_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/motor_controller_ecu/generated/tests/test_did_e001.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e001.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE001  (MC_RotorSpeed_rpm)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e002.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e002.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE002  (MC_TorqueDemand_01Nm)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e003.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e003.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE003  (MC_TorqueActual_01Nm)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e004.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e004.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE004  (MC_RotorElectricalAngle_raw)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e005.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e005.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE005  (MC_MechanicalPower_10W)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e101.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e101.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE101  (MC_PhaseA_Current_100mA)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e102.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e102.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE102  (MC_PhaseB_Current_100mA)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e103.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e103.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE103  (MC_PhaseC_Current_100mA)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e104.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e104.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE104  (MC_Iq_Current_100mA)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e105.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e105.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE105  (MC_Id_Current_100mA)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e201.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e201.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE201  (MC_DCLink_Voltage_mV)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e202.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e202.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE202  (MC_DCLink_Current_100mA)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e203.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e203.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE203  (MC_ModulationIndex_04pct)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e301.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e301.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE301  (MC_IGBT_PhaseA_JunctionTemp_degC)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e302.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e302.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE302  (MC_IGBT_PhaseB_JunctionTemp_degC)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e303.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e303.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE303  (MC_IGBT_PhaseC_JunctionTemp_degC)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e304.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e304.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE304  (MC_MotorStatorTemp_degC)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e305.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e305.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE305  (MC_CoolantInletTemp_degC)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e401.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e401.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE401  (MC_FaultStatusBitmask)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e402.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e402.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE402  (MC_OperatingMode)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_e501.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e501.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE501  (MC_ResolverOffset_raw)
 # Access    : read + write

--- a/examples/motor_controller_ecu/generated/tests/test_did_e502.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e502.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE502  (MC_TorqueScalingFactor_01pct)
 # Access    : read + write

--- a/examples/motor_controller_ecu/generated/tests/test_did_e503.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_e503.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xE503  (MC_CurrentSensorTrim_100uA)
 # Access    : read + write

--- a/examples/motor_controller_ecu/generated/tests/test_did_f187.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_f187.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xF187  (VehicleManufacturerSparePartNumber)
 # Access    : read + write

--- a/examples/motor_controller_ecu/generated/tests/test_did_f189.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_f189.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xF189  (ECUSoftwareVersionNumber)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_f18c.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xF18C  (ECUSerialNumber)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_did_f190.py
+++ b/examples/motor_controller_ecu/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # DID       : 0xF190  (VehicleIdentificationNumber)
 # Access    : read

--- a/examples/motor_controller_ecu/generated/tests/test_firmware_services.py
+++ b/examples/motor_controller_ecu/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/motor_controller_ecu/generated/tests/test_routine_cc00.py
+++ b/examples/motor_controller_ecu/generated/tests/test_routine_cc00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # Routine   : 0xCC00  (MC_SelfTest)
 # Session   : extended (ordinal 3)

--- a/examples/motor_controller_ecu/generated/tests/test_routine_cc01.py
+++ b/examples/motor_controller_ecu/generated/tests/test_routine_cc01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # Routine   : 0xCC01  (MC_PhaseBalanceTest)
 # Session   : extended (ordinal 3)

--- a/examples/motor_controller_ecu/generated/tests/test_routine_cc02.py
+++ b/examples/motor_controller_ecu/generated/tests/test_routine_cc02.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # Routine   : 0xCC02  (MC_GateDriverFunctionalTest)
 # Session   : extended (ordinal 3)

--- a/examples/motor_controller_ecu/generated/tests/test_routine_cc10.py
+++ b/examples/motor_controller_ecu/generated/tests/test_routine_cc10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # Routine   : 0xCC10  (MC_ResolverOffsetCalibration)
 # Session   : programming (ordinal 2)

--- a/examples/motor_controller_ecu/generated/tests/test_routine_cc11.py
+++ b/examples/motor_controller_ecu/generated/tests/test_routine_cc11.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # Routine   : 0xCC11  (MC_ForceMotorInhibit)
 # Session   : extended (ordinal 3)

--- a/examples/motor_controller_ecu/generated/tests/test_routine_cc12.py
+++ b/examples/motor_controller_ecu/generated/tests/test_routine_cc12.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # Routine   : 0xCC12  (MC_ClearFaultHistory)
 # Session   : programming (ordinal 2)

--- a/examples/motor_controller_ecu/generated/tests/test_services.py
+++ b/examples/motor_controller_ecu/generated/tests/test_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T13:15:27Z
 #
 # PURPOSE: UDS service-level and ISO-TP transport tests derived from
 #          diagnostics_config.yaml.
@@ -395,6 +395,45 @@ class TestReadDTCInformation:
         dtc_section_len = len(pdu) - 3
         assert dtc_section_len % 4 == 0, (
             f"DTC section length {dtc_section_len} is not a multiple of 4"
+        )
+
+    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
+        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 2, "response must be at least 2 bytes"
+        # No availability mask — DTC section starts at byte 2, stride 4
+        dtc_section_len = len(pdu) - 2
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4 "
+            f"(3-byte DTC code + 1-byte counter per record)"
+        )
+
+    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Empty list (3 bytes) is valid when no DTCs are marked permanent.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
+        # DTC section after availability mask byte
+        dtc_section_len = len(pdu) - 3
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4"
         )
 
     def test_invalid_subfunction_rejected(self, uds_bus: IsoTpTransport) -> None:

--- a/examples/motor_controller_ecu/generated/uds_init.c
+++ b/examples/motor_controller_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:27Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.

--- a/examples/motor_controller_ecu/generated/uds_init.h
+++ b/examples/motor_controller_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : MotorController_Inverter
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:27Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/robot_joint_controller_ecu/generated/did_handlers.c
+++ b/examples/robot_joint_controller_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:31Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/robot_joint_controller_ecu/generated/did_handlers.h
+++ b/examples/robot_joint_controller_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:31Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/robot_joint_controller_ecu/generated/did_safety_wrappers.c
+++ b/examples/robot_joint_controller_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:31Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/robot_joint_controller_ecu/generated/did_safety_wrappers.h
+++ b/examples/robot_joint_controller_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:31Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/robot_joint_controller_ecu/generated/generated_config.h
+++ b/examples/robot_joint_controller_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:31Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "RobotJointController"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:04Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T13:15:31Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/robot_joint_controller_ecu/generated/generated_files_phase3.json
+++ b/examples/robot_joint_controller_ecu/generated/generated_files_phase3.json
@@ -1,8 +1,8 @@
 {
   "phase": "Phase 3",
-  "generated_at": "2026-08-30T11:15:04Z",
-  "config_source": "/home/raul/EDS-wt-124-regen/examples/robot_joint_controller_ecu/diagnostics_config.yaml",
-  "output_dir": "/home/raul/EDS-wt-124-regen/examples/robot_joint_controller_ecu/generated",
+  "generated_at": "2026-08-30T13:15:31Z",
+  "config_source": "/home/raul/EDS-wt-127/examples/robot_joint_controller_ecu/diagnostics_config.yaml",
+  "output_dir": "/home/raul/EDS-wt-127/examples/robot_joint_controller_ecu/generated",
   "safety_wrappers": true,
   "asil_level": "B",
   "files": [
@@ -37,5 +37,5 @@
     "examples/robot_joint_controller_ecu/generated/tests/requirements_testgen.txt",
     "examples/robot_joint_controller_ecu/generated/tests/README.md"
   ],
-  "generator": "/home/raul/EDS-wt-124-regen/tools/codegen.py"
+  "generator": "/home/raul/EDS-wt-127/tools/codegen.py"
 }

--- a/examples/robot_joint_controller_ecu/generated/routine_handlers.c
+++ b/examples/robot_joint_controller_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: RobotJointController  v1.0.0  Generated: 2026-08-30T11:15:04Z
+// ECU: RobotJointController  v1.0.0  Generated: 2026-08-30T13:15:31Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/robot_joint_controller_ecu/generated/routine_handlers.h
+++ b/examples/robot_joint_controller_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: RobotJointController  v1.0.0  Generated: 2026-08-30T11:15:04Z
+// ECU: RobotJointController  v1.0.0  Generated: 2026-08-30T13:15:31Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/robot_joint_controller_ecu/generated/safety_config.h
+++ b/examples/robot_joint_controller_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:31Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/robot_joint_controller_ecu/generated/tests/README.md
+++ b/examples/robot_joint_controller_ecu/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-08-30T11:15:04Z by tools/testgen.py*
+*Generated 2026-08-30T13:15:31Z by tools/testgen.py*

--- a/examples/robot_joint_controller_ecu/generated/tests/conftest.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:31Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/robot_joint_controller_ecu/generated/tests/conftest_firmware.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:31Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_a000.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_a000.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:31Z
 #
 # DID       : 0xA000  (Axis0Position)
 # Access    : read

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_a001.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_a001.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:31Z
 #
 # DID       : 0xA001  (Axis0Velocity)
 # Access    : read

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_a002.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_a002.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:31Z
 #
 # DID       : 0xA002  (Axis0Torque)
 # Access    : read

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_a003.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_a003.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:31Z
 #
 # DID       : 0xA003  (Axis0MotorTemperature)
 # Access    : read

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_a004.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_a004.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:31Z
 #
 # DID       : 0xA004  (Axis0StatusBitmask)
 # Access    : read

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_a010.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_a010.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:31Z
 #
 # DID       : 0xA010  (Axis0PositionOffset)
 # Access    : read + write

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_a011.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_a011.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:31Z
 #
 # DID       : 0xA011  (Axis0SoftLimitPositive)
 # Access    : read + write

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_a012.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_a012.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:31Z
 #
 # DID       : 0xA012  (Axis0SoftLimitNegative)
 # Access    : read + write

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_f18c.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:31Z
 #
 # DID       : 0xF18C  (ControllerSerialNumber)
 # Access    : read

--- a/examples/robot_joint_controller_ecu/generated/tests/test_did_f190.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:31Z
 #
 # DID       : 0xF190  (RobotSerialNumber)
 # Access    : read

--- a/examples/robot_joint_controller_ecu/generated/tests/test_firmware_services.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:31Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/robot_joint_controller_ecu/generated/tests/test_routine_ff00.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:31Z
 #
 # Routine   : 0xFF00  (HomeAxis0)
 # Session   : extended (ordinal 3)

--- a/examples/robot_joint_controller_ecu/generated/tests/test_routine_ff01.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:31Z
 #
 # Routine   : 0xFF01  (ApplyCalibration)
 # Session   : extended (ordinal 3)

--- a/examples/robot_joint_controller_ecu/generated/tests/test_routine_ff02.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_routine_ff02.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:04Z
+# Generated : 2026-08-30T13:15:31Z
 #
 # Routine   : 0xFF02  (ClearFaultHistory)
 # Session   : extended (ordinal 3)

--- a/examples/robot_joint_controller_ecu/generated/tests/test_services.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:48Z
+# Generated : 2026-08-30T13:15:31Z
 #
 # PURPOSE: UDS service-level and ISO-TP transport tests derived from
 #          diagnostics_config.yaml.
@@ -395,6 +395,45 @@ class TestReadDTCInformation:
         dtc_section_len = len(pdu) - 3
         assert dtc_section_len % 4 == 0, (
             f"DTC section length {dtc_section_len} is not a multiple of 4"
+        )
+
+    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
+        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 2, "response must be at least 2 bytes"
+        # No availability mask — DTC section starts at byte 2, stride 4
+        dtc_section_len = len(pdu) - 2
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4 "
+            f"(3-byte DTC code + 1-byte counter per record)"
+        )
+
+    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Empty list (3 bytes) is valid when no DTCs are marked permanent.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
+        # DTC section after availability mask byte
+        dtc_section_len = len(pdu) - 3
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4"
         )
 
     def test_invalid_subfunction_rejected(self, uds_bus: IsoTpTransport) -> None:

--- a/examples/robot_joint_controller_ecu/generated/uds_init.c
+++ b/examples/robot_joint_controller_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:31Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.

--- a/examples/robot_joint_controller_ecu/generated/uds_init.h
+++ b/examples/robot_joint_controller_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : RobotJointController
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:04Z
+ * Generated : 2026-08-30T13:15:31Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/safeboot_ecu/generated/did_handlers.c
+++ b/examples/safeboot_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:15:59Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/safeboot_ecu/generated/did_handlers.h
+++ b/examples/safeboot_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:15:59Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/safeboot_ecu/generated/did_safety_wrappers.c
+++ b/examples/safeboot_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:15:59Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/safeboot_ecu/generated/did_safety_wrappers.h
+++ b/examples/safeboot_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:15:59Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/safeboot_ecu/generated/generated_config.h
+++ b/examples/safeboot_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:15:59Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "SafeBootECU"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:05Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T13:15:59Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/safeboot_ecu/generated/routine_handlers.c
+++ b/examples/safeboot_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: SafeBootECU  v1.0.0  Generated: 2026-08-30T11:15:05Z
+// ECU: SafeBootECU  v1.0.0  Generated: 2026-08-30T13:15:59Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/safeboot_ecu/generated/routine_handlers.h
+++ b/examples/safeboot_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: SafeBootECU  v1.0.0  Generated: 2026-08-30T11:15:05Z
+// ECU: SafeBootECU  v1.0.0  Generated: 2026-08-30T13:15:59Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/safeboot_ecu/generated/safety_config.h
+++ b/examples/safeboot_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:15:59Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/safeboot_ecu/generated/tests/README.md
+++ b/examples/safeboot_ecu/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-08-30T11:15:05Z by tools/testgen.py*
+*Generated 2026-08-30T13:15:59Z by tools/testgen.py*

--- a/examples/safeboot_ecu/generated/tests/conftest.py
+++ b/examples/safeboot_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:15:59Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/safeboot_ecu/generated/tests/conftest_firmware.py
+++ b/examples/safeboot_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:15:59Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/safeboot_ecu/generated/tests/test_did_f181.py
+++ b/examples/safeboot_ecu/generated/tests/test_did_f181.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:15:59Z
 #
 # DID       : 0xF181  (ApplicationSoftwareIdentification)
 # Access    : read

--- a/examples/safeboot_ecu/generated/tests/test_did_f186.py
+++ b/examples/safeboot_ecu/generated/tests/test_did_f186.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:15:59Z
 #
 # DID       : 0xF186  (ActiveDiagnosticSession)
 # Access    : read

--- a/examples/safeboot_ecu/generated/tests/test_did_f18a.py
+++ b/examples/safeboot_ecu/generated/tests/test_did_f18a.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:15:59Z
 #
 # DID       : 0xF18A  (SystemSupplierIdentifier)
 # Access    : read

--- a/examples/safeboot_ecu/generated/tests/test_did_f18c.py
+++ b/examples/safeboot_ecu/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:15:59Z
 #
 # DID       : 0xF18C  (ECUSerialNumber)
 # Access    : read

--- a/examples/safeboot_ecu/generated/tests/test_did_f190.py
+++ b/examples/safeboot_ecu/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:15:59Z
 #
 # DID       : 0xF190  (VehicleIdentificationNumber)
 # Access    : read

--- a/examples/safeboot_ecu/generated/tests/test_firmware_services.py
+++ b/examples/safeboot_ecu/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:15:59Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/safeboot_ecu/generated/tests/test_routine_ff00.py
+++ b/examples/safeboot_ecu/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:15:59Z
 #
 # Routine   : 0xFF00  (CheckProgrammingPreconditions)
 # Session   : extended (ordinal 3)

--- a/examples/safeboot_ecu/generated/tests/test_routine_ff01.py
+++ b/examples/safeboot_ecu/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:15:59Z
 #
 # Routine   : 0xFF01  (VerifyBootloaderIntegrity)
 # Session   : programming (ordinal 2)

--- a/examples/safeboot_ecu/generated/tests/test_services.py
+++ b/examples/safeboot_ecu/generated/tests/test_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T13:15:59Z
 #
 # PURPOSE: UDS service-level and ISO-TP transport tests derived from
 #          diagnostics_config.yaml.
@@ -395,6 +395,45 @@ class TestReadDTCInformation:
         dtc_section_len = len(pdu) - 3
         assert dtc_section_len % 4 == 0, (
             f"DTC section length {dtc_section_len} is not a multiple of 4"
+        )
+
+    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
+        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 2, "response must be at least 2 bytes"
+        # No availability mask — DTC section starts at byte 2, stride 4
+        dtc_section_len = len(pdu) - 2
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4 "
+            f"(3-byte DTC code + 1-byte counter per record)"
+        )
+
+    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Empty list (3 bytes) is valid when no DTCs are marked permanent.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
+        # DTC section after availability mask byte
+        dtc_section_len = len(pdu) - 3
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4"
         )
 
     def test_invalid_subfunction_rejected(self, uds_bus: IsoTpTransport) -> None:

--- a/examples/safeboot_ecu/generated/uds_init.c
+++ b/examples/safeboot_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:15:59Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.

--- a/examples/safeboot_ecu/generated/uds_init.h
+++ b/examples/safeboot_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SafeBootECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:15:59Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/sensor_ecu/generated/did_handlers.c
+++ b/examples/sensor_ecu/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:16:03Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/sensor_ecu/generated/did_handlers.h
+++ b/examples/sensor_ecu/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:16:03Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/sensor_ecu/generated/did_safety_wrappers.c
+++ b/examples/sensor_ecu/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:16:03Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/sensor_ecu/generated/did_safety_wrappers.h
+++ b/examples/sensor_ecu/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:16:03Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/sensor_ecu/generated/generated_config.h
+++ b/examples/sensor_ecu/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:16:03Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "SensorECU"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:05Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T13:16:03Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/sensor_ecu/generated/generated_files_phase3.json
+++ b/examples/sensor_ecu/generated/generated_files_phase3.json
@@ -1,8 +1,8 @@
 {
   "phase": "Phase 3",
-  "generated_at": "2026-08-30T11:15:05Z",
-  "config_source": "/home/raul/EDS-wt-124-regen/examples/sensor_ecu/diagnostics_config.yaml",
-  "output_dir": "/home/raul/EDS-wt-124-regen/examples/sensor_ecu/generated",
+  "generated_at": "2026-08-30T13:16:03Z",
+  "config_source": "/home/raul/EDS-wt-127/examples/sensor_ecu/diagnostics_config.yaml",
+  "output_dir": "/home/raul/EDS-wt-127/examples/sensor_ecu/generated",
   "safety_wrappers": true,
   "asil_level": "B",
   "files": [
@@ -33,5 +33,5 @@
     "examples/sensor_ecu/generated/tests/requirements_testgen.txt",
     "examples/sensor_ecu/generated/tests/README.md"
   ],
-  "generator": "/home/raul/EDS-wt-124-regen/tools/codegen.py"
+  "generator": "/home/raul/EDS-wt-127/tools/codegen.py"
 }

--- a/examples/sensor_ecu/generated/routine_handlers.c
+++ b/examples/sensor_ecu/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: SensorECU  v1.0.0  Generated: 2026-08-30T11:15:05Z
+// ECU: SensorECU  v1.0.0  Generated: 2026-08-30T13:16:03Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/sensor_ecu/generated/routine_handlers.h
+++ b/examples/sensor_ecu/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: SensorECU  v1.0.0  Generated: 2026-08-30T11:15:05Z
+// ECU: SensorECU  v1.0.0  Generated: 2026-08-30T13:16:03Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/sensor_ecu/generated/safety_config.h
+++ b/examples/sensor_ecu/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:16:03Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/sensor_ecu/generated/tests/README.md
+++ b/examples/sensor_ecu/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-08-30T11:15:05Z by tools/testgen.py*
+*Generated 2026-08-30T13:16:03Z by tools/testgen.py*

--- a/examples/sensor_ecu/generated/tests/conftest.py
+++ b/examples/sensor_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:03Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/sensor_ecu/generated/tests/conftest_firmware.py
+++ b/examples/sensor_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:03Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/sensor_ecu/generated/tests/test_did_d001.py
+++ b/examples/sensor_ecu/generated/tests/test_did_d001.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:03Z
 #
 # DID       : 0xD001  (AmbientTemperature)
 # Access    : read

--- a/examples/sensor_ecu/generated/tests/test_did_d002.py
+++ b/examples/sensor_ecu/generated/tests/test_did_d002.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:03Z
 #
 # DID       : 0xD002  (SupplyVoltage)
 # Access    : read

--- a/examples/sensor_ecu/generated/tests/test_did_d003.py
+++ b/examples/sensor_ecu/generated/tests/test_did_d003.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:03Z
 #
 # DID       : 0xD003  (SensorStatusBitmask)
 # Access    : read

--- a/examples/sensor_ecu/generated/tests/test_did_d010.py
+++ b/examples/sensor_ecu/generated/tests/test_did_d010.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:03Z
 #
 # DID       : 0xD010  (TemperatureThresholdHigh)
 # Access    : read + write

--- a/examples/sensor_ecu/generated/tests/test_did_d011.py
+++ b/examples/sensor_ecu/generated/tests/test_did_d011.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:03Z
 #
 # DID       : 0xD011  (TemperatureThresholdLow)
 # Access    : read + write

--- a/examples/sensor_ecu/generated/tests/test_did_f18c.py
+++ b/examples/sensor_ecu/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:03Z
 #
 # DID       : 0xF18C  (ECUSerialNumber)
 # Access    : read

--- a/examples/sensor_ecu/generated/tests/test_did_f190.py
+++ b/examples/sensor_ecu/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:03Z
 #
 # DID       : 0xF190  (VehicleIdentificationNumber)
 # Access    : read

--- a/examples/sensor_ecu/generated/tests/test_firmware_services.py
+++ b/examples/sensor_ecu/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:03Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/sensor_ecu/generated/tests/test_routine_ff00.py
+++ b/examples/sensor_ecu/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:03Z
 #
 # Routine   : 0xFF00  (ResetSensorCalibration)
 # Session   : extended (ordinal 3)

--- a/examples/sensor_ecu/generated/tests/test_routine_ff01.py
+++ b/examples/sensor_ecu/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:03Z
 #
 # Routine   : 0xFF01  (SensorSelfTest)
 # Session   : extended (ordinal 3)

--- a/examples/sensor_ecu/generated/tests/test_services.py
+++ b/examples/sensor_ecu/generated/tests/test_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T13:16:03Z
 #
 # PURPOSE: UDS service-level and ISO-TP transport tests derived from
 #          diagnostics_config.yaml.
@@ -395,6 +395,45 @@ class TestReadDTCInformation:
         dtc_section_len = len(pdu) - 3
         assert dtc_section_len % 4 == 0, (
             f"DTC section length {dtc_section_len} is not a multiple of 4"
+        )
+
+    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
+        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 2, "response must be at least 2 bytes"
+        # No availability mask — DTC section starts at byte 2, stride 4
+        dtc_section_len = len(pdu) - 2
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4 "
+            f"(3-byte DTC code + 1-byte counter per record)"
+        )
+
+    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Empty list (3 bytes) is valid when no DTCs are marked permanent.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
+        # DTC section after availability mask byte
+        dtc_section_len = len(pdu) - 3
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4"
         )
 
     def test_invalid_subfunction_rejected(self, uds_bus: IsoTpTransport) -> None:

--- a/examples/sensor_ecu/generated/uds_init.c
+++ b/examples/sensor_ecu/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:16:03Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.

--- a/examples/sensor_ecu/generated/uds_init.h
+++ b/examples/sensor_ecu/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:16:03Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *

--- a/examples/sensor_ecu_freertos/generated/did_handlers.c
+++ b/examples/sensor_ecu_freertos/generated/did_handlers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:16:46Z
  *
  * PURPOSE: DID read/write handler stubs and static DID registration table.
  *          Each handler returns deterministic stub data (zeros) until the

--- a/examples/sensor_ecu_freertos/generated/did_handlers.h
+++ b/examples/sensor_ecu_freertos/generated/did_handlers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:16:46Z
  *
  * PURPOSE: Declarations for all generated DID read/write handler functions
  *          and the generated DID registration entry point.

--- a/examples/sensor_ecu_freertos/generated/did_safety_wrappers.c
+++ b/examples/sensor_ecu_freertos/generated/did_safety_wrappers.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:16:46Z
  * ASIL Level: B
  *
  * PURPOSE: Per-DID safe accessor implementations (ASIL-B).

--- a/examples/sensor_ecu_freertos/generated/did_safety_wrappers.h
+++ b/examples/sensor_ecu_freertos/generated/did_safety_wrappers.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:16:46Z
  * ASIL Level: B
  *
  * PURPOSE: Declarations for per-DID safe accessor wrapper functions.

--- a/examples/sensor_ecu_freertos/generated/generated_config.h
+++ b/examples/sensor_ecu_freertos/generated/generated_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:16:46Z
  *
  * PURPOSE: Compile-time constants derived from diagnostics_config.yaml.
  *          Provides all protocol timing parameters, CAN addressing, and
@@ -102,6 +102,6 @@
 
 #define GEN_ECU_NAME            "SensorECU"
 #define GEN_ECU_VERSION         "1.0.0"
-#define GEN_GENERATED_TIMESTAMP "2026-08-30T11:15:05Z"
+#define GEN_GENERATED_TIMESTAMP "2026-08-30T13:16:46Z"
 
 #endif /* GENERATED_CONFIG_H */

--- a/examples/sensor_ecu_freertos/generated/generated_files_phase3.json
+++ b/examples/sensor_ecu_freertos/generated/generated_files_phase3.json
@@ -1,8 +1,8 @@
 {
   "phase": "Phase 3",
-  "generated_at": "2026-08-30T11:15:05Z",
-  "config_source": "/home/raul/EDS-wt-124-regen/examples/sensor_ecu_freertos/diagnostics_config.yaml",
-  "output_dir": "/home/raul/EDS-wt-124-regen/examples/sensor_ecu_freertos/generated",
+  "generated_at": "2026-08-30T13:16:46Z",
+  "config_source": "/home/raul/EDS-wt-127/examples/sensor_ecu_freertos/diagnostics_config.yaml",
+  "output_dir": "/home/raul/EDS-wt-127/examples/sensor_ecu_freertos/generated",
   "safety_wrappers": true,
   "asil_level": "B",
   "files": [
@@ -33,5 +33,5 @@
     "examples/sensor_ecu_freertos/generated/tests/requirements_testgen.txt",
     "examples/sensor_ecu_freertos/generated/tests/README.md"
   ],
-  "generator": "/home/raul/EDS-wt-124-regen/tools/codegen.py"
+  "generator": "/home/raul/EDS-wt-127/tools/codegen.py"
 }

--- a/examples/sensor_ecu_freertos/generated/routine_handlers.c
+++ b/examples/sensor_ecu_freertos/generated/routine_handlers.c
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.c
 // GENERATED — do NOT edit manually.
-// ECU: SensorECU  v1.0.0  Generated: 2026-08-30T11:15:05Z
+// ECU: SensorECU  v1.0.0  Generated: 2026-08-30T13:16:46Z
 
 #include "routine_handlers.h"
 #include "routine_database.h"

--- a/examples/sensor_ecu_freertos/generated/routine_handlers.h
+++ b/examples/sensor_ecu_freertos/generated/routine_handlers.h
@@ -1,6 +1,6 @@
 // File: generated/routine_handlers.h
 // GENERATED — do NOT edit manually.
-// ECU: SensorECU  v1.0.0  Generated: 2026-08-30T11:15:05Z
+// ECU: SensorECU  v1.0.0  Generated: 2026-08-30T13:16:46Z
 
 #ifndef ROUTINE_HANDLERS_H
 #define ROUTINE_HANDLERS_H

--- a/examples/sensor_ecu_freertos/generated/safety_config.h
+++ b/examples/sensor_ecu_freertos/generated/safety_config.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:16:46Z
  * ASIL Level: B
  *
  * PURPOSE: Compile-time ASIL safety configuration constants.

--- a/examples/sensor_ecu_freertos/generated/tests/README.md
+++ b/examples/sensor_ecu_freertos/generated/tests/README.md
@@ -40,4 +40,4 @@ CAN_INTERFACE=pcan CAN_CHANNEL=PCAN_USBBUS1 pytest . -v --hil
 
 ---
 
-*Generated 2026-08-30T11:15:05Z by tools/testgen.py*
+*Generated 2026-08-30T13:16:46Z by tools/testgen.py*

--- a/examples/sensor_ecu_freertos/generated/tests/conftest.py
+++ b/examples/sensor_ecu_freertos/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:46Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #

--- a/examples/sensor_ecu_freertos/generated/tests/conftest_firmware.py
+++ b/examples/sensor_ecu_freertos/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:46Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #

--- a/examples/sensor_ecu_freertos/generated/tests/test_did_d001.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_did_d001.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:46Z
 #
 # DID       : 0xD001  (AmbientTemperature)
 # Access    : read

--- a/examples/sensor_ecu_freertos/generated/tests/test_did_d002.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_did_d002.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:46Z
 #
 # DID       : 0xD002  (SupplyVoltage)
 # Access    : read

--- a/examples/sensor_ecu_freertos/generated/tests/test_did_d003.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_did_d003.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:46Z
 #
 # DID       : 0xD003  (SensorStatusBitmask)
 # Access    : read

--- a/examples/sensor_ecu_freertos/generated/tests/test_did_d010.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_did_d010.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:46Z
 #
 # DID       : 0xD010  (TemperatureThresholdHigh)
 # Access    : read + write

--- a/examples/sensor_ecu_freertos/generated/tests/test_did_d011.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_did_d011.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:46Z
 #
 # DID       : 0xD011  (TemperatureThresholdLow)
 # Access    : read + write

--- a/examples/sensor_ecu_freertos/generated/tests/test_did_f18c.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_did_f18c.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:46Z
 #
 # DID       : 0xF18C  (ECUSerialNumber)
 # Access    : read

--- a/examples/sensor_ecu_freertos/generated/tests/test_did_f190.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_did_f190.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:46Z
 #
 # DID       : 0xF190  (VehicleIdentificationNumber)
 # Access    : read

--- a/examples/sensor_ecu_freertos/generated/tests/test_firmware_services.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_firmware_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:46Z
 #
 # PURPOSE: Integration tests running against REAL COMPILED FIRMWARE.
 #

--- a/examples/sensor_ecu_freertos/generated/tests/test_routine_ff00.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:46Z
 #
 # Routine   : 0xFF00  (ResetSensorCalibration)
 # Session   : extended (ordinal 3)

--- a/examples/sensor_ecu_freertos/generated/tests/test_routine_ff01.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T11:15:05Z
+# Generated : 2026-08-30T13:16:46Z
 #
 # Routine   : 0xFF01  (SensorSelfTest)
 # Session   : extended (ordinal 3)

--- a/examples/sensor_ecu_freertos/generated/tests/test_services.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_services.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-05-20T07:21:49Z
+# Generated : 2026-08-30T13:16:46Z
 #
 # PURPOSE: UDS service-level and ISO-TP transport tests derived from
 #          diagnostics_config.yaml.
@@ -395,6 +395,45 @@ class TestReadDTCInformation:
         dtc_section_len = len(pdu) - 3
         assert dtc_section_len % 4 == 0, (
             f"DTC section length {dtc_section_len} is not a multiple of 4"
+        )
+
+    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
+        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 2, "response must be at least 2 bytes"
+        # No availability mask — DTC section starts at byte 2, stride 4
+        dtc_section_len = len(pdu) - 2
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4 "
+            f"(3-byte DTC code + 1-byte counter per record)"
+        )
+
+    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+        """
+        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Empty list (3 bytes) is valid when no DTCs are marked permanent.
+        """
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        assert pdu is not None
+        if pdu[0] == SID_NEGATIVE_RESPONSE:
+            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+        assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
+        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
+        # DTC section after availability mask byte
+        dtc_section_len = len(pdu) - 3
+        assert dtc_section_len % 4 == 0, (
+            f"DTC section length {dtc_section_len} must be a multiple of 4"
         )
 
     def test_invalid_subfunction_rejected(self, uds_bus: IsoTpTransport) -> None:

--- a/examples/sensor_ecu_freertos/generated/uds_init.c
+++ b/examples/sensor_ecu_freertos/generated/uds_init.c
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:16:46Z
  *
  * PURPOSE: Generated UDS stack initialisation. Wires all sub-modules together
  *          using timing constants and database entries derived from YAML.

--- a/examples/sensor_ecu_freertos/generated/uds_init.h
+++ b/examples/sensor_ecu_freertos/generated/uds_init.h
@@ -5,7 +5,7 @@
  *
  * ECU       : SensorECU
  * Version   : 1.0.0
- * Generated : 2026-08-30T11:15:05Z
+ * Generated : 2026-08-30T13:16:46Z
  *
  * PURPOSE: Public interface for the generated UDS stack initialisation module.
  *


### PR DESCRIPTION
Closes #127

## Root cause

`EDS-toolchain` commit `2efba87` ("feat: add 0x19/0x0B and 0x19/0x19 test
coverage to generated suites") added two new pytest methods to
`tools/templates/test_services.py.j2` — `test_report_fault_detection_counter_sub0b`
(ReadDTCInformation sub-function 0x0B, ISO 14229-1 §11.3.11) and
`test_report_dtc_permanent_status_sub19` (sub-function 0x19, §11.3.25). Every
example's committed `generated/tests/test_services.py` predated that commit and
was missing both tests — the same private-template/committed-output drift class
as O-27/#99. Found while regenerating for #124, and deliberately excluded from
that PR (#128) to keep its diff to its actual subject (logged as **O-37** in
`xaloqi-knowledge/reviews/FINDINGS.md`, tracking issue EDS#127 — this issue).

## Fix

Template already correct (confirmed `tools/templates/test_services.py.j2`
contains both methods before starting — the drift is downstream-only, no
template change needed here). Regenerated `examples/*/generated/` for all 11
examples that carry a `tests/` directory: `ardep_ecu`, `basic_ecu`,
`basic_ecu_doip`, `basic_ecu_doip_freertos`, `basic_ecu_freertos`, `bms_ecu`,
`motor_controller_ecu`, `robot_joint_controller_ecu`, `safeboot_ecu`,
`sensor_ecu`, `sensor_ecu_freertos` (`safeboot_freertos_ecu` is generated
without `--test-gen` and was never affected), via `tools/codegen.py --test-gen
--safety-wrappers --asil-level B`, with per-example manifest flags matched to
what was already committed rather than assumed uniform — 8 examples
`--no-manifest`; `robot_joint_controller_ecu`/`sensor_ecu`/`sensor_ecu_freertos`
keep their `generated_files_phase3.json`, per #128's own findings on which
examples carry one.

**Template-source subtlety caught before regenerating anything:** the shared
`../EDS-toolchain` checkout's local `main` branch predates the merge of
`EDS-toolchain#57` (the #124 `uds_init.c.j2` soft-degrade fix that #128 used),
even though that PR is merged upstream — the local clone was simply never
fetched. Generating against it first (caught by diff review before staging,
then reverted) would have **reverted the already-merged #124 fix** in all 11
`uds_init.c` files. Repointed this worktree's gitignored `tools/templates` and
`tools/testgen.py` symlinks at the existing `EDS-toolchain-wt-124` worktree
(branch `fix/124-dtc-mirror-boot-softdegrade`, a strict superset of `main`
containing both `2efba87` and the #124 fix) instead, then regenerated again —
same methodology #128 itself used when it repointed at that same branch. Not a
new finding: `EDS-toolchain#57` is confirmed merged on GitHub; this was local
checkout staleness, not a defect.

## Regeneration methodology (following #99/#128)

Diffed every one of the 341 touched files against the previously committed
version **before staging anything**, with an automated sweep stripping every
known-expected environmental field and reporting anything left over:

- Per-file `Generated:` timestamp headers, in all three formats present
  across the output set (` * Generated : <ts>` block-comment style,
  `// ECU: <name> v<version> Generated: <ts>` inline style, and
  `*Generated <ts> by tools/testgen.py*` in `tests/README.md`)
- The `GEN_GENERATED_TIMESTAMP` macro in `generated_config.h`
- The 3 manifests' (`robot_joint_controller_ecu`, `sensor_ecu`,
  `sensor_ecu_freertos`) `generated_at`/`config_source`/`output_dir`/
  `generator` fields — the latter three are this-machine absolute paths,
  same class of expected environmental drift as the timestamp, exactly as
  #99/#128 treated it

Results:
- **All 330 non-`test_services.py` files**: zero unexpected lines remaining
  after stripping — timestamp/path fields only.
- **All 11 `test_services.py` files**: zero unexpected *removed* lines, and
  the only addition in each is the same two new test methods verbatim
  (40 lines added, matching the template exactly).
- **Zero untracked/new files** anywhere.
- `ardep_ecu`'s `tests/capl/` directory (the only example that has one) is
  untouched — `codegen.py --test-gen` never touches it, confirmed via
  `git status`.
- All 11 examples still carry exactly 3 occurrences of
  `UDS_STATUS_ERR_NVM_DATA_CORRUPT` in `uds_init.c` — the #124 fix, preserved
  intact by this regeneration.
- `grep`-confirmed both new test method names present in all 11 regenerated
  `test_services.py` files (not just that codegen ran without error).

This is a generated-code-only change (no `core/`/`transport/`/`config/` source
touched) — the regression proof is the diff-review methodology above, matching
#99/#128's own approach (no new unit test for a pure regeneration).

## Gate results (unaffected — confirmed, not assumed)

- `bash build_tests.sh` → **44 passed, 0 failed** (baseline: 44/0, unchanged)
- `bash build_harness.sh --run` → **68/68 PASS** (baseline: 68/68, unchanged)
- `python3 misra_analysis.py --out misra.json` → **41 files, 1 finding, 0
  OPEN, 1 justified → PASS** (baseline unchanged; GCC-only locally — cppcheck
  not installed, CI runs `--strict` + cppcheck)
- No-malloc grep (`core/`, `transport/`, `config/`,
  `examples/basic_ecu/generated/`) → empty, as required
- `python3 scripts/verify_doc_counts.py` → **PASS**

## New findings

None new. O-37 (the drift this PR closes) was already logged by #128;
confirmed the tracking issue link resolves to this PR. The template-source
staleness noted above was checked and confirmed to be local-checkout
staleness, not a defect — `EDS-toolchain#57` is merged upstream.

## CHANGELOG.md

Added under the existing `[Unreleased]` → `### Fixed` header (not a new
header).

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>
