### PR TITLE
fix: guard N_Ar branch on rx_state == RX_WAIT_CF (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,21 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **ISO-TP: the N_Ar timer in `isotp_tick_1ms()` could drive `rx_state` to
+  `ISOTP_STATE_ERROR` from any state, including `IDLE`.** (#135) The N_Ar
+  branch added by #122 decremented `rx_ar_timer_ms` and fired unconditionally,
+  unlike its TX-side mirror, N_As, which #111 deliberately guarded on
+  `tx_state`. Latent under the single-diagnostics-task model — `isotp_send_fc()`
+  arms and disarms `rx_ar_timer_ms` around one `can_transport_transmit()` call,
+  so it is never still armed when a tick lands — but `can_transport_transmit()`
+  is permitted to block, and in an integration that drives `isotp_tick_1ms()`
+  from an independent timer context, a tick landing inside that window could
+  expire N_Ar and set `rx_state = ISOTP_STATE_ERROR` concurrently with a
+  caller's `isotp_reset()` / `isotp_reset_rx()` (#132), silently undoing the
+  recovery. Guarded the branch on `rx_state == ISOTP_STATE_RX_WAIT_CF` — the
+  only state in which an FC confirmation can be outstanding — and added the
+  symmetric disarm-on-`IDLE` branch, mirroring #111's N_As treatment exactly.
+
 - **ISO-TP: `isotp_get_state()` hid an RX error behind any concurrent transmit,
   and `isotp_reset()` could not recover one direction alone.** (#132)
   `isotp_ctx_t` runs two independent state machines, `rx_state` and `tx_state`,

--- a/tests/unit_runnable/test_isotp.c
+++ b/tests/unit_runnable/test_isotp.c
@@ -1348,6 +1348,98 @@ ZTEST(test_isotp_tick, test_tick_idle)
     }
 }
 
+/**
+ * TC-ISTP-TICK-004 [#135]: a stale rx_ar_timer_ms while rx_state is IDLE must
+ * not corrupt rx_state to ERROR.
+ *
+ * isotp_send_fc() always disarms rx_ar_timer_ms on return, so this timer
+ * should never legitimately be nonzero once rx_state is back to IDLE. But
+ * that is exactly the "should never happen" case the N_As guard (#111) was
+ * written to survive rather than assume away -- a caller that has just
+ * reset the RX channel (e.g. isotp_reset_rx() / isotp_reset(), #132) must
+ * not have that recovery silently undone by a stray decrement landing on
+ * the very next tick. This is the issue's own suggested regression test,
+ * reproduced here for N_Ar's TX-side mirror is guarded the same way.
+ */
+ZTEST(test_isotp_tick, test_stale_ar_timer_in_idle_does_not_corrupt_state)
+{
+    mock_can_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp(&ctx), UDS_STATUS_OK, "init failed");
+
+    isotp_state_t state;
+    isotp_get_state(&ctx, &state);
+    zassert_equal(state, ISOTP_STATE_IDLE, "Must start IDLE");
+
+    /* Simulate a stale N_Ar left armed by, e.g., a caller resetting the RX
+     * channel out from under an outstanding FC confirmation in a
+     * multi-context integration. */
+    ctx.rx_ar_timer_ms = 1U;
+
+    uds_status_t rc = isotp_tick_1ms(&ctx);
+    zassert_equal(rc, UDS_STATUS_OK,
+                  "A stale N_Ar must not fire while rx_state is IDLE");
+
+    isotp_get_state(&ctx, &state);
+    zassert_equal(state, ISOTP_STATE_IDLE,
+                  "rx_state must remain IDLE -- N_Ar must not corrupt it");
+}
+
+/**
+ * TC-ISTP-TICK-005 [#135]: a stale rx_ar_timer_ms while rx_state is already
+ * ERROR must not return a spurious N_Ar timeout status.
+ *
+ * Unlike the IDLE case, overwriting rx_state with ERROR here is a no-op --
+ * but the tick's return value is not. Without the state guard, this path
+ * would return UDS_STATUS_ERR_TP_TIMEOUT_AR for a timer that has nothing to
+ * do with why the channel is actually in ERROR, misreporting the cause to
+ * the caller. Covers "any state other than RX_WAIT_CF", not just IDLE.
+ */
+ZTEST(test_isotp_tick, test_stale_ar_timer_in_error_does_not_report_ar_timeout)
+{
+    mock_can_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp(&ctx), UDS_STATUS_OK, "init failed");
+
+    ctx.rx_state        = ISOTP_STATE_ERROR;
+    ctx.rx_ar_timer_ms  = 1U;
+
+    uds_status_t rc = isotp_tick_1ms(&ctx);
+    zassert_equal(rc, UDS_STATUS_OK,
+                  "A stale N_Ar must not report ERR_TP_TIMEOUT_AR outside RX_WAIT_CF");
+
+    isotp_state_t state;
+    isotp_get_state(&ctx, &state);
+    zassert_equal(state, ISOTP_STATE_ERROR, "rx_state must remain ERROR, unchanged");
+}
+
+/**
+ * TC-ISTP-TICK-006 [#135]: disarm-on-idle safety net -- if rx_state is IDLE
+ * while rx_ar_timer_ms is still nonzero, a tick must zero it so it cannot
+ * fire late on some future re-arm sequence.
+ *
+ * Mirrors the symmetric tx_as_timer_ms disarm-on-idle branch (#111) exactly;
+ * this state (IDLE with a nonzero rx_ar_timer_ms) should not be reachable in
+ * practice given how isotp_send_fc() arms and disarms the timer today, but
+ * the guard exists as a safety net regardless and is tested the same way.
+ */
+ZTEST(test_isotp_tick, test_ar_timer_disarmed_when_idle)
+{
+    mock_can_reset();
+    isotp_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    zassert_equal(init_isotp(&ctx), UDS_STATUS_OK, "init failed");
+
+    ctx.rx_ar_timer_ms = (uint32_t)ISOTP_TIMEOUT_AR_MS;
+
+    zassert_equal(isotp_tick_1ms(&ctx), UDS_STATUS_OK,
+                  "Disarm-on-idle tick must return OK");
+    zassert_equal(ctx.rx_ar_timer_ms, 0U,
+                  "rx_ar_timer_ms must be disarmed while rx_state is IDLE");
+}
+
 /* =========================================================================
  * Test suite: isotp_reset
  * ========================================================================= */
@@ -2094,6 +2186,9 @@ extern void test_isotp_transmit__test_tx_busy(void);
 extern void test_isotp_tick__test_null_ctx(void);
 extern void test_isotp_tick__test_cr_timeout(void);
 extern void test_isotp_tick__test_tick_idle(void);
+extern void test_isotp_tick__test_stale_ar_timer_in_idle_does_not_corrupt_state(void);
+extern void test_isotp_tick__test_stale_ar_timer_in_error_does_not_report_ar_timeout(void);
+extern void test_isotp_tick__test_ar_timer_disarmed_when_idle(void);
 extern void test_isotp_reset__test_null_ctx(void);
 extern void test_isotp_reset__test_reset_from_error(void);
 extern void test_isotp_get_state__test_null_ctx(void);
@@ -2159,6 +2254,9 @@ void run_all_tests(void)
     RUN_TEST(test_isotp_tick__test_null_ctx);
     RUN_TEST(test_isotp_tick__test_cr_timeout);
     RUN_TEST(test_isotp_tick__test_tick_idle);
+    RUN_TEST(test_isotp_tick__test_stale_ar_timer_in_idle_does_not_corrupt_state);
+    RUN_TEST(test_isotp_tick__test_stale_ar_timer_in_error_does_not_report_ar_timeout);
+    RUN_TEST(test_isotp_tick__test_ar_timer_disarmed_when_idle);
     RUN_TEST(test_isotp_reset__test_null_ctx);
     RUN_TEST(test_isotp_reset__test_reset_from_error);
     RUN_TEST(test_isotp_get_state__test_null_ctx);

--- a/transport/isotp.c
+++ b/transport/isotp.c
@@ -737,23 +737,39 @@ uds_status_t isotp_tick_1ms(isotp_ctx_t *ctx)
 
     /* --- RX Ar timer (FC transmission confirmation) ---
      *
-     * [#122] N_Ar mirrors N_As on the receiver side. isotp_send_fc() arms it
-     * immediately before can_transport_transmit() and stops it on that call's
-     * return, so under the single diagnostics-task model used by every
-     * reference integration it is never still armed when a tick lands and this
-     * branch cannot fire. It is the enforcement point should an FC confirmation
-     * ever be left outstanding across a tick boundary — can_transport_transmit()
-     * is permitted to block (the Zephyr port blocks in can_send() for up to
-     * K_MSEC(25)), so an integration that drives isotp_tick_1ms() from an
-     * independent timer context can observe the window and must not be left
-     * without a bound on it.
+     * [#122][#135] N_Ar mirrors N_As on the receiver side. isotp_send_fc()
+     * arms it immediately before can_transport_transmit() and stops it on
+     * that call's return, so under the single diagnostics-task model used by
+     * every reference integration it is never still armed when a tick lands
+     * and this branch cannot fire. It is the enforcement point should an FC
+     * confirmation ever be left outstanding across a tick boundary —
+     * can_transport_transmit() is permitted to block (the Zephyr port blocks
+     * in can_send() for up to K_MSEC(25)), so an integration that drives
+     * isotp_tick_1ms() from an independent timer context can observe the
+     * window and must not be left without a bound on it.
+     *
+     * [#135] Guarded exactly like N_As below: rx_state == RX_WAIT_CF is the
+     * only state in which an FC confirmation can be outstanding (rx_state is
+     * only ever IDLE, RX_WAIT_CF or ERROR). Two of isotp_send_fc()'s three
+     * call sites — the FF handler's CTS path and the CF handler's
+     * block-boundary FC — run with rx_state already RX_WAIT_CF. The third,
+     * the FF handler's overflow-reject FC, arms the timer before rx_state is
+     * touched for the new frame, so it can be entered with rx_state IDLE —
+     * the exact same trade-off isotp_transmit()'s own FF frame accepts on the
+     * As side below (also armed before tx_state leaves IDLE). The state
+     * guard keeps a stale timer from corrupting rx_state once RX is complete
+     * (IDLE) or already in ERROR.
      */
-    if (ctx->rx_ar_timer_ms > 0U) {
+    if ((ctx->rx_ar_timer_ms > 0U) &&
+        (ctx->rx_state == ISOTP_STATE_RX_WAIT_CF)) {
         ctx->rx_ar_timer_ms--;
         if (ctx->rx_ar_timer_ms == 0U) {
             ctx->rx_state = ISOTP_STATE_ERROR;
             return UDS_STATUS_ERR_TP_TIMEOUT_AR;
         }
+    } else if (ctx->rx_state == ISOTP_STATE_IDLE) {
+        /* RX finished — disarm the Ar timer so it doesn't fire late. */
+        ctx->rx_ar_timer_ms = 0U;
     }
 
     /* --- TX As timer (single-frame transmission confirmation) ---


### PR DESCRIPTION
Closes #135

## Root cause

The N_Ar branch in `isotp_tick_1ms()`, added by #122 (PR #131), decremented and fired unconditionally:

```c
if (ctx->rx_ar_timer_ms > 0U) {
    ctx->rx_ar_timer_ms--;
    if (ctx->rx_ar_timer_ms == 0U) {
        ctx->rx_state = ISOTP_STATE_ERROR;
        return UDS_STATUS_ERR_TP_TIMEOUT_AR;
    }
}
```

Its TX-side mirror, N_As — added by #111, immediately below it in the same function — *is* guarded, deliberately, with a comment explaining why a stale timer must not corrupt state once the direction is idle or already errored. N_Ar had neither the guard nor the disarm-on-idle counterpart, so a stale `rx_ar_timer_ms` could drive `rx_state` to `ISOTP_STATE_ERROR` from **any** state — including `IDLE`, including a state a caller had just deliberately reset via `isotp_reset_rx()` (#132, PR #136).

**Reachability:** latent under the single-diagnostics-task model — `isotp_send_fc()` arms and disarms `rx_ar_timer_ms` around one `can_transport_transmit()` call, so the timer is never still armed when a tick lands. But `can_transport_transmit()` is permitted to block (the Zephyr port blocks in `can_send()` for up to `K_MSEC(25)`), and in an integration that drives `isotp_tick_1ms()` from an independent timer context, a tick landing inside that window could expire N_Ar and set `rx_state = ISOTP_STATE_ERROR` concurrently with a caller's `isotp_reset()` / `isotp_reset_rx()` — silently undoing the recovery the caller just performed.

## The fix

Guard the branch on `rx_state == ISOTP_STATE_RX_WAIT_CF` — the only state in which an FC confirmation can be outstanding (`rx_state` is only ever `IDLE`, `RX_WAIT_CF`, or `ERROR`) — and add the symmetric disarm-on-`IDLE` else-branch, mirroring #111's N_As treatment exactly.

**Verified the guard is correct against all three `isotp_send_fc()` call sites**, not just asserted:

| Call site | `rx_state` when armed |
|---|---|
| FF handler's CTS path | Already `RX_WAIT_CF` (set immediately before the call) — guard protects it |
| CF handler's block-boundary FC | Already `RX_WAIT_CF` (CF processing requires it) — guard protects it |
| FF handler's OVERFLOW-reject FC | Still `IDLE` (armed before `rx_state` is touched for the new frame) — **not** covered by the guard |

That third case is a real, acknowledged gap — but it is **exactly the same trade-off the existing, shipped N_As guard already has** on its own FF-send path: `isotp_transmit()` arms `tx_as_timer_ms`, calls `can_transport_transmit()`, and disarms it, all *before* `tx_state` leaves `IDLE` and becomes `TX_WAIT_FC`. I read that code directly to confirm this isn't hand-waved — the pattern is identical and already in production. This PR is consistent with precedent, not introducing a new class of gap.

## Regression tests

Three new cases in the existing `test_isotp_tick` suite:
- `test_stale_ar_timer_in_idle_does_not_corrupt_state` — the issue's own suggested test.
- `test_stale_ar_timer_in_error_does_not_report_ar_timeout` — a stale timer already in `ERROR` must not report a spurious `ERR_TP_TIMEOUT_AR`.
- `test_ar_timer_disarmed_when_idle` — the disarm-on-idle safety net actually disarms.

All three fail against unmodified `isotp.c` and pass after the fix.

## Gates

| Gate | Result |
|---|---|
| `bash build_tests.sh` | **44 passed, 0 failed** |
| `bash build_harness.sh --run` | **68 / 68 PASS** |
| `python3 misra_analysis.py` | 41 files, 1 finding, **0 OPEN**, 1 justified — PASS (GCC-only; cppcheck not installed locally, CI runs `--strict` + cppcheck) |
| No-malloc CI mirror grep | clean |
| `python3 scripts/verify_doc_counts.py` | PASS |

`transport/isotp.c` is on CONTRIBUTING.md's heightened-review list.

Reviewed-by: Xaloqi <contact@xaloqi.com>