### PR TITLE
ci: install xaloqi-tester and strengthen the Integration Tests gate (Critical, campaign finding #3 part 3/3) — DO NOT MERGE BEFORE #141

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,7 +513,14 @@ jobs:
           sudo apt-get install -y --no-install-recommends python3 python3-pip
 
       - name: Install Python dependencies
-        run: pip install pyyaml jinja2 pytest pycryptodome
+        # xaloqi-tester was missing here (found #3, 2026-08-31 campaign):
+        # conftest.py's `from xaloqi.tester import ...` failed at import
+        # time, every generated test hit the `_XALOQI_AVAILABLE` skip guard,
+        # and this job has been "green" on 0 executed tests since the
+        # initial public release. Installing it from real PyPI is also the
+        # most representative choice: it's exactly what INSTALL.md Step 6
+        # and a real customer's environment already require.
+        run: pip install pyyaml jinja2 pytest pycryptodome xaloqi-tester
 
       - name: Verify pre-committed generated test files exist
         run: |
@@ -553,6 +560,14 @@ jobs:
             -q
 
       - name: Verify integration test pass count
+        # Found #3, 2026-08-31 campaign: `grep -q "failed" && exit 1 || true`
+        # passes trivially on all-skipped output ("136 skipped" has no
+        # "failed" substring) — which is exactly what this job produced,
+        # undetected, since the initial public release (xaloqi-tester was
+        # never installed; see the previous step). Require a real minimum
+        # passed count (134, basic_ecu's actual total minus its 2 expected
+        # xaloqi-tester-optional skips) in addition to zero failures, so an
+        # all-skipped or mostly-skipped run fails loudly instead of passing.
         run: |
           cd examples/basic_ecu/generated/tests
           result=$(python3 -m pytest . -q \
@@ -571,7 +586,16 @@ jobs:
             --ignore=test_robustness_L_codegen_output_fidelity.py \
             --can-interface=simulator --tb=no 2>&1 | tail -1)
           echo "Result: $result"
-          echo "$result" | grep -q "failed" && exit 1 || true
+          failed=$(echo "$result" | grep -oE '[0-9]+ failed' | grep -oE '^[0-9]+' || echo 0)
+          passed=$(echo "$result" | grep -oE '[0-9]+ passed' | grep -oE '^[0-9]+' || echo 0)
+          echo "passed=$passed failed=$failed"
+          [ "$failed" -eq 0 ] \
+            || (echo "FAIL: $failed test(s) failed" && exit 1)
+          [ "$passed" -ge 134 ] \
+            || (echo "FAIL: only $passed passed (expected >= 134) — xaloqi-tester" \
+                     "may not be installed, or tests are being silently skipped" \
+                && exit 1)
+          echo "PASS: $passed passed, 0 failed"
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
## ⚠️ Merge order

**Do not merge this before [#141](https://github.com/Xaloqi/EDS/pull/141).** This PR's CI is expected to be red against current `main` — that's proof the gate works, not a bug in this PR. See verification below.

## What

Two independent problems in "Integration Tests (generated, simulator mode)", both fixed here:

**1. `xaloqi-tester` was never installed.** `conftest.py`'s
`from xaloqi.tester import ...` failed at import time
(`_XALOQI_AVAILABLE = False`), every generated test hit the skip guard, and
the job has been green on **0 executed tests** since the initial public
release — confirmed via the actual v1.12.0 release run's log:
`136 skipped in 0.28s`. Now installs `xaloqi-tester` from real PyPI,
matching what INSTALL.md Step 6 and a real customer's environment already
require.

**2. The gate was `grep -q "failed" && exit 1 || true`.** Passes trivially
on all-skipped output — `"136 skipped"` contains no `"failed"` substring.
Replaced with an explicit passed/failed count parse: zero failed AND at
least 134 passed (basic_ecu's real total minus its 2 expected
optional-dependency skips).

## Why this surfaces failures, and why the order matters

Installing `xaloqi-tester` runs tests that have never actually executed
before, revealing 30 real failures fixed in two companion PRs:
- [#141](https://github.com/Xaloqi/EDS/pull/141) (this repo): two
  protocol-test bugs.
- [EDS-toolchain#66](https://github.com/Xaloqi/EDS-toolchain/pull/66): the
  template bug behind half of #141.

## Verification

Simulated this exact job's steps locally (`pip install xaloqi-tester`,
identical `pytest` invocation, identical gate arithmetic):

Against current `main`:
```
Result: 4 failed, 130 passed, 2 skipped, 25 warnings in 7.43s
GATE WOULD FAIL: 4 failed
GATE WOULD FAIL: only 130 passed
```

With #141's changes applied on top (via `git show #141-branch -- <files> | git apply`, not merged):
```
Result: 134 passed, 2 skipped, 25 warnings in 7.43s
GATE: failed check OK
GATE: passed check OK
```

So: this PR's own CI run will fail right now (exactly the same 4 failures,
since `main` doesn't have #141 yet) — merge #141 first, then this one, and
CI here will go green without any further changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)