### PR TITLE
chore(release): v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+## [1.12.0] — 2026-08-30
+
 ### Changed
 
 - **The `unit-tests` CI job no longer carries the module count in its display

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 > repo. Community users cloning the public repo can ignore this file.
 
 **Product:** Xaloqi EDS (Xaloqi Embedded Diagnostic Suite)  
-**Version:** v1.11.0  
+**Version:** v1.12.0  
 **Support:** contact@xaloqi.com
 
 ---
@@ -50,7 +50,7 @@ cd EDS
 Verify you are on the correct version:
 
 ```bash
-git checkout v1.11.0
+git checkout v1.12.0
 ```
 
 ---
@@ -59,10 +59,10 @@ git checkout v1.11.0
 
 ```bash
 # From the EDS repo root:
-unzip -o /path/to/xaloqi-eds-developer-v1.11.0.zip
+unzip -o /path/to/xaloqi-eds-developer-v1.12.0.zip
 
 # Or for Professional:
-unzip -o /path/to/xaloqi-eds-professional-v1.11.0.zip
+unzip -o /path/to/xaloqi-eds-professional-v1.12.0.zip
 ```
 
 The `-o` flag overwrites existing files without prompting — required when updating an existing installation.
@@ -75,7 +75,7 @@ The `-o` flag overwrites existing files without prompting — required when upda
 >
 > ```bash
 > rm -f tools/templates tools/testgen.py tools/_license.py harness
-> unzip -o /path/to/xaloqi-eds-developer-v1.11.0.zip
+> unzip -o /path/to/xaloqi-eds-developer-v1.12.0.zip
 > ```
 
 This extracts the toolchain files directly into the repo tree. No separate directory. After extraction you will have:
@@ -185,7 +185,7 @@ Expected output:
 
 ```
 ========================================================================
-  Xaloqi EDS — Code Generator v1.11.0
+  Xaloqi EDS — Code Generator v1.12.0
 ========================================================================
   Config   : examples/bms_ecu/diagnostics_config.yaml
   ...

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Xaloqi Embedded Diagnostics Suite
 
 [![CI](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml/badge.svg)](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-v1.11.0-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.11.0)
+[![Version](https://img.shields.io/badge/version-v1.12.0-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.12.0)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](LICENSE)
 [![Zephyr](https://img.shields.io/badge/Zephyr-v3.7%2B-brightgreen)](https://zephyrproject.org)
 
@@ -157,7 +157,7 @@ manifest:
   projects:
     - name: EDS
       remote: xaloqi
-      revision: v1.10.1
+      revision: v1.12.0
       path: modules/eds
 ```
 
@@ -181,7 +181,7 @@ The `ZEPHYR_EDS_MODULE_DIR` variable is set automatically by west when the modul
 
 ```bash
 pip install west
-west init -m https://github.com/Xaloqi/EDS --mr v1.10.1 eds-workspace
+west init -m https://github.com/Xaloqi/EDS --mr v1.12.0 eds-workspace
 cd eds-workspace && west update
 pip install -r tools/requirements.txt
 ```
@@ -233,7 +233,7 @@ For the full FreeRTOS integration guide (callbacks, NVM, reset, production porti
 ### Run the test suite
 
 ```bash
-# 43 Unity unit tests (host-native, no Zephyr SDK needed)
+# 44 Unity unit tests (host-native, no Zephyr SDK needed)
 bash build_tests.sh
 
 # 68 harness integration tests (Professional tier — requires harness/ sources)
@@ -308,7 +308,7 @@ Step 5  Data length correct?     → NRC 0x13 incorrectMessageLengthOrInvalidFor
 | `ide/vscode-extension/` | YAML validation, hover docs, Run Codegen command *(Developer/Professional tier)* |
 | `examples/` | basic\_ecu · basic\_ecu\_doip · basic\_ecu\_freertos · basic\_ecu\_doip\_freertos · sensor\_ecu · sensor\_ecu\_freertos · safeboot\_ecu · safeboot\_freertos\_ecu · robot\_joint\_controller\_ecu · bms\_ecu · motor\_controller\_ecu · ardep\_ecu · each with its own `generated/` subfolder |
 | `gui/` | React/TypeScript configurator + live dashboard *(Developer/Professional tier)* |
-| `tests/` | 43 Unity unit tests, harness, Python integration tests |
+| `tests/` | 44 Unity unit tests, harness, Python integration tests |
 
 ---
 

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -13,7 +13,7 @@ ISO 15765-2 (ISO-TP) diagnostics stack for embedded RTOS targets. It is YAML-dri
 describe your DIDs, DTCs, and routines in YAML, run the code generator, and receive
 ASIL-B safety-wrapped C code ready to compile into your ECU firmware.
 
-**Version:** v1.10.1
+**Version:** v1.12.0
 **Target RTOS:** Zephyr v3.7+ · FreeRTOS (any version with static allocation support)
 **Target boards:** native_sim (CI/dev) · STM32 Nucleo-H743ZI2 (Cortex-M7) · NXP FRDM-MCX-N947 (MCX N947, Cortex-M33) · NXP MR-CANHUBK3 (S32K344, Cortex-M7) · QEMU ARM Cortex-M4 (FreeRTOS CI)
 **Transport:** ISO-TP over CAN (default) · DoIP over Ethernet/TCP (v1.6.0+)
@@ -1008,5 +1008,5 @@ tooling and lives in EDS-toolchain — it is not part of this repo's public CI.)
 
 ---
 
-*EDS v1.10.1 — Developer €690/yr · Professional €1,990/yr — xaloqi.com*
+*EDS v1.12.0 — Developer €690/yr · Professional €1,990/yr — xaloqi.com*
 *Runtime: GPL v2 · Examples: Apache 2.0 · Tools + IDE + GUI: Commercial*

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture — Xaloqi EDS
 
-**Version:** v1.10.1  
+**Version:** v1.12.0  
 **Status:** Production-ready. All CI jobs passing.
 
 ---
@@ -301,7 +301,7 @@ expect fixed-length frames. See [docs/ISOTP_PADDING.md](ISOTP_PADDING.md).
 
 Added in v1.6.0. Implements the ECU (entity) side of the DoIP diagnostics protocol over TCP.
 
-#### DoIP Feature Matrix (current as of v1.10.1, ISO 13400-2:2019)
+#### DoIP Feature Matrix (current as of v1.12.0, ISO 13400-2:2019)
 
 | Feature | Payload type | Status | Notes |
 |---|---|---|---|
@@ -315,10 +315,10 @@ Added in v1.6.0. Implements the ECU (entity) side of the DoIP diagnostics protoc
 | Diagnostic Message Positive Ack | 0x8002 | ✅ Implemented | Sent before UDS dispatch per ISO 13400-2 §9.5 |
 | Diagnostic Message Negative Ack | 0x8003 | ✅ Implemented | NACK codes: 0x03 (invalid src), 0x04 (unknown tgt), 0x05 (too large), 0x07 (not routed) |
 | Single active TCP connection | — | ✅ Implemented | Sequential accept; routing state reset on new connection |
-| UDP Vehicle Identification Request | 0x0001 | ❌ Not implemented | Out of scope as of v1.10.1 |
-| UDP Vehicle Identification w/ EID | 0x0002 | ❌ Not implemented | Out of scope as of v1.10.1 |
-| Vehicle Announcement | 0x0004 | ❌ Not implemented | Out of scope as of v1.10.1 |
-| Entity Status Request/Response | 0x4001/0x4002 | ❌ Not implemented | Out of scope as of v1.10.1 |
+| UDP Vehicle Identification Request | 0x0001 | ❌ Not implemented | Out of scope as of v1.12.0 |
+| UDP Vehicle Identification w/ EID | 0x0002 | ❌ Not implemented | Out of scope as of v1.12.0 |
+| Vehicle Announcement | 0x0004 | ❌ Not implemented | Out of scope as of v1.12.0 |
+| Entity Status Request/Response | 0x4001/0x4002 | ❌ Not implemented | Out of scope as of v1.12.0 |
 | Activation type 0x01 (OEM-specific) | 0x0005 | ❌ Not implemented | Only Default (0x00) supported |
 | Multiple simultaneous TCP clients | — | ❌ Not implemented | One client per server instance; clients queue sequentially |
 | TLS transport | — | ❌ Not implemented | Plain TCP only |

--- a/docs/COMMERCIAL_ONBOARDING.md
+++ b/docs/COMMERCIAL_ONBOARDING.md
@@ -15,7 +15,7 @@ After purchase you will have received a download link containing a ZIP file.
 ### Developer license ZIP contents
 
 ```
-xaloqi-eds-developer-v1.10.1.zip
+xaloqi-eds-developer-v1.12.0.zip
 ├── tools/
 │   ├── _license.py          ← License validation module (required for codegen)
 │   └── templates/           ← Jinja2 templates for all generated C/H files
@@ -37,7 +37,7 @@ xaloqi-eds-developer-v1.10.1.zip
 Everything in Developer, plus:
 
 ```
-xaloqi-eds-professional-v1.10.1.zip
+xaloqi-eds-professional-v1.12.0.zip
 ├── tools/
 │   ├── _license.py
 │   └── templates/           ← Same Jinja2 templates

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -61,7 +61,7 @@ west --version   # must print 1.2 or newer
 mkdir eds-workspace && cd eds-workspace
 
 # Initialise the workspace from the EDS repository
-west init -m https://github.com/Xaloqi/EDS --mr v1.10.1 .
+west init -m https://github.com/Xaloqi/EDS --mr v1.12.0 .
 
 # Pull Zephyr and all dependencies (this downloads ~500 MB, takes 2-4 min)
 west update

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -1,15 +1,15 @@
 # Integration Guide
 
-## Xaloqi EDS — Zephyr RTOS, FreeRTOS, DoIP, and SOVD (v1.10.1)
+## Xaloqi EDS — Zephyr RTOS, FreeRTOS, DoIP, and SOVD (v1.12.0)
 
 | Field | Value |
 |---|---|
-| Stack version | 1.9.0 |
+| Stack version | 1.12.0 |
 | Zephyr version | v3.7.0 (pinned in `west.yml`) |
 | FreeRTOS version | FreeRTOS-Kernel (any recent release; tested with HEAD) |
 | ISO standard | ISO 14229-1:2020 (UDS), ISO 15765-2:2016 (ISO-TP), ISO 13400-2 (DoIP) |
 | Safety target | ASIL-B candidate |
-| Last updated | 2026-06-26 |
+| Last updated | 2026-08-30 |
 
 ---
 
@@ -183,7 +183,7 @@ manifest:
 
     - name: embedded-diagnostics-suite
       url: https://github.com/your-org/embedded-diagnostics-suite
-      revision: v1.10.1            # pin to a release tag
+      revision: v1.12.0            # pin to a release tag
       path: eds
 ```
 
@@ -1212,7 +1212,7 @@ The flag is opt-in — omitting it leaves all existing behaviour unchanged.
 ```json
 {
   "sovdVersion": "1.0.0",
-  "generatedBy": "Xaloqi EDS codegen v1.10.1",
+  "generatedBy": "Xaloqi EDS codegen v1.12.0",
   "generatedAt": "2026-05-20T10:00:00Z",
   "ecuIdentification": {
     "name": "BasicECU",

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -1,6 +1,6 @@
 # Testing Strategy — Xaloqi EDS
 
-**Version:** v1.10.1  
+**Version:** v1.12.0  
 **Status:** 44/44 unit test modules passing. 68/68 harness tests passing. 21/21 CI jobs green. FreeRTOS, SafeBoot (Zephyr + FreeRTOS), DoIP, and sensor examples all covered.
 
 ---
@@ -10,7 +10,7 @@
 EDS uses a four-layer testing strategy: unit tests, harness tests, integration tests, and system
 tests. All four layers run automatically in CI on every push and pull request.
 
-**Current test counts (v1.10.1):**
+**Current test counts (v1.12.0):**
 
 | Layer | Count | Framework | Status |
 |---|---|---|---|

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -210,7 +210,7 @@ platform/
 tools/              codegen.py, testgen.py, mcp_server.py, 17 Jinja2 templates
 examples/           12 ECU examples — each with diagnostics_config.yaml + generated/
 gui/                React/TypeScript configurator and live dashboard
-tests/              43 Unity unit tests, Python integration tests, harness (68 tests)
+tests/              44 Unity unit tests, Python integration tests, harness (68 tests)
 ide/vscode-extension/  YAML validation, hover docs, Run Codegen command
 
 ## Requirements

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -100,7 +100,7 @@ except ImportError:
     print("ERROR: Jinja2 is required.  pip install jinja2", file=sys.stderr)
     sys.exit(2)
 
-__version__ = "1.11.0"
+__version__ = "1.12.0"
 
 # =============================================================================
 # Constants


### PR DESCRIPTION
## v1.12.0 — 12 fixes from external review, plus release-doc currency sweep

Ships everything merged since v1.11.0: #111–#114, #119, #121–#124, #127, #132, #135 (full detail in the CHANGELOG's new `[1.12.0]` section). One item is flagged **BREAKING** there — the UDS access-control table's fail-open→fail-closed default (#113) — already called out prominently in its own PR and merged; no new action needed here, just noting it's in this release.

### Version bumps
- `tools/codegen.py` `__version__` → 1.12.0 (CI-asserted to match the CHANGELOG's top entry)
- `INSTALL.md`, `README.md` version strings → v1.12.0
- CHANGELOG `[Unreleased]` rolled to `[1.12.0] — 2026-08-30`

### Docs sweep — `check_release_docs.py`, run for real
Ran `xaloqi-knowledge/scripts/check_release_docs.py` (the release-time drift sweep) against both repos. Beyond the routine version-string bump, it surfaced real staleness that predates this release cycle — several docs were never updated at v1.11.0's own release:

- **Stale unit-test count (43→44):** `README.md` (×2), `docs/llms.txt`
- **Stale version headers never touched since v1.10.1**, despite v1.11.0 shipping in between: `docs/TESTING_STRATEGY.md`, `docs/AI_CONTEXT.md` (header + footer), `docs/ARCHITECTURE.md` (header + DoIP feature-matrix currency markers ×4)
- **`docs/INTEGRATION_GUIDE.md` was the most drifted** — page header said v1.10.1, its own "Stack version" table row said **1.9.0** (three releases behind), "Last updated" was dated 2026-06-26. Fixed header, table row, both `west.yml revision:` examples, the `generatedBy` example string, and the date.
- `README.md` / `docs/GETTING_STARTED.md`: stale `west init --mr v1.10.1` example commands
- `docs/COMMERCIAL_ONBOARDING.md`: stale ZIP filenames (`...v1.10.1.zip`)

`CONTRIBUTING.md`'s one `v1.8.2 through v1.10.0` mention is a historical drift-incident description and was correctly left alone.

**Companion EDS-toolchain PR:** [#58](https://github.com/Xaloqi/EDS-toolchain/pull/58) — same sweep surfaced a stale `for Xaloqi EDS v1.10.1` claim and a stale count in that repo too, both missed at v1.11.0's own release. It also catches up that repo's `CHANGELOG.md`, which never got its `[Unreleased]` rolled at v1.11.0 either, and adds the CHANGELOG entry [#57](https://github.com/Xaloqi/EDS-toolchain/pull/57) (the #124 template fix) shipped without.

### Gates
| Gate | Result |
|---|---|
| `bash build_tests.sh` | **44 passed, 0 failed** |
| `bash build_harness.sh --run` | **68 / 68 PASS** |
| `python3 misra_analysis.py` | 41 files, 1 finding, **0 OPEN**, 1 justified — PASS (GCC-only locally; CI runs `--strict` + cppcheck) |
| No-malloc CI mirror grep | clean |
| `python3 scripts/verify_doc_counts.py` | PASS |
| `python3 xaloqi-knowledge/scripts/check_release_docs.py` | 0 hard failures once this tag exists (pre-tag, it correctly flags the bumped docs against the still-current v1.11.0 tag — expected) |

Docs + version files only — no runtime source under `core/`, `transport/`, `config/`, `platform/` touched.

### Next steps after merge (release runbook)
1. `git tag v1.12.0 && git push origin v1.12.0` — triggers the automated public GitHub Release.
2. `bash build_release.sh` in EDS-toolchain (needs `../EDS` and `../EDS-Safety` siblings) — builds + gates + publishes the `delivery-v1.12.0` backup Release.
3. Founder uploads the built ZIPs to Polar by hand.