### PR TITLE
fix: two protocol-test bugs hidden by CI's all-skipped Integration Tests (Critical, campaign finding #3 part 2/3)

### DIFF
--- a/examples/ardep_ecu/generated/tests/test_routine_ff00.py
+++ b/examples/ardep_ecu/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:12:17Z
+# Generated : 2026-08-31T12:02:05Z
 #
 # Routine   : 0xFF00  (ECU_SelfTest)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsEcuselftest:
         Expected: [0x71, 0x03, 0xFF, 0x00]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/ardep_ecu/generated/tests/test_routine_ff01.py
+++ b/examples/ardep_ecu/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:12:17Z
+# Generated : 2026-08-31T12:02:05Z
 #
 # Routine   : 0xFF01  (ResetCalibrationToDefaults)
 # Session   : extended (ordinal 3)

--- a/examples/ardep_ecu/generated/tests/test_routine_ff10.py
+++ b/examples/ardep_ecu/generated/tests/test_routine_ff10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:12:17Z
+# Generated : 2026-08-31T12:02:05Z
 #
 # Routine   : 0xFF10  (EraseApplicationFlash)
 # Session   : programming (ordinal 2)
@@ -187,6 +187,8 @@ class TestResultsEraseapplicationflash:
         Expected: [0x71, 0x03, 0xFF, 0x10]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/ardep_ecu/generated/tests/test_routine_ff11.py
+++ b/examples/ardep_ecu/generated/tests/test_routine_ff11.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:12:17Z
+# Generated : 2026-08-31T12:02:05Z
 #
 # Routine   : 0xFF11  (VerifyApplicationImage)
 # Session   : programming (ordinal 2)
@@ -187,6 +187,8 @@ class TestResultsVerifyapplicationimage:
         Expected: [0x71, 0x03, 0xFF, 0x11]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/ardep_ecu/generated/tests/test_routine_ff20.py
+++ b/examples/ardep_ecu/generated/tests/test_routine_ff20.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:12:17Z
+# Generated : 2026-08-31T12:02:05Z
 #
 # Routine   : 0xFF20  (ActivateOutputChannel)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsActivateoutputchannel:
         Expected: [0x71, 0x03, 0xFF, 0x20]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/ardep_ecu/generated/tests/test_routine_ff21.py
+++ b/examples/ardep_ecu/generated/tests/test_routine_ff21.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:12:17Z
+# Generated : 2026-08-31T12:02:05Z
 #
 # Routine   : 0xFF21  (MeasureSupplyVoltage)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsMeasuresupplyvoltage:
         Expected: [0x71, 0x03, 0xFF, 0x21]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/basic_ecu/generated/tests/test_phase1_protocol_edge_cases.py
+++ b/examples/basic_ecu/generated/tests/test_phase1_protocol_edge_cases.py
@@ -604,7 +604,14 @@ class TestClearDiagnosticInformation:
     def test_clear_dtc_returns_positive_response(
         self, uds_bus: IsoTpTransport
     ) -> None:
-        """[0x14, 0xFF, 0xFF, 0xFF] → [0x54]."""
+        """[0x14, 0xFF, 0xFF, 0xFF] → [0x54].
+
+        ClearDiagnosticInformation is a non-default-session-only service
+        (core/uds_access_table.c) — must enter a non-default session first,
+        or the ECU correctly rejects it with NRC 0x7F
+        (serviceNotSupportedInActiveSession), which this test was not
+        checking for."""
+        _session(uds_bus, SESSION_EXTENDED)
         pdu = uds_bus.request(bytes([0x14, 0xFF, 0xFF, 0xFF]))
         assert pdu is not None
         assert pdu[0] == 0x54, (
@@ -613,6 +620,7 @@ class TestClearDiagnosticInformation:
 
     def test_clear_dtc_idempotent(self, uds_bus: IsoTpTransport) -> None:
         """Calling ClearDTC twice must return [0x54] both times."""
+        _session(uds_bus, SESSION_EXTENDED)
         pdu1 = uds_bus.request(bytes([0x14, 0xFF, 0xFF, 0xFF]))
         pdu2 = uds_bus.request(bytes([0x14, 0xFF, 0xFF, 0xFF]))
         assert pdu1 is not None and pdu1[0] == 0x54
@@ -640,7 +648,12 @@ class TestClearDiagnosticInformation:
         This test mirrors TestDTCStatusMaskFiltering.test_sub02_mask_0xff but
         explicitly runs ClearDTC first to make the state explicit.
         """
-        uds_bus.request(bytes([0x14, 0xFF, 0xFF, 0xFF]))
+        _session(uds_bus, SESSION_EXTENDED)
+        clear_pdu = uds_bus.request(bytes([0x14, 0xFF, 0xFF, 0xFF]))
+        assert clear_pdu is not None and clear_pdu[0] == 0x54, (
+            f"ClearDTC must succeed for this test to prove anything about "
+            f"post-clear state, got {clear_pdu.hex(' ') if clear_pdu else None}"
+        )
         pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x02, 0xFF]))
         assert pdu is not None
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)

--- a/examples/basic_ecu/generated/tests/test_routine_ff00.py
+++ b/examples/basic_ecu/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T13:12:55Z
+# Generated : 2026-08-31T12:02:05Z
 #
 # Routine   : 0xFF00  (ECU_SelfTest)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsEcuselftest:
         Expected: [0x71, 0x03, 0xFF, 0x00]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/basic_ecu/generated/tests/test_routine_ff01.py
+++ b/examples/basic_ecu/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T13:12:55Z
+# Generated : 2026-08-31T12:02:05Z
 #
 # Routine   : 0xFF01  (ResetToFactoryDefaults)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu/generated/tests/test_routine_ff10.py
+++ b/examples/basic_ecu/generated/tests/test_routine_ff10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T13:12:55Z
+# Generated : 2026-08-31T12:02:05Z
 #
 # Routine   : 0xFF10  (EraseNVM)
 # Session   : programming (ordinal 2)
@@ -187,6 +187,8 @@ class TestResultsErasenvm:
         Expected: [0x71, 0x03, 0xFF, 0x10]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/basic_ecu_doip/generated/tests/test_routine_ff00.py
+++ b/examples/basic_ecu_doip/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-08-30T13:13:32Z
+# Generated : 2026-08-31T12:02:05Z
 #
 # Routine   : 0xFF00  (ECU_SelfTest)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsEcuselftest:
         Expected: [0x71, 0x03, 0xFF, 0x00]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/basic_ecu_doip/generated/tests/test_routine_ff01.py
+++ b/examples/basic_ecu_doip/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-08-30T13:13:32Z
+# Generated : 2026-08-31T12:02:05Z
 #
 # Routine   : 0xFF01  (ResetToFactoryDefaults)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu_doip/generated/tests/test_routine_ff10.py
+++ b/examples/basic_ecu_doip/generated/tests/test_routine_ff10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-08-30T13:13:32Z
+# Generated : 2026-08-31T12:02:05Z
 #
 # Routine   : 0xFF10  (EraseNVM)
 # Session   : programming (ordinal 2)
@@ -187,6 +187,8 @@ class TestResultsErasenvm:
         Expected: [0x71, 0x03, 0xFF, 0x10]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_routine_ff00.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-08-30T13:14:20Z
+# Generated : 2026-08-31T12:02:05Z
 #
 # Routine   : 0xFF00  (ECU_SelfTest)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsEcuselftest:
         Expected: [0x71, 0x03, 0xFF, 0x00]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_routine_ff01.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-08-30T13:14:20Z
+# Generated : 2026-08-31T12:02:05Z
 #
 # Routine   : 0xFF01  (ResetToFactoryDefaults)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_routine_ff10.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_routine_ff10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-08-30T13:14:20Z
+# Generated : 2026-08-31T12:02:05Z
 #
 # Routine   : 0xFF10  (EraseNVM)
 # Session   : programming (ordinal 2)
@@ -187,6 +187,8 @@ class TestResultsErasenvm:
         Expected: [0x71, 0x03, 0xFF, 0x10]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/basic_ecu_freertos/generated/tests/test_routine_ff00.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T13:15:18Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xFF00  (ECU_SelfTest)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsEcuselftest:
         Expected: [0x71, 0x03, 0xFF, 0x00]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/basic_ecu_freertos/generated/tests/test_routine_ff01.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T13:15:18Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xFF01  (ResetToFactoryDefaults)
 # Session   : extended (ordinal 3)

--- a/examples/basic_ecu_freertos/generated/tests/test_routine_ff10.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_routine_ff10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T13:15:18Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xFF10  (EraseNVM)
 # Session   : programming (ordinal 2)
@@ -187,6 +187,8 @@ class TestResultsErasenvm:
         Expected: [0x71, 0x03, 0xFF, 0x10]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/bms_ecu/generated/tests/test_routine_bb00.py
+++ b/examples/bms_ecu/generated/tests/test_routine_bb00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:22Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xBB00  (BMS_SelfTest)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsBmsselftest:
         Expected: [0x71, 0x03, 0xBB, 0x00]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/bms_ecu/generated/tests/test_routine_bb01.py
+++ b/examples/bms_ecu/generated/tests/test_routine_bb01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:22Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xBB01  (BMS_ForcePassiveBalance)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsBmsforcepassivebalance:
         Expected: [0x71, 0x03, 0xBB, 0x01]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/bms_ecu/generated/tests/test_routine_bb02.py
+++ b/examples/bms_ecu/generated/tests/test_routine_bb02.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:22Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xBB02  (BMS_ContactorFunctionalTest)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsBmscontactorfunctionaltest:
         Expected: [0x71, 0x03, 0xBB, 0x02]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/bms_ecu/generated/tests/test_routine_bb10.py
+++ b/examples/bms_ecu/generated/tests/test_routine_bb10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:22Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xBB10  (BMS_ResetSoCToFullCharge)
 # Session   : programming (ordinal 2)

--- a/examples/bms_ecu/generated/tests/test_routine_bb11.py
+++ b/examples/bms_ecu/generated/tests/test_routine_bb11.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:22Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xBB11  (BMS_ClearFaultHistory)
 # Session   : programming (ordinal 2)

--- a/examples/motor_controller_ecu/generated/tests/test_routine_cc00.py
+++ b/examples/motor_controller_ecu/generated/tests/test_routine_cc00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:27Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xCC00  (MC_SelfTest)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsMcselftest:
         Expected: [0x71, 0x03, 0xCC, 0x00]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/motor_controller_ecu/generated/tests/test_routine_cc01.py
+++ b/examples/motor_controller_ecu/generated/tests/test_routine_cc01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:27Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xCC01  (MC_PhaseBalanceTest)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsMcphasebalancetest:
         Expected: [0x71, 0x03, 0xCC, 0x01]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/motor_controller_ecu/generated/tests/test_routine_cc02.py
+++ b/examples/motor_controller_ecu/generated/tests/test_routine_cc02.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:27Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xCC02  (MC_GateDriverFunctionalTest)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsMcgatedriverfunctionaltest:
         Expected: [0x71, 0x03, 0xCC, 0x02]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/motor_controller_ecu/generated/tests/test_routine_cc10.py
+++ b/examples/motor_controller_ecu/generated/tests/test_routine_cc10.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:27Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xCC10  (MC_ResolverOffsetCalibration)
 # Session   : programming (ordinal 2)
@@ -187,6 +187,8 @@ class TestResultsMcresolveroffsetcalibration:
         Expected: [0x71, 0x03, 0xCC, 0x10]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/motor_controller_ecu/generated/tests/test_routine_cc11.py
+++ b/examples/motor_controller_ecu/generated/tests/test_routine_cc11.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:27Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xCC11  (MC_ForceMotorInhibit)
 # Session   : extended (ordinal 3)

--- a/examples/motor_controller_ecu/generated/tests/test_routine_cc12.py
+++ b/examples/motor_controller_ecu/generated/tests/test_routine_cc12.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:27Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xCC12  (MC_ClearFaultHistory)
 # Session   : programming (ordinal 2)

--- a/examples/robot_joint_controller_ecu/generated/tests/test_routine_ff00.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:31Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xFF00  (HomeAxis0)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsHomeaxis0:
         Expected: [0x71, 0x03, 0xFF, 0x00]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/robot_joint_controller_ecu/generated/tests/test_routine_ff01.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:31Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xFF01  (ApplyCalibration)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsApplycalibration:
         Expected: [0x71, 0x03, 0xFF, 0x01]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/robot_joint_controller_ecu/generated/tests/test_routine_ff02.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_routine_ff02.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:31Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xFF02  (ClearFaultHistory)
 # Session   : extended (ordinal 3)

--- a/examples/safeboot_ecu/generated/tests/test_routine_ff00.py
+++ b/examples/safeboot_ecu/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:59Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xFF00  (CheckProgrammingPreconditions)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsCheckprogrammingpreconditions:
         Expected: [0x71, 0x03, 0xFF, 0x00]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/safeboot_ecu/generated/tests/test_routine_ff01.py
+++ b/examples/safeboot_ecu/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:59Z
+# Generated : 2026-08-31T12:02:06Z
 #
 # Routine   : 0xFF01  (VerifyBootloaderIntegrity)
 # Session   : programming (ordinal 2)
@@ -187,6 +187,8 @@ class TestResultsVerifybootloaderintegrity:
         Expected: [0x71, 0x03, 0xFF, 0x01]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/sensor_ecu/generated/tests/test_routine_ff00.py
+++ b/examples/sensor_ecu/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:16:03Z
+# Generated : 2026-08-31T12:02:07Z
 #
 # Routine   : 0xFF00  (ResetSensorCalibration)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsResetsensorcalibration:
         Expected: [0x71, 0x03, 0xFF, 0x00]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/sensor_ecu/generated/tests/test_routine_ff01.py
+++ b/examples/sensor_ecu/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:16:03Z
+# Generated : 2026-08-31T12:02:07Z
 #
 # Routine   : 0xFF01  (SensorSelfTest)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsSensorselftest:
         Expected: [0x71, 0x03, 0xFF, 0x01]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/sensor_ecu_freertos/generated/tests/test_routine_ff00.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_routine_ff00.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:16:46Z
+# Generated : 2026-08-31T12:02:07Z
 #
 # Routine   : 0xFF00  (ResetSensorCalibration)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsResetsensorcalibration:
         Expected: [0x71, 0x03, 0xFF, 0x00]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 

--- a/examples/sensor_ecu_freertos/generated/tests/test_routine_ff01.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_routine_ff01.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:16:46Z
+# Generated : 2026-08-31T12:02:07Z
 #
 # Routine   : 0xFF01  (SensorSelfTest)
 # Session   : extended (ordinal 3)
@@ -187,6 +187,8 @@ class TestResultsSensorselftest:
         Expected: [0x71, 0x03, 0xFF, 0x01]
         """
         _setup(uds_bus, aes_keys)
+        start_pdu = _rc(uds_bus, _SUBFN_START)
+        _assert_positive(start_pdu, _SUBFN_START)
         pdu = _rc(uds_bus, _SUBFN_RESULTS)
         _assert_positive(pdu, _SUBFN_RESULTS)
 


### PR DESCRIPTION
## What

CI's "Integration Tests (generated, simulator mode)" job never installs
`xaloqi-tester`, so every generated pytest test skips
(`conftest.py:429 _XALOQI_AVAILABLE = False`), and the job's own gate
(`grep -q "failed" && exit 1 || true`) passes trivially on all-skipped
output. It has been green this way since the initial public release —
confirmed via the actual v1.12.0 release run: `136 skipped in 0.28s`.

Installing `xaloqi-tester` (as a real customer's `pip install xaloqi-tester`
+ INSTALL.md Step 6 would) reveals **30 real failures across all 12
examples**, in two independent classes, both fixed here:

**1. RoutineControl requestRoutineResults tested without starting the
routine first (28 failures).** `tools/templates/test_routine_XXXX.py.j2`'s
own docstring said "after start" but never actually called Start. Fixed in
EDS-toolchain (see the companion PR there); regenerated here: 28
`test_routine_*.py` files across all affected examples now Start before
requesting Results.

**2. ClearDiagnosticInformation (SID 0x14) tested without entering a
non-default session (2 failures + 1 latent gap).**
`core/uds_access_table.c` deliberately restricts 0x14 to non-default
sessions. `examples/basic_ecu/generated/tests/test_phase1_protocol_edge_cases.py`
(hand-written, not template-generated, present only in `basic_ecu`) called
ClearDTC directly in the default session in three of its four tests. Two
asserted `pdu[0] == 0x54` and got NRC 0x7F instead. The third
(`test_sub02_after_clear_returns_empty_list`) discarded ClearDTC's response
entirely and only happened to pass because there were never any DTCs to
clear — it provided no real coverage. All three now enter EXTENDED session
first, and the third now asserts ClearDTC actually succeeded before
checking the post-clear DTC list.

## Companion PR

[EDS-toolchain#66](https://github.com/Xaloqi/EDS-toolchain/pull/66) fixes
the template itself (`test_routine_XXXX.py.j2`); this PR regenerates the
affected output here using that fix.

## Verification

With `xaloqi-tester` installed, all 12 examples now show **0 failures**
(previously 30 across ardep/basic_ecu-family/bms/motor/robot_joint/
safeboot/sensor-family — 2312 tests total, was 2282 passed + 30 failed).
`build_tests.sh` 44/44 and `build_harness.sh --run` 68/68 unaffected — this
fix is Python-test-only, no C changed.

The 39 changed files are exactly: the hand-edited test file (4 tests
touched) + 38 regenerated `test_routine_*.py` files, of which 28 carry the
real 2-line fix and the rest differ only on the timestamp line — verified
with a content-only diff (timestamp lines excluded) before committing.

## Not fixed here

CI itself still needs to actually install `xaloqi-tester` and replace the
`grep -q "failed"` gate with a minimum real-pass-count assertion — that's
next, once this PR and #66 are both merged (landing it first would go red
on exactly these 30 failures, which is why the order matters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)