### PR TITLE
fix: add per-direction ISO-TP state accessors and reset (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,36 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **ISO-TP: `isotp_get_state()` hid an RX error behind any concurrent transmit,
+  and `isotp_reset()` could not recover one direction alone.** (#132)
+  `isotp_ctx_t` runs two independent state machines, `rx_state` and `tx_state`,
+  but the only public read path collapsed them: `isotp_get_state()` reported
+  `tx_state` whenever it was not `ISOTP_STATE_IDLE` and `rx_state` only
+  otherwise. An RX channel sitting in `ISOTP_STATE_ERROR` was therefore
+  invisible to a polling caller for the entire duration of a transmit — and on
+  a UDS server the transmit direction is busy for exactly as long as a
+  segmented response is going out, which is precisely when an inbound request
+  is being reassembled. Compounding it, `isotp_reset()` — the documented
+  recovery from `ISOTP_STATE_ERROR` — cleared both directions unconditionally,
+  so a caller that did observe an RX error and reset destroyed any in-flight
+  TX with it. Per-direction error handling was not expressible at all. #122
+  made this materially more reachable by adding a new way for `rx_state` to
+  become `ERROR` (a rejected Flow Control transmit) while a TX is active.
+  Added `isotp_get_rx_state()` / `isotp_get_tx_state()`, which report each
+  direction faithfully, and `isotp_reset_rx()` / `isotp_reset_tx()`, which
+  recover one direction while leaving the other's state, buffers and timers
+  untouched — verified safe by a field-ownership audit showing the two
+  directions share nothing mutable, only the read-only configuration and the
+  bound `can_transport_t`. `isotp_get_state()` and `isotp_reset()` keep their
+  exact previous behaviour for source compatibility; `isotp_get_state()`'s
+  aliasing is now documented as a warning on its declaration, and
+  `isotp_reset()` is composed from the two directional clears so a full reset
+  can never drift out of step with the narrow ones. Also fixed the FreeRTOS
+  ECU-reset snippet in `docs/INTEGRATION_GUIDE.md` §4.3, which called
+  `isotp_get_state(tp, &rx_st, &tx_st)` — a three-argument form that has never
+  existed in any released header, so the documented sequence could not compile;
+  it now calls `isotp_get_tx_state()`, which is what it always meant.
+
 - **11 examples' `generated/tests/test_services.py` was missing ReadDTCInformation
   sub `0x0B`/`0x19` coverage that the template gained months ago.** (#127)
   `EDS-toolchain` commit `2efba87` added `test_report_fault_detection_counter_sub0b`

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -78,6 +78,7 @@ The following table covers every service defined in ISO 14229-1:2020. "Implement
 | Mixed addressing | **Out of scope** | — |
 | CAN FD (ISO 15765-2 §9.8) | **Implemented** (v1.7.1+) | Enable with `ISOTP_ENABLE_CAN_FD=1` (`CONFIG_CAN_FD_MODE=y` on Zephyr). Adds SF escape sequence (up to 62-byte SF), FF escape sequence (32-bit FF_DL for PDU > 4095 bytes). Set `isotp_cfg_t.use_fd = true` to activate. Platform HAL wired in `zephyr_can.c` and `freertos_can.c` since v1.7.2. |
 | Max PDU length | **4095 bytes** | Defined by `UDS_MAX_PAYLOAD_LEN` in `core/uds_types.h`. Reducible at compile time to save RAM (see §2). |
+| Per-direction state and recovery | **Implemented** (unreleased) | RX and TX are independent state machines. `isotp_get_rx_state()` / `isotp_get_tx_state()` report each direction faithfully; `isotp_reset_rx()` / `isotp_reset_tx()` recover one direction without disturbing a transfer in flight in the other. `isotp_get_state()` is retained unchanged for source compatibility, but it collapses both directions — it reports the TX state whenever a transmit is in progress, so an RX error is invisible through it for the duration of that transmit. Prefer the directional accessors in new code. |
 
 ---
 
@@ -672,12 +673,12 @@ isotp_transmit(tp, resp.data, resp.length);
 /* 2. Wait for the ISO-TP TX state machine to return to IDLE.
  *    This confirms the last CAN frame has left the TX mailbox
  *    and the N_As timer has not expired. */
-isotp_state_t rx_st, tx_st;
+isotp_state_t tx_st;
 uint32_t wait_ms = 0U;
 do {
     vTaskDelay(1);
     isotp_tick_1ms(tp);
-    isotp_get_state(tp, &rx_st, &tx_st);
+    isotp_get_tx_state(tp, &tx_st);   /* [#132] TX direction only */
     wait_ms++;
 } while ((tx_st != ISOTP_STATE_IDLE) && (wait_ms < 50U));  /* 50ms max */
 

--- a/tests/unit_runnable/test_isotp.c
+++ b/tests/unit_runnable/test_isotp.c
@@ -22,6 +22,9 @@
  *     - isotp_tick_1ms: Cr timeout detection
  *     - isotp_reset: clears state back to IDLE
  *     - isotp_get_state: NULL guard, state reporting
+ *     - [#132] isotp_get_rx_state / isotp_get_tx_state / isotp_reset_rx /
+ *       isotp_reset_tx: per-direction state reporting and recovery while
+ *       the other direction has a transfer in flight
  *
  * DID constant cross-references:
  *   0x0C00 Engine Speed  → 2 bytes  (single frame)
@@ -1421,6 +1424,419 @@ ZTEST(test_isotp_get_state, test_null_state_ptr)
 }
 
 /* =========================================================================
+ * Test suite: [#132] directional state accessors and per-direction reset
+ *
+ * isotp_ctx_t runs two independent state machines. isotp_get_state()
+ * collapses them (it reports tx_state whenever a TX is in progress), so an
+ * RX channel in ISOTP_STATE_ERROR is invisible for the whole duration of a
+ * concurrent transmit; and isotp_reset() clears BOTH directions, so
+ * recovering the failed one destroyed the healthy one.
+ *
+ * These tests build a genuine concurrent scenario — a real multi-frame TX
+ * parked in TX_WAIT_FC / TX_SEND_CF while the RX side is driven to ERROR by
+ * the [#122] rejected-Flow-Control path — and assert that:
+ *   - the new per-direction accessors report each direction faithfully,
+ *   - isotp_get_state()'s aliasing is UNCHANGED (source compatibility),
+ *   - each directional reset recovers its own direction and leaves the other
+ *     not merely field-intact but functionally able to finish its transfer.
+ * ========================================================================= */
+
+ZTEST_SUITE(test_isotp_directional, NULL, NULL, NULL, NULL, NULL);
+
+/** 20-byte multi-frame TX payload: FF carries 6 bytes, then 2 CFs of 7. */
+static void fill_tx_payload(uint8_t *buf)
+{
+    buf[0] = 0x62U; buf[1] = 0xF1U; buf[2] = 0x90U;
+    memset(&buf[3], 0x41U, 17U);  /* 'A' x 17 */
+}
+
+/** Inbound FF announcing a 20-byte PDU, carrying the first 6 bytes. */
+static uds_can_frame_t make_rx_ff_20(void)
+{
+    uint8_t ff_payload[8] = { 0x10U, 0x14U, 0x11U, 0x12U, 0x13U, 0x14U, 0x15U, 0x16U };
+    return make_can_frame(0x7DFU, ff_payload, 8U);
+}
+
+/** Flow Control frame with the given flow status (BS = 0, STmin = 0). */
+static uds_can_frame_t make_fc(uint8_t flow_status)
+{
+    uint8_t fc_payload[3];
+    fc_payload[0] = (uint8_t)((uint8_t)(ISOTP_FRAME_TYPE_FC << 4U) | flow_status);
+    fc_payload[1] = 0x00U;  /* BS    = unlimited */
+    fc_payload[2] = 0x00U;  /* STmin = 0 ms */
+    return make_can_frame(0x7E8U, fc_payload, 3U);
+}
+
+/**
+ * TC-ISTP-DIR-001: RX error during TX_WAIT_FC.
+ *
+ * The blind spot itself: with a real multi-frame TX awaiting Flow Control,
+ * drive the RX direction into ISOTP_STATE_ERROR via a rejected FC transmit
+ * ([#122]).  isotp_get_state() must STILL report the TX state — that is the
+ * behaviour being preserved — while isotp_get_rx_state() exposes the error
+ * that was previously unreachable.
+ */
+ZTEST(test_isotp_directional, test_rx_error_hidden_behind_tx_wait_fc)
+{
+    mock_can_reset();
+    rx_cb_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp(&ctx), UDS_STATUS_OK, "init failed");
+
+    /* --- A genuine TX in flight: FF sent, parked awaiting FC. --- */
+    uint8_t tx_payload[20];
+    fill_tx_payload(tx_payload);
+    zassert_equal(isotp_transmit(&ctx, tx_payload, 20U), UDS_STATUS_OK,
+                  "Multi-frame TX initiation must succeed");
+
+    isotp_state_t tx_state;
+    zassert_equal(isotp_get_tx_state(&ctx, &tx_state), UDS_STATUS_OK, "get_tx_state failed");
+    zassert_equal(tx_state, ISOTP_STATE_TX_WAIT_FC,
+                  "TX must genuinely be awaiting Flow Control");
+
+    /* --- Concurrently, an inbound FF whose FC CTS the data link rejects. --- */
+    g_mock_fail_on_fc = true;
+    uds_can_frame_t ff = make_rx_ff_20();
+    uds_status_t rc = isotp_process_rx_frame(&ctx, &ff, rx_complete_cb, NULL);
+    zassert_equal(rc, UDS_STATUS_ERR_TP_TX_FAILED,
+                  "Rejected FC must surface as ERR_TP_TX_FAILED");
+
+    /* --- The defect: the old accessor cannot see the RX error. --- */
+    isotp_state_t collapsed;
+    zassert_equal(isotp_get_state(&ctx, &collapsed), UDS_STATUS_OK, "get_state failed");
+    zassert_equal(collapsed, ISOTP_STATE_TX_WAIT_FC,
+                  "isotp_get_state() must keep its documented aliasing unchanged");
+    zassert_not_equal(collapsed, ISOTP_STATE_ERROR,
+                      "The RX error is invisible through the collapsing accessor");
+
+    /* --- The fix: each direction is now reportable on its own. --- */
+    isotp_state_t rx_state;
+    zassert_equal(isotp_get_rx_state(&ctx, &rx_state), UDS_STATUS_OK, "get_rx_state failed");
+    zassert_equal(rx_state, ISOTP_STATE_ERROR,
+                  "RX direction must report ERROR despite the concurrent TX");
+
+    zassert_equal(isotp_get_tx_state(&ctx, &tx_state), UDS_STATUS_OK, "get_tx_state failed");
+    zassert_equal(tx_state, ISOTP_STATE_TX_WAIT_FC,
+                  "TX direction must be unaffected by the RX failure");
+}
+
+/**
+ * TC-ISTP-DIR-002: RX error during TX_SEND_CF.
+ *
+ * Same blind spot in the other in-progress TX state — the FC CTS has been
+ * received, so the TX state machine is actively pumping consecutive frames.
+ */
+ZTEST(test_isotp_directional, test_rx_error_hidden_behind_tx_send_cf)
+{
+    mock_can_reset();
+    rx_cb_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp(&ctx), UDS_STATUS_OK, "init failed");
+
+    uint8_t tx_payload[20];
+    fill_tx_payload(tx_payload);
+    zassert_equal(isotp_transmit(&ctx, tx_payload, 20U), UDS_STATUS_OK, "TX init failed");
+
+    /* Peer grants CTS -> TX enters TX_SEND_CF (no tick yet, so it stays there). */
+    uds_can_frame_t fc = make_fc((uint8_t)ISOTP_FC_STATUS_CONTINUE_TO_SEND);
+    zassert_equal(isotp_process_rx_frame(&ctx, &fc, rx_complete_cb, NULL), UDS_STATUS_OK,
+                  "FC CTS must be accepted");
+
+    isotp_state_t tx_state;
+    zassert_equal(isotp_get_tx_state(&ctx, &tx_state), UDS_STATUS_OK, "get_tx_state failed");
+    zassert_equal(tx_state, ISOTP_STATE_TX_SEND_CF, "TX must be pumping CFs");
+
+    g_mock_fail_on_fc = true;
+    uds_can_frame_t ff = make_rx_ff_20();
+    zassert_equal(isotp_process_rx_frame(&ctx, &ff, rx_complete_cb, NULL),
+                  UDS_STATUS_ERR_TP_TX_FAILED, "Rejected FC must be reported");
+
+    isotp_state_t collapsed;
+    zassert_equal(isotp_get_state(&ctx, &collapsed), UDS_STATUS_OK, "get_state failed");
+    zassert_equal(collapsed, ISOTP_STATE_TX_SEND_CF,
+                  "Old accessor still reports the TX state, unchanged");
+
+    isotp_state_t rx_state;
+    zassert_equal(isotp_get_rx_state(&ctx, &rx_state), UDS_STATUS_OK, "get_rx_state failed");
+    zassert_equal(rx_state, ISOTP_STATE_ERROR, "RX error must be visible");
+}
+
+/**
+ * TC-ISTP-DIR-003: isotp_reset_rx() recovers RX without destroying the TX.
+ *
+ * The TX is not merely checked field-by-field: after the partial reset it is
+ * driven to completion and every consecutive frame is verified, proving the
+ * transmit remained functional and not just superficially intact.
+ */
+ZTEST(test_isotp_directional, test_reset_rx_preserves_inflight_tx)
+{
+    mock_can_reset();
+    rx_cb_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp(&ctx), UDS_STATUS_OK, "init failed");
+
+    uint8_t tx_payload[20];
+    fill_tx_payload(tx_payload);
+    zassert_equal(isotp_transmit(&ctx, tx_payload, 20U), UDS_STATUS_OK, "TX init failed");
+
+    uds_can_frame_t fc = make_fc((uint8_t)ISOTP_FC_STATUS_CONTINUE_TO_SEND);
+    zassert_equal(isotp_process_rx_frame(&ctx, &fc, rx_complete_cb, NULL), UDS_STATUS_OK,
+                  "FC CTS must be accepted");
+
+    /* Break the RX direction while that TX is mid-flight. */
+    g_mock_fail_on_fc = true;
+    uds_can_frame_t ff = make_rx_ff_20();
+    zassert_equal(isotp_process_rx_frame(&ctx, &ff, rx_complete_cb, NULL),
+                  UDS_STATUS_ERR_TP_TX_FAILED, "Rejected FC must be reported");
+    g_mock_fail_on_fc = false;
+
+    /* Recover ONLY the receive direction. */
+    zassert_equal(isotp_reset_rx(&ctx), UDS_STATUS_OK, "isotp_reset_rx must return OK");
+
+    isotp_state_t rx_state;
+    isotp_state_t tx_state;
+    zassert_equal(isotp_get_rx_state(&ctx, &rx_state), UDS_STATUS_OK, "get_rx_state failed");
+    zassert_equal(rx_state, ISOTP_STATE_IDLE, "RX must be recovered to IDLE");
+    zassert_equal(isotp_get_tx_state(&ctx, &tx_state), UDS_STATUS_OK, "get_tx_state failed");
+    zassert_equal(tx_state, ISOTP_STATE_TX_SEND_CF,
+                  "isotp_reset_rx() must NOT tear down the in-flight TX");
+
+    /* The TX must still be able to finish: pump it to completion. */
+    uint8_t cf_before = g_mock_tx_count;
+    for (uint32_t i = 0U; i < 8U; i++) {
+        zassert_equal(isotp_tick_1ms(&ctx), UDS_STATUS_OK,
+                      "Ticks after a partial reset must not report a timeout");
+    }
+
+    zassert_equal(isotp_get_tx_state(&ctx, &tx_state), UDS_STATUS_OK, "get_tx_state failed");
+    zassert_equal(tx_state, ISOTP_STATE_IDLE, "TX must run to completion after reset_rx");
+
+    /* Exactly two consecutive frames, carrying bytes 6..12 and 13..19. */
+    zassert_equal((uint32_t)(g_mock_tx_count - cf_before), 2U,
+                  "Remaining payload must be sent as exactly 2 consecutive frames");
+
+    const uds_can_frame_t *cf1 = &g_mock_tx_frames[cf_before];
+    const uds_can_frame_t *cf2 = &g_mock_tx_frames[cf_before + 1U];
+
+    zassert_equal((cf1->data[0] >> 4U), (uint8_t)ISOTP_FRAME_TYPE_CF, "CF1 PCI type");
+    zassert_equal((cf1->data[0] & 0x0FU), 1U, "CF1 sequence number must be 1");
+    zassert_mem_equal(&cf1->data[1], &tx_payload[6], 7U, "CF1 payload bytes 6..12");
+
+    zassert_equal((cf2->data[0] >> 4U), (uint8_t)ISOTP_FRAME_TYPE_CF, "CF2 PCI type");
+    zassert_equal((cf2->data[0] & 0x0FU), 2U, "CF2 sequence number must be 2");
+    zassert_mem_equal(&cf2->data[1], &tx_payload[13], 7U, "CF2 payload bytes 13..19");
+}
+
+/**
+ * TC-ISTP-DIR-004: isotp_reset_tx() recovers TX without destroying the RX.
+ *
+ * Mirror of DIR-003. The reassembly is completed after the partial reset and
+ * its payload verified end to end.
+ */
+ZTEST(test_isotp_directional, test_reset_tx_preserves_inflight_rx)
+{
+    mock_can_reset();
+    rx_cb_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp(&ctx), UDS_STATUS_OK, "init failed");
+
+    /* A genuine reassembly in progress: 6 of 20 bytes received. */
+    uds_can_frame_t ff = make_rx_ff_20();
+    zassert_equal(isotp_process_rx_frame(&ctx, &ff, rx_complete_cb, NULL), UDS_STATUS_OK,
+                  "FF must be accepted");
+
+    isotp_state_t rx_state;
+    zassert_equal(isotp_get_rx_state(&ctx, &rx_state), UDS_STATUS_OK, "get_rx_state failed");
+    zassert_equal(rx_state, ISOTP_STATE_RX_WAIT_CF, "RX must be awaiting CFs");
+
+    /* Concurrently start a TX and have the peer abort it with FC OVERFLOW. */
+    uint8_t tx_payload[20];
+    fill_tx_payload(tx_payload);
+    zassert_equal(isotp_transmit(&ctx, tx_payload, 20U), UDS_STATUS_OK, "TX init failed");
+
+    uds_can_frame_t fc_ovflw = make_fc((uint8_t)ISOTP_FC_STATUS_OVERFLOW);
+    zassert_equal(isotp_process_rx_frame(&ctx, &fc_ovflw, rx_complete_cb, NULL),
+                  UDS_STATUS_ERR_TP_OVERFLOW, "FC OVERFLOW must abort the TX");
+
+    isotp_state_t tx_state;
+    zassert_equal(isotp_get_tx_state(&ctx, &tx_state), UDS_STATUS_OK, "get_tx_state failed");
+    zassert_equal(tx_state, ISOTP_STATE_ERROR, "TX must be in ERROR");
+    zassert_equal(isotp_get_rx_state(&ctx, &rx_state), UDS_STATUS_OK, "get_rx_state failed");
+    zassert_equal(rx_state, ISOTP_STATE_RX_WAIT_CF, "RX reassembly must be unaffected");
+
+    /* Recover ONLY the transmit direction. */
+    zassert_equal(isotp_reset_tx(&ctx), UDS_STATUS_OK, "isotp_reset_tx must return OK");
+    zassert_equal(isotp_get_tx_state(&ctx, &tx_state), UDS_STATUS_OK, "get_tx_state failed");
+    zassert_equal(tx_state, ISOTP_STATE_IDLE, "TX must be recovered to IDLE");
+    zassert_equal(isotp_get_rx_state(&ctx, &rx_state), UDS_STATUS_OK, "get_rx_state failed");
+    zassert_equal(rx_state, ISOTP_STATE_RX_WAIT_CF,
+                  "isotp_reset_tx() must NOT tear down the in-flight reassembly");
+
+    /* The reassembly must still complete correctly. */
+    uint8_t cf1_payload[8] = { 0x21U, 0x17U, 0x18U, 0x19U, 0x1AU, 0x1BU, 0x1CU, 0x1DU };
+    uds_can_frame_t cf1 = make_can_frame(0x7DFU, cf1_payload, 8U);
+    zassert_equal(isotp_process_rx_frame(&ctx, &cf1, rx_complete_cb, NULL), UDS_STATUS_OK,
+                  "CF1 must be accepted after isotp_reset_tx()");
+
+    uint8_t cf2_payload[8] = { 0x22U, 0x1EU, 0x1FU, 0x20U, 0x21U, 0x22U, 0x23U, 0x24U };
+    uds_can_frame_t cf2 = make_can_frame(0x7DFU, cf2_payload, 8U);
+    zassert_equal(isotp_process_rx_frame(&ctx, &cf2, rx_complete_cb, NULL), UDS_STATUS_OK,
+                  "CF2 must be accepted after isotp_reset_tx()");
+
+    zassert_true(g_rx_cb_called, "Reassembly must complete after a TX-only reset");
+    zassert_equal(g_rx_cb_len, 20U, "Full 20-byte PDU must be delivered");
+
+    uint8_t expected[20];
+    for (uint8_t i = 0U; i < 20U; i++) {
+        expected[i] = (uint8_t)(0x11U + i);
+    }
+    zassert_mem_equal(g_rx_cb_data, expected, 20U,
+                      "Reassembled payload must be byte-exact across the TX reset");
+}
+
+/**
+ * TC-ISTP-DIR-005: a partial RX reset leaves the context valid, not merely
+ * idle-looking.
+ *
+ * The risk of resetting one direction alone is that rx_state == IDLE becomes
+ * a false "safe to start" signal that corrupts something the live TX depends
+ * on.  It does not: an unsolicited CF is still rejected as an unexpected PDU,
+ * a fresh FF starts a clean reassembly, and neither disturbs the transmit,
+ * which still runs to completion.
+ */
+ZTEST(test_isotp_directional, test_reset_rx_leaves_context_valid_for_new_rx)
+{
+    mock_can_reset();
+    rx_cb_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp(&ctx), UDS_STATUS_OK, "init failed");
+
+    uint8_t tx_payload[20];
+    fill_tx_payload(tx_payload);
+    zassert_equal(isotp_transmit(&ctx, tx_payload, 20U), UDS_STATUS_OK, "TX init failed");
+    uds_can_frame_t fc = make_fc((uint8_t)ISOTP_FC_STATUS_CONTINUE_TO_SEND);
+    zassert_equal(isotp_process_rx_frame(&ctx, &fc, rx_complete_cb, NULL), UDS_STATUS_OK,
+                  "FC CTS must be accepted");
+
+    g_mock_fail_on_fc = true;
+    uds_can_frame_t bad_ff = make_rx_ff_20();
+    zassert_equal(isotp_process_rx_frame(&ctx, &bad_ff, rx_complete_cb, NULL),
+                  UDS_STATUS_ERR_TP_TX_FAILED, "Rejected FC must be reported");
+    g_mock_fail_on_fc = false;
+
+    zassert_equal(isotp_reset_rx(&ctx), UDS_STATUS_OK, "isotp_reset_rx must return OK");
+
+    /* A stray CF from the abandoned transfer must be rejected, not absorbed. */
+    uint8_t stray_payload[8] = { 0x21U, 0x17U, 0x18U, 0x19U, 0x1AU, 0x1BU, 0x1CU, 0x1DU };
+    uds_can_frame_t stray = make_can_frame(0x7DFU, stray_payload, 8U);
+    zassert_equal(isotp_process_rx_frame(&ctx, &stray, rx_complete_cb, NULL),
+                  UDS_STATUS_ERR_TP_UNEXPECTED_PDU,
+                  "A CF with no FF must be rejected after a partial RX reset");
+    zassert_false(g_rx_cb_called, "No callback for a stray CF");
+
+    /* A fresh reassembly must start cleanly, with the TX still in flight. */
+    uds_can_frame_t ff2 = make_rx_ff_20();
+    zassert_equal(isotp_process_rx_frame(&ctx, &ff2, rx_complete_cb, NULL), UDS_STATUS_OK,
+                  "A new FF must be accepted after a partial RX reset");
+
+    isotp_state_t rx_state;
+    isotp_state_t tx_state;
+    zassert_equal(isotp_get_rx_state(&ctx, &rx_state), UDS_STATUS_OK, "get_rx_state failed");
+    zassert_equal(rx_state, ISOTP_STATE_RX_WAIT_CF, "New reassembly must be underway");
+    zassert_equal(isotp_get_tx_state(&ctx, &tx_state), UDS_STATUS_OK, "get_tx_state failed");
+    zassert_equal(tx_state, ISOTP_STATE_TX_SEND_CF, "The TX must still be in flight");
+
+    for (uint32_t i = 0U; i < 8U; i++) {
+        (void)isotp_tick_1ms(&ctx);
+    }
+    zassert_equal(isotp_get_tx_state(&ctx, &tx_state), UDS_STATUS_OK, "get_tx_state failed");
+    zassert_equal(tx_state, ISOTP_STATE_IDLE,
+                  "The TX must still complete alongside the restarted reassembly");
+}
+
+/**
+ * TC-ISTP-DIR-006: isotp_reset() remains exactly isotp_reset_rx() +
+ * isotp_reset_tx().
+ *
+ * isotp_reset() is now composed from the two directional clears; this pins
+ * that refactor by comparing a fully-dirty context reset both ways, so the
+ * full reset can never silently stop clearing a field.
+ */
+ZTEST(test_isotp_directional, test_full_reset_equals_both_directional_resets)
+{
+    mock_can_reset();
+    rx_cb_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp(&ctx), UDS_STATUS_OK, "init failed");
+
+    /* Dirty BOTH directions: reassembly underway, segmented TX underway. */
+    uds_can_frame_t ff = make_rx_ff_20();
+    zassert_equal(isotp_process_rx_frame(&ctx, &ff, rx_complete_cb, NULL), UDS_STATUS_OK,
+                  "FF must be accepted");
+    uint8_t tx_payload[20];
+    fill_tx_payload(tx_payload);
+    zassert_equal(isotp_transmit(&ctx, tx_payload, 20U), UDS_STATUS_OK, "TX init failed");
+    uds_can_frame_t fc = make_fc((uint8_t)ISOTP_FC_STATUS_CONTINUE_TO_SEND);
+    zassert_equal(isotp_process_rx_frame(&ctx, &fc, rx_complete_cb, NULL), UDS_STATUS_OK,
+                  "FC CTS must be accepted");
+
+    isotp_ctx_t via_full = ctx;
+    isotp_ctx_t via_pair = ctx;
+
+    zassert_equal(isotp_reset(&via_full), UDS_STATUS_OK, "isotp_reset must return OK");
+    zassert_equal(isotp_reset_rx(&via_pair), UDS_STATUS_OK, "isotp_reset_rx must return OK");
+    zassert_equal(isotp_reset_tx(&via_pair), UDS_STATUS_OK, "isotp_reset_tx must return OK");
+
+    zassert_mem_equal(&via_full, &via_pair, sizeof(isotp_ctx_t),
+                      "isotp_reset() must equal isotp_reset_rx() + isotp_reset_tx()");
+
+    isotp_state_t state;
+    zassert_equal(isotp_get_rx_state(&via_full, &state), UDS_STATUS_OK, "get_rx_state failed");
+    zassert_equal(state, ISOTP_STATE_IDLE, "Full reset must idle the RX direction");
+    zassert_equal(isotp_get_tx_state(&via_full, &state), UDS_STATUS_OK, "get_tx_state failed");
+    zassert_equal(state, ISOTP_STATE_IDLE, "Full reset must idle the TX direction");
+}
+
+/**
+ * TC-ISTP-DIR-007: NULL and not-initialised guards on the four new entry
+ * points, matching isotp_get_state() / isotp_reset().
+ */
+ZTEST(test_isotp_directional, test_new_api_null_and_init_guards)
+{
+    mock_can_reset();
+    isotp_state_t state;
+
+    zassert_equal(isotp_get_rx_state(NULL, &state), UDS_STATUS_ERR_NULL_PTR, "NULL ctx");
+    zassert_equal(isotp_get_tx_state(NULL, &state), UDS_STATUS_ERR_NULL_PTR, "NULL ctx");
+    zassert_equal(isotp_reset_rx(NULL), UDS_STATUS_ERR_NULL_PTR, "NULL ctx");
+    zassert_equal(isotp_reset_tx(NULL), UDS_STATUS_ERR_NULL_PTR, "NULL ctx");
+
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp(&ctx), UDS_STATUS_OK, "init failed");
+
+    zassert_equal(isotp_get_rx_state(&ctx, NULL), UDS_STATUS_ERR_NULL_PTR, "NULL out_state");
+    zassert_equal(isotp_get_tx_state(&ctx, NULL), UDS_STATUS_ERR_NULL_PTR, "NULL out_state");
+
+    isotp_ctx_t uninit;
+    memset(&uninit, 0, sizeof(uninit));
+    zassert_equal(isotp_get_rx_state(&uninit, &state), UDS_STATUS_ERR_NOT_INITIALIZED,
+                  "Uninitialised ctx must be rejected");
+    zassert_equal(isotp_get_tx_state(&uninit, &state), UDS_STATUS_ERR_NOT_INITIALIZED,
+                  "Uninitialised ctx must be rejected");
+    zassert_equal(isotp_reset_rx(&uninit), UDS_STATUS_ERR_NOT_INITIALIZED,
+                  "Uninitialised ctx must be rejected");
+    zassert_equal(isotp_reset_tx(&uninit), UDS_STATUS_ERR_NOT_INITIALIZED,
+                  "Uninitialised ctx must be rejected");
+}
+
+/* =========================================================================
  * Test suite: TX frame padding (ISOTP_TX_PADDING)
  * Tests only compiled and wired when ISOTP_TX_PADDING=1.
  * REQ-TP-PAD-001: unused frame bytes filled with ISOTP_TX_PADDING_BYTE.
@@ -1682,6 +2098,13 @@ extern void test_isotp_reset__test_null_ctx(void);
 extern void test_isotp_reset__test_reset_from_error(void);
 extern void test_isotp_get_state__test_null_ctx(void);
 extern void test_isotp_get_state__test_null_state_ptr(void);
+extern void test_isotp_directional__test_rx_error_hidden_behind_tx_wait_fc(void);
+extern void test_isotp_directional__test_rx_error_hidden_behind_tx_send_cf(void);
+extern void test_isotp_directional__test_reset_rx_preserves_inflight_tx(void);
+extern void test_isotp_directional__test_reset_tx_preserves_inflight_rx(void);
+extern void test_isotp_directional__test_reset_rx_leaves_context_valid_for_new_rx(void);
+extern void test_isotp_directional__test_full_reset_equals_both_directional_resets(void);
+extern void test_isotp_directional__test_new_api_null_and_init_guards(void);
 #if ISOTP_TX_PADDING
 extern void test_isotp_padding__test_classic_sf_padded(void);
 extern void test_isotp_padding__test_classic_sf_max_payload_no_tail(void);
@@ -1740,6 +2163,13 @@ void run_all_tests(void)
     RUN_TEST(test_isotp_reset__test_reset_from_error);
     RUN_TEST(test_isotp_get_state__test_null_ctx);
     RUN_TEST(test_isotp_get_state__test_null_state_ptr);
+    RUN_TEST(test_isotp_directional__test_rx_error_hidden_behind_tx_wait_fc);
+    RUN_TEST(test_isotp_directional__test_rx_error_hidden_behind_tx_send_cf);
+    RUN_TEST(test_isotp_directional__test_reset_rx_preserves_inflight_tx);
+    RUN_TEST(test_isotp_directional__test_reset_tx_preserves_inflight_rx);
+    RUN_TEST(test_isotp_directional__test_reset_rx_leaves_context_valid_for_new_rx);
+    RUN_TEST(test_isotp_directional__test_full_reset_equals_both_directional_resets);
+    RUN_TEST(test_isotp_directional__test_new_api_null_and_init_guards);
 #if ISOTP_TX_PADDING
     RUN_TEST(test_isotp_padding__test_classic_sf_padded);
     RUN_TEST(test_isotp_padding__test_classic_sf_max_payload_no_tail);

--- a/transport/isotp.c
+++ b/transport/isotp.c
@@ -89,6 +89,23 @@ static uint8_t isotp_decode_stmin_ms(uint8_t stmin_raw);
  */
 static void isotp_tx_pump(isotp_ctx_t *ctx);
 
+/**
+ * [#132] Clear every RX-direction field of the context.
+ *
+ * Guard-free: every caller (isotp_reset_rx(), isotp_reset()) has already
+ * validated ctx. Sole definition of "what the RX direction owns" — see the
+ * DIRECTIONAL STATE OWNERSHIP audit above isotp_reset().
+ */
+static void isotp_clear_rx(isotp_ctx_t *ctx);
+
+/**
+ * [#132] Clear every TX-direction field of the context.
+ *
+ * Guard-free: every caller (isotp_reset_tx(), isotp_reset()) has already
+ * validated ctx. Sole definition of "what the TX direction owns".
+ */
+static void isotp_clear_tx(isotp_ctx_t *ctx);
+
 /* --------------------------------------------------------------------------
  * Public API implementations
  * -------------------------------------------------------------------------- */
@@ -316,7 +333,8 @@ uds_status_t isotp_process_rx_frame(
              * already handles an RX fault that has mutated context (see the CF
              * handler's SN, DLC and overflow paths) and how the TX path handles
              * a failed can_transport_transmit() in isotp_tx_pump(). Recovery is
-             * via isotp_reset(), as for every other RX error.
+             * via isotp_reset_rx() ([#132] — or isotp_reset(), which also
+             * tears down any concurrent TX), as for every other RX error.
              */
             fc_rc = isotp_send_fc(ctx,
                                   (uint8_t)ISOTP_FC_STATUS_CONTINUE_TO_SEND,
@@ -787,6 +805,49 @@ uds_status_t isotp_tick_1ms(isotp_ctx_t *ctx)
     return UDS_STATUS_OK;
 }
 
+/*
+ * [#132] DIRECTIONAL STATE OWNERSHIP
+ *
+ * isotp_ctx_t runs two independent state machines. The audit below is what
+ * makes a per-direction reset safe, and it is the contract isotp_clear_rx()
+ * and isotp_clear_tx() encode. Any new context field must be added to exactly
+ * one of these two lists (or to the read-only group).
+ *
+ *   RX-owned (written only by the SF/FF/CF handlers, isotp_send_fc()'s N_Ar
+ *   arming, and the Cr/Ar branches of isotp_tick_1ms()):
+ *     rx_state, rx_buf, rx_expected_len, rx_received_len, rx_expected_sn,
+ *     rx_blocks_received, rx_cr_timer_ms, rx_ar_timer_ms
+ *
+ *   TX-owned (written only by isotp_transmit(), the FC handler, the As/Bs/
+ *   STmin branches of isotp_tick_1ms(), and isotp_tx_pump()):
+ *     tx_state, tx_data, tx_total_len, tx_sent_len, tx_sn, tx_block_size,
+ *     tx_stmin_ms, tx_blocks_sent, tx_stmin_timer_ms, tx_bs_timer_ms,
+ *     tx_as_timer_ms
+ *
+ *   Shared but READ-ONLY after isotp_init(), so neither reset touches them:
+ *     initialized, rx_can_id, tx_can_id, local_block_size, local_stmin_ms,
+ *     use_fd, can
+ *
+ * The two lists are disjoint and their union is exactly the set isotp_reset()
+ * has always cleared. Neither direction reads a field the other writes: the
+ * RX handlers never inspect tx_state, and isotp_tx_pump() never inspects
+ * rx_state. The only object both touch is the bound can_transport_t, which
+ * they use through can_transport_transmit() without holding any cross-call
+ * state. Resetting one direction mid-transfer in the other is therefore
+ * sound: no half-updated invariant is left behind, and no buffer either side
+ * depends on is freed or reused.
+ *
+ * Note in particular that clearing rx_state to IDLE does NOT hand the RX path
+ * a false "safe to start" signal that could disturb the TX side. The FF
+ * handler never consults rx_state at all (an FF always restarts a
+ * reassembly), the CF handler requires RX_WAIT_CF and so rejects a stray CF
+ * with ERR_TP_UNEXPECTED_PDU, and the FC handler — the only RX-path branch
+ * that writes TX fields — is gated on tx_state, which isotp_clear_rx() does
+ * not touch. Symmetrically, clearing tx_state to IDLE only makes a late FC
+ * be ignored (the FC handler's existing "outside expected window" branch),
+ * which is already the behaviour after a full isotp_reset().
+ */
+
 uds_status_t isotp_reset(isotp_ctx_t *ctx)
 {
     if (ctx == NULL) {
@@ -797,24 +858,44 @@ uds_status_t isotp_reset(isotp_ctx_t *ctx)
         return UDS_STATUS_ERR_NOT_INITIALIZED;
     }
 
-    ctx->rx_state           = ISOTP_STATE_IDLE;
-    ctx->tx_state           = ISOTP_STATE_IDLE;
-    ctx->rx_expected_len    = (uint32_t)0U;
-    ctx->rx_received_len    = (uint32_t)0U;
-    ctx->rx_expected_sn     = (uint8_t)0U;
-    ctx->rx_blocks_received = (uint8_t)0U;
-    ctx->rx_cr_timer_ms     = 0U;
-    ctx->rx_ar_timer_ms     = 0U;
-    ctx->tx_data            = NULL;
-    ctx->tx_total_len       = (uint32_t)0U;
-    ctx->tx_sent_len        = (uint32_t)0U;
-    ctx->tx_sn              = (uint8_t)0U;
-    ctx->tx_block_size      = (uint8_t)0U;
-    ctx->tx_stmin_ms        = (uint8_t)0U;
-    ctx->tx_stmin_timer_ms  = 0U;
-    ctx->tx_bs_timer_ms     = 0U;
-    ctx->tx_as_timer_ms     = 0U;
-    ctx->tx_blocks_sent     = (uint8_t)0U;
+    /*
+     * [#132] Composed from the two directional clears rather than repeating
+     * their field lists, so the full reset cannot drift out of step with the
+     * narrow ones when a context field is added. Behaviour is byte-identical
+     * to the previous open-coded body.
+     */
+    isotp_clear_rx(ctx);
+    isotp_clear_tx(ctx);
+
+    return UDS_STATUS_OK;
+}
+
+uds_status_t isotp_reset_rx(isotp_ctx_t *ctx)
+{
+    if (ctx == NULL) {
+        return UDS_STATUS_ERR_NULL_PTR;
+    }
+
+    if (!ctx->initialized) {
+        return UDS_STATUS_ERR_NOT_INITIALIZED;
+    }
+
+    isotp_clear_rx(ctx);
+
+    return UDS_STATUS_OK;
+}
+
+uds_status_t isotp_reset_tx(isotp_ctx_t *ctx)
+{
+    if (ctx == NULL) {
+        return UDS_STATUS_ERR_NULL_PTR;
+    }
+
+    if (!ctx->initialized) {
+        return UDS_STATUS_ERR_NOT_INITIALIZED;
+    }
+
+    isotp_clear_tx(ctx);
 
     return UDS_STATUS_OK;
 }
@@ -831,11 +912,53 @@ uds_status_t isotp_get_state(
         return UDS_STATUS_ERR_NOT_INITIALIZED;
     }
 
+    /*
+     * [#132] Aliasing preserved verbatim for source compatibility: this
+     * reports tx_state whenever a transmit is in progress, which hides an
+     * rx_state of ISOTP_STATE_ERROR for the whole duration of that transmit.
+     * The blind spot is documented on the declaration in isotp.h and is
+     * addressed by isotp_get_rx_state() / isotp_get_tx_state() below, not by
+     * changing what this function returns.
+     */
     if (ctx->tx_state != ISOTP_STATE_IDLE) {
         *out_state = ctx->tx_state;
     } else {
         *out_state = ctx->rx_state;
     }
+
+    return UDS_STATUS_OK;
+}
+
+uds_status_t isotp_get_rx_state(
+    const isotp_ctx_t *ctx,
+    isotp_state_t     *out_state)
+{
+    if ((ctx == NULL) || (out_state == NULL)) {
+        return UDS_STATUS_ERR_NULL_PTR;
+    }
+
+    if (!ctx->initialized) {
+        return UDS_STATUS_ERR_NOT_INITIALIZED;
+    }
+
+    *out_state = ctx->rx_state;
+
+    return UDS_STATUS_OK;
+}
+
+uds_status_t isotp_get_tx_state(
+    const isotp_ctx_t *ctx,
+    isotp_state_t     *out_state)
+{
+    if ((ctx == NULL) || (out_state == NULL)) {
+        return UDS_STATUS_ERR_NULL_PTR;
+    }
+
+    if (!ctx->initialized) {
+        return UDS_STATUS_ERR_NOT_INITIALIZED;
+    }
+
+    *out_state = ctx->tx_state;
 
     return UDS_STATUS_OK;
 }
@@ -942,6 +1065,47 @@ static uint8_t isotp_decode_stmin_ms(uint8_t stmin_raw)
 
     /* 0x80–0xF0 and 0xFA–0xFF: reserved — treat as 0 ms. */
     return (uint8_t)0U;
+}
+
+/*
+ * [#132] Directional clears. The field lists below are the single
+ * definition of what each direction owns; isotp_reset(),
+ * isotp_reset_rx() and isotp_reset_tx() are all built from them. See the
+ * DIRECTIONAL STATE OWNERSHIP audit above isotp_reset() for why the split
+ * is sound. Field assignment order is preserved exactly as the original
+ * open-coded isotp_reset() had it — deliberately, so this refactor
+ * introduces no new behaviour of any kind.
+ */
+static void isotp_clear_rx(isotp_ctx_t *ctx)
+{
+    /*
+     * rx_buf is deliberately not scrubbed — isotp_reset() never scrubbed it
+     * either, and zeroing up to ISOTP_RX_BUF_LEN (4095 B by default) in what
+     * may be an error path is not free. rx_received_len is zeroed, so no
+     * stale byte is reachable through the API.
+     */
+    ctx->rx_state           = ISOTP_STATE_IDLE;
+    ctx->rx_expected_len    = (uint32_t)0U;
+    ctx->rx_received_len    = (uint32_t)0U;
+    ctx->rx_expected_sn     = (uint8_t)0U;
+    ctx->rx_blocks_received = (uint8_t)0U;
+    ctx->rx_cr_timer_ms     = 0U;
+    ctx->rx_ar_timer_ms     = 0U;
+}
+
+static void isotp_clear_tx(isotp_ctx_t *ctx)
+{
+    ctx->tx_state           = ISOTP_STATE_IDLE;
+    ctx->tx_data            = NULL;
+    ctx->tx_total_len       = (uint32_t)0U;
+    ctx->tx_sent_len        = (uint32_t)0U;
+    ctx->tx_sn              = (uint8_t)0U;
+    ctx->tx_block_size      = (uint8_t)0U;
+    ctx->tx_stmin_ms        = (uint8_t)0U;
+    ctx->tx_stmin_timer_ms  = 0U;
+    ctx->tx_bs_timer_ms     = 0U;
+    ctx->tx_as_timer_ms     = 0U;
+    ctx->tx_blocks_sent     = (uint8_t)0U;
 }
 
 /* [P2-TP-04] [P2-TP-06] Consecutive Frame TX pump — sends one CF per call. */

--- a/transport/isotp.h
+++ b/transport/isotp.h
@@ -314,7 +314,11 @@ uds_status_t isotp_init(isotp_ctx_t *ctx, const isotp_cfg_t *cfg);
  * @return UDS_STATUS_ERR_TP_UNEXPECTED_PDU if frame received in invalid state.
  * @return UDS_STATUS_ERR_TP_TX_FAILED if the Flow Control frame this function
  *         had to transmit was rejected by the data link layer. The RX channel
- *         is left in ISOTP_STATE_ERROR and requires isotp_reset().
+ *         is left in ISOTP_STATE_ERROR and requires isotp_reset_rx() (or
+ *         isotp_reset(), if tearing down both directions is acceptable).
+ *         [#132] Note that this error is NOT observable through
+ *         isotp_get_state() while a transmit is in progress — use
+ *         isotp_get_rx_state(), or this return value.
  *
  * @note TIMING: Must complete within CAN frame inter-arrival time.
  */
@@ -380,27 +384,151 @@ uds_status_t isotp_transmit(
 uds_status_t isotp_tick_1ms(isotp_ctx_t *ctx);
 
 /**
- * @brief Reset the ISO-TP channel to IDLE state.
+ * @brief Reset BOTH directions of the ISO-TP channel to IDLE state.
  *
  * Clears all RX and TX state. May be called after error recovery.
+ *
+ * Exactly equivalent to isotp_reset_rx() followed by isotp_reset_tx(); it is
+ * implemented as such so the two never drift apart.
+ *
+ * @warning [#132] This tears down BOTH directions. Recovering an RX error
+ *          with it aborts any transmit still in flight (and vice versa). To
+ *          recover one direction only, use isotp_reset_rx() /
+ *          isotp_reset_tx().
  *
  * @param[in] ctx  Initialized ISO-TP context.
  *
  * @return UDS_STATUS_OK on success.
  * @return UDS_STATUS_ERR_NULL_PTR if ctx is NULL.
+ * @return UDS_STATUS_ERR_NOT_INITIALIZED if ctx is not initialized.
  */
 uds_status_t isotp_reset(isotp_ctx_t *ctx);
 
 /**
- * @brief Query the current channel state.
+ * @brief [#132] Reset ONLY the receive direction to IDLE state.
+ *
+ * Clears rx_state, the reassembly length/sequence counters, the RX block
+ * counter and the Cr/Ar timers. An in-flight transmit — tx_state, tx_data,
+ * the CF sequence number, the negotiated BS/STmin and the As/Bs/STmin timers
+ * — is left completely untouched and continues normally.
+ *
+ * This is the targeted recovery from an RX-side ISOTP_STATE_ERROR (a Cr or Ar
+ * timeout, a sequence-number or DLC fault, a buffer overflow, or the
+ * UDS_STATUS_ERR_TP_TX_FAILED reported by isotp_process_rx_frame() when a
+ * Flow Control frame is rejected by the data link layer).
+ *
+ * SAFETY: the two directions share no mutable state — only the read-only
+ * configuration and the bound can_transport_t — so this leaves the context
+ * fully valid for every other API function. Afterwards a new First Frame is
+ * accepted normally and a stray Consecutive Frame is rejected with
+ * UDS_STATUS_ERR_TP_UNEXPECTED_PDU, exactly as from a freshly initialized
+ * channel.
+ *
+ * @note The reassembly buffer contents are not scrubbed (neither does
+ *       isotp_reset()); rx_received_len is zeroed, so no stale byte is
+ *       reachable.
+ * @note This is a local teardown only. It does not signal the peer, which
+ *       may still be sending consecutive frames for the abandoned PDU; those
+ *       are rejected as unexpected PDUs. Same semantics as isotp_reset().
+ *
+ * @param[in] ctx  Initialized ISO-TP context.
+ *
+ * @return UDS_STATUS_OK on success.
+ * @return UDS_STATUS_ERR_NULL_PTR if ctx is NULL.
+ * @return UDS_STATUS_ERR_NOT_INITIALIZED if ctx is not initialized.
+ */
+uds_status_t isotp_reset_rx(isotp_ctx_t *ctx);
+
+/**
+ * @brief [#132] Reset ONLY the transmit direction to IDLE state.
+ *
+ * Clears tx_state, the borrowed tx_data pointer, the length/sequence
+ * counters, the negotiated block size and STmin, and the As/Bs/STmin timers.
+ * An in-progress reassembly — rx_state, the RX buffer and its counters, and
+ * the Cr/Ar timers — is left completely untouched and continues normally.
+ *
+ * This is the targeted recovery from a TX-side ISOTP_STATE_ERROR (a Bs or As
+ * timeout, a Flow Control OVERFLOW or reserved flow-status abort, or a
+ * consecutive frame rejected by the data link layer).
+ *
+ * SAFETY: see isotp_reset_rx(). Dropping the tx_data pointer here also
+ * releases the caller's obligation to keep that buffer alive.
+ *
+ * @note This is a local teardown only. It does not signal the peer, which may
+ *       still be awaiting the remainder of the aborted PDU. Same semantics as
+ *       isotp_reset().
+ *
+ * @param[in] ctx  Initialized ISO-TP context.
+ *
+ * @return UDS_STATUS_OK on success.
+ * @return UDS_STATUS_ERR_NULL_PTR if ctx is NULL.
+ * @return UDS_STATUS_ERR_NOT_INITIALIZED if ctx is not initialized.
+ */
+uds_status_t isotp_reset_tx(isotp_ctx_t *ctx);
+
+/**
+ * @brief Query the current channel state (direction-collapsing).
+ *
+ * @warning [#132] This accessor reports ONE state for a context that runs TWO
+ *          independent state machines. It returns tx_state whenever a
+ *          transmit is in progress and rx_state only otherwise, so an RX
+ *          channel sitting in ISOTP_STATE_ERROR is invisible here for the
+ *          entire duration of any concurrent transmit. On a UDS server the
+ *          transmit direction is busy for exactly as long as a segmented
+ *          response is going out, which is precisely when an inbound request
+ *          is being reassembled.
+ *
+ *          Retained unchanged for source compatibility. New code should use
+ *          isotp_get_rx_state() and isotp_get_tx_state(), which report each
+ *          direction faithfully.
  *
  * @param[in]  ctx        Initialized ISO-TP context.
- * @param[out] out_state  Pointer to receive current channel state.
+ * @param[out] out_state  Receives tx_state if it is not ISOTP_STATE_IDLE,
+ *                        otherwise rx_state.
  *
  * @return UDS_STATUS_OK on success.
  * @return UDS_STATUS_ERR_NULL_PTR if any pointer is NULL.
+ * @return UDS_STATUS_ERR_NOT_INITIALIZED if ctx is not initialized.
  */
 uds_status_t isotp_get_state(
+    const isotp_ctx_t *ctx,
+    isotp_state_t     *out_state
+);
+
+/**
+ * @brief [#132] Query the receive-direction state, unaliased.
+ *
+ * Reports rx_state exactly, whether or not a transmit is in progress. This is
+ * the only way to observe an RX-side ISOTP_STATE_ERROR concurrently with a
+ * transmit; isotp_get_state() hides it.
+ *
+ * @param[in]  ctx        Initialized ISO-TP context.
+ * @param[out] out_state  Pointer to receive the current RX state.
+ *
+ * @return UDS_STATUS_OK on success.
+ * @return UDS_STATUS_ERR_NULL_PTR if any pointer is NULL.
+ * @return UDS_STATUS_ERR_NOT_INITIALIZED if ctx is not initialized.
+ */
+uds_status_t isotp_get_rx_state(
+    const isotp_ctx_t *ctx,
+    isotp_state_t     *out_state
+);
+
+/**
+ * @brief [#132] Query the transmit-direction state, unaliased.
+ *
+ * Reports tx_state exactly. Unlike isotp_get_state(), an ISOTP_STATE_IDLE
+ * result here unambiguously means "no transmit in progress" rather than
+ * "no transmit in progress AND the receiver is also idle".
+ *
+ * @param[in]  ctx        Initialized ISO-TP context.
+ * @param[out] out_state  Pointer to receive the current TX state.
+ *
+ * @return UDS_STATUS_OK on success.
+ * @return UDS_STATUS_ERR_NULL_PTR if any pointer is NULL.
+ * @return UDS_STATUS_ERR_NOT_INITIALIZED if ctx is not initialized.
+ */
+uds_status_t isotp_get_tx_state(
     const isotp_ctx_t *ctx,
     isotp_state_t     *out_state
 );


### PR DESCRIPTION
Closes #132

## Root cause

`isotp_ctx_t` carries two independent state machines, `rx_state` and `tx_state`, and `transport/isotp.c` drives them independently. But the only public read path collapsed them:

```c
if (ctx->tx_state != ISOTP_STATE_IDLE) {
    *out_state = ctx->tx_state;
} else {
    *out_state = ctx->rx_state;
}
```

So `rx_state` was reportable only while no TX was in progress. An RX channel sitting in `ISOTP_STATE_ERROR` was invisible to a polling caller for the entire duration of a concurrent transmit — and on a UDS server the TX direction is busy for exactly as long as a segmented response is going out, which is precisely when an inbound request from the tester is being reassembled.

Compounding it, `isotp_reset()` — the documented recovery from `ISOTP_STATE_ERROR` — cleared **both** directions unconditionally (`rx_state`, `tx_state`, `tx_data`, all six timers). A caller that did observe an RX error and reset therefore destroyed any in-flight TX at the same time. Error recovery was not per-direction even though the error states are, so an integration could not implement per-direction error handling at all: it either polled `isotp_get_state()` and silently missed RX errors during a TX, or reacted to one and aborted a healthy transfer in the other direction.

Pre-existing, not introduced by #122, but #131 made it materially more reachable — the RX side now enters `ISOTP_STATE_ERROR` on a rejected FC transmit, a new way for `rx_state` to become `ERROR` while a TX is active.

## Caller audit (what determined the API shape)

`grep -rn "isotp_get_state\|isotp_reset"` across the entire repo — `core/`, `transport/`, `config/`, `platform/`, `examples/` including every `generated/` tree, the gitignored `harness/` symlink, `tools/`, `docs/` and `tests/`:

| Location | Callers | Consequence |
|---|---|---|
| `core/`, `config/`, `platform/`, `examples/**/generated/`, `harness/`, `tools/` | **none** | No production caller exists. Blast radius of a signature change would have been zero *in-tree*, but the functions are public API in a shipped header, so out-of-tree integrations are the real constraint. |
| `tests/unit_runnable/test_isotp.c` | 14 × `isotp_get_state`, 2 × `isotp_reset` | All still compile and pass untouched — behaviour of both is unchanged. |
| `tests/unit_runnable/test_isotp_concurrent.c` | none | Covers RX-vs-RX concurrency (a new request interrupting a reassembly), not bidirectional RX/TX — so it is not the right home for these tests. |
| `docs/INTEGRATION_GUIDE.md` §4.3 | 1 | **Pre-existing defect, fixed here — see below.** |

Two things followed from this:

1. **`isotp_get_state()` keeps its exact aliasing.** With no in-tree caller depending on it, changing its signature was tempting, but it is public API in a shipped header and #132 explicitly asks for source compatibility. Its behaviour is byte-identical; what changed is that the aliasing is now a documented `@warning` on the declaration rather than something a caller has to reverse-engineer, and the `@return` docs on `isotp_process_rx_frame()` now say outright that `ERR_TP_TX_FAILED` is not observable through `isotp_get_state()` during a transmit.

2. **The doc snippet in §4.3 never compiled.** The FreeRTOS ECU-reset TX-confirmation contract — the sequence the guide tells integrators to use before `eds_platform_ecu_reset()` — reads:

   ```c
   isotp_state_t rx_st, tx_st;
   ...
   isotp_get_state(tp, &rx_st, &tx_st);   /* three arguments */
   } while ((tx_st != ISOTP_STATE_IDLE) && ...);
   ```

   `isotp_get_state()` has never taken three arguments in any released header. The documentation was already written against the per-direction API this issue asks for — it wanted to poll the TX direction alone, which was inexpressible. Fixed to `isotp_get_tx_state(tp, &tx_st)`, which is what it always meant. Filed separately as #134 for the record; it is repaired here because it is a caller of the exact API this PR changes, and this PR is what makes it expressible.

## The fix

**Accessors** — `isotp_get_rx_state()` / `isotp_get_tx_state()`. Simple `const`-qualified readers, same NULL / not-initialised guards as `isotp_get_state()`, no state mutation.

**Recovery** — chose **two named functions** (`isotp_reset_rx()` / `isotp_reset_tx()`) over one `isotp_reset()` taking a direction enum:

- A direction argument would need a new public enum plus a runtime validation branch for out-of-range values — more public surface and an extra error path, for no gain.
- Two named functions let `isotp_reset()` be **composed** from the same two internal clears (`isotp_clear_rx()` / `isotp_clear_tx()`) that the narrow entry points use. The full reset is then the union of the narrow ones *by construction*, so it can never silently stop clearing a field when a context member is added. That property is pinned by a test (DIR-006) that resets a fully-dirty context both ways and `memcmp`s the results.
- `isotp_reset()` is retained unchanged as the both-direction entry point; nothing that calls it breaks.

## Reset safety — why a fully independent per-direction reset is sound

The PR asked whether resetting only one direction can leave the context invalid for anything else that touches it, e.g. a shared buffer or the CAN transmit path. It cannot. A field-ownership audit is recorded as a comment above `isotp_reset()`:

- **RX-owned**, written only by the SF/FF/CF handlers, `isotp_send_fc()`'s N_Ar arming, and the Cr/Ar branches of `isotp_tick_1ms()`: `rx_state`, `rx_buf`, `rx_expected_len`, `rx_received_len`, `rx_expected_sn`, `rx_blocks_received`, `rx_cr_timer_ms`, `rx_ar_timer_ms`.
- **TX-owned**, written only by `isotp_transmit()`, the FC handler, the As/Bs/STmin branches of `isotp_tick_1ms()`, and `isotp_tx_pump()`: `tx_state`, `tx_data`, `tx_total_len`, `tx_sent_len`, `tx_sn`, `tx_block_size`, `tx_stmin_ms`, `tx_blocks_sent`, `tx_stmin_timer_ms`, `tx_bs_timer_ms`, `tx_as_timer_ms`.
- **Shared but read-only** after `isotp_init()`, so neither reset touches them: `initialized`, `rx_can_id`, `tx_can_id`, `local_block_size`, `local_stmin_ms`, `use_fd`, `can`.

The two lists are disjoint and their union is exactly what `isotp_reset()` has always cleared. Neither direction *reads* a field the other writes — the RX handlers never inspect `tx_state`, and `isotp_tx_pump()` never inspects `rx_state`. There is no shared buffer: `rx_buf` is RX-only and `tx_data` is a borrowed caller pointer, TX-only. The only object both touch is the bound `can_transport_t`, used through `can_transport_transmit()` without holding any cross-call state, so neither reset can disturb an in-flight frame on the other side.

The specific hazard the PR flagged — does `rx_state == IDLE` become a false "safe to start a new FF" signal that corrupts something TX depends on — was checked path by path and does not occur:

- The **FF handler never consults `rx_state` at all** (an FF always restarts a reassembly, by design), so a partial RX reset changes nothing about how it behaves.
- The **CF handler requires `RX_WAIT_CF`**, so a stray CF from the abandoned transfer is rejected with `ERR_TP_UNEXPECTED_PDU` rather than being absorbed into a fresh buffer.
- The **FC handler is the only RX-path branch that writes TX fields**, and it is gated on `tx_state`, which `isotp_clear_rx()` does not touch.

Symmetrically, clearing `tx_state` to IDLE only makes a late FC be ignored via the FC handler's existing "outside expected window" branch — already the behaviour after a full `isotp_reset()`. Both directional resets are local teardowns that do not signal the peer; that is documented on each, and is unchanged from `isotp_reset()`'s long-standing semantics.

Field **assignment order** inside the two clears is preserved exactly as the original open-coded `isotp_reset()` had it, deliberately, so the refactor introduces no new behaviour of any kind under any interleaving.

## Regression tests

Seven cases added to `tests/unit_runnable/test_isotp.c` (suite `test_isotp_directional`), where the existing `isotp_get_state` / `isotp_reset` tests live. No new test module, so the module count stays at 44. Every case builds a **genuine** concurrent scenario — a real multi-frame TX (`isotp_transmit()` of a 20-byte PDU, FF actually emitted) parked in `TX_WAIT_FC` or `TX_SEND_CF`, with the RX side driven to `ISOTP_STATE_ERROR` through #122's rejected-Flow-Control path — never a hand-poked context.

- **DIR-001** RX error during `TX_WAIT_FC`: `isotp_get_rx_state()` reports `ERROR` while `isotp_get_state()` still reports `TX_WAIT_FC`, proving the blind spot existed and is now visible without changing old-accessor behaviour.
- **DIR-002** the same during `TX_SEND_CF`.
- **DIR-003** `isotp_reset_rx()` recovers RX to IDLE, TX stays in `TX_SEND_CF` — and is then *pumped to completion*, with both consecutive frames verified for PCI type, sequence number and payload bytes. The TX is proven functional, not merely field-intact.
- **DIR-004** mirror: `isotp_reset_tx()` recovers TX, and the interrupted reassembly is then *completed*, with the full 20-byte PDU verified byte-exact through the RX callback.
- **DIR-005** the partial-reset safety case: after an RX-only reset mid-TX, a stray CF is rejected as an unexpected PDU, a fresh FF starts a clean reassembly, and the TX still runs to completion alongside it.
- **DIR-006** `isotp_reset()` ≡ `isotp_reset_rx()` + `isotp_reset_tx()`, by `memcmp` of a fully-dirty context reset both ways.
- **DIR-007** NULL and not-initialised guards on all four new entry points.

### Before/after proof

Per the no-`git stash` rule, `transport/isotp.{c,h}` were copied aside to `/tmp` and restored.

**(a) Against pristine `origin/main` sources** — the API does not exist:

```
  test_isotp                                     BUILD_FAIL
  === Unit Test Summary: 43 passed, 1 failed ===

test_isotp.c:1494: error: implicit declaration of function 'isotp_get_tx_state';
                          did you mean 'isotp_get_state'?
test_isotp.c:1515: error: implicit declaration of function 'isotp_get_rx_state';
                          did you mean 'isotp_get_state'?
```

**(b) The meaningful proof** — new API surface kept so the tests compile, but the bodies reverted to pre-fix semantics (both accessors collapsing the directions as `isotp_get_state()` did; both narrow resets clearing everything, the only recovery that existed):

```
[FAIL] test_isotp_directional__test_rx_error_hidden_behind_tx_wait_fc
       test_isotp.c:1516: {2, 4} = {TX_WAIT_FC, ERROR}   RX error invisible
[FAIL] test_isotp_directional__test_rx_error_hidden_behind_tx_send_cf
       test_isotp.c:1563: {3, 4} = {TX_SEND_CF, ERROR}   RX error invisible
[FAIL] test_isotp_directional__test_reset_rx_preserves_inflight_tx
       test_isotp.c:1604: {0, 3} = {IDLE, TX_SEND_CF}    reset destroyed the TX
[FAIL] test_isotp_directional__test_reset_tx_preserves_inflight_rx
       test_isotp.c:1669: {4, 1} = {ERROR, RX_WAIT_CF}   RX state unobservable
[FAIL] test_isotp_directional__test_reset_rx_leaves_context_valid_for_new_rx
[PASS] test_isotp_directional__test_full_reset_equals_both_directional_resets
[PASS] test_isotp_directional__test_new_api_null_and_init_guards

Tests run: 56   passed: 51   failed: 5
```

Each failing assertion is precisely the one encoding the defect. The two that pass are the invariant and NULL-guard cases, which hold either way — stated plainly rather than dressed up.

**After the fix**, same module:

```
Tests run: 56   Tests passed: 56   Tests failed: 0
```

## Gate results

| Gate | Result |
|---|---|
| `bash build_tests.sh` | **44 passed, 0 failed** (isotp module 56/56 cases, up from 49) |
| `bash build_harness.sh --run` | **68 / 68 PASS** |
| `python3 misra_analysis.py` | 41 files, 1 finding, **0 OPEN**, 1 justified → **PASS** |
| No-malloc gate (CI mirror) | **no output** |
| `python3 scripts/verify_doc_counts.py` | **PASS** (44, no dead script paths) |

MISRA ran **GCC-only** — cppcheck is not installed on this machine, so the `--strict` + cppcheck combination that CI runs was not exercised locally.

## Self-review (heightened review — `transport/isotp.c`)

Per CONTRIBUTING.md's safety-relevant list. Explicit pass over the diff:

- **No behavioural change to any existing entry point.** `isotp_get_state()` and `isotp_reset()` produce identical results; the `isotp_reset()` refactor moves lines between functions without adding, dropping or reordering a single field assignment, and DIR-006 pins that by construction.
- **New functions are side-effect-free apart from their intended clears**; the accessors take `const isotp_ctx_t *` and cannot mutate.
- **Guard symmetry**: all four new entry points use the same NULL and `!initialized` guards as their existing counterparts. The internal clears are guard-free by design, documented as such, and unreachable from outside the file.
- **MISRA / house style**: explicit `U` suffixes and casts carried over verbatim; early-return guards match the surrounding functions; no `(void)`-discarded returns introduced. No malloc, VLA or recursion — `isotp_reset()` calling the two clears is not recursive.
- **Structure**: the two new statics are forward-declared in the existing prototype block and defined in the `Internal helper implementations` section, matching where every other static in this file lives.
- **Ordering under concurrent ticks**: `isotp_clear_tx()` assigns `tx_state = IDLE` before `tx_data = NULL`, so a tick landing mid-clear sees a state that disables `isotp_tx_pump()` rather than a live `TX_SEND_CF` with a NULL data pointer. The reverse order would be unsafe. This is inherited from the original ordering, not newly chosen, but it was checked rather than assumed.

## New finding logged

While auditing the tick path for the reset-safety argument I found an unrelated latent defect and did **not** fix it here, per repo convention: the **N_Ar branch in `isotp_tick_1ms()` has no `rx_state` guard**, unlike the N_As branch directly below it, which #111 deliberately guarded to keep "a stale timer from corrupting `tx_state` once TX is complete (IDLE) or already in ERROR". The N_Ar branch can therefore drive `rx_state` to `ERROR` from any state including IDLE, and has no disarm-on-idle counterpart. Latent under the single-diagnostics-task model (`isotp_send_fc()` arms and disarms N_Ar around the transmit call), but the file's own comments explicitly contemplate an integration ticking from an independent timer context. Filed as #135 and recorded as O-39 in the internal review ledger.

Reviewed-by: Xaloqi <contact@xaloqi.com>
