### PR TITLE
fix: firmware_bus fixture was unreachable and pointed at the wrong repo root (High, campaign finding #8)

### DIFF
--- a/examples/ardep_ecu/generated/tests/conftest.py
+++ b/examples/ardep_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:12:17Z
+# Generated : 2026-08-31T12:21:24Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #
@@ -33,6 +33,15 @@ from __future__ import annotations
 import asyncio, os, logging
 from typing import Optional
 import pytest
+
+# [SEC-FIRMWARE-CONFTEST-01, 2026-08-31 campaign] pytest only auto-loads
+# conftest.py, never a sibling conftest_firmware.py — so the firmware_bus
+# fixture that test_firmware_services.py.j2 depends on was never available
+# ("fixture 'firmware_bus' not found"), producing a setup error for every
+# firmware-backed test in every example. Declaring it as a plugin here
+# makes conftest_firmware.py's fixtures and --firmware/--firmware-sec-key-*
+# options available the same way pytest would treat a second conftest.py.
+pytest_plugins = ["conftest_firmware"]
 
 try:
     from xaloqi.tester import (

--- a/examples/ardep_ecu/generated/tests/conftest_firmware.py
+++ b/examples/ardep_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : ARDEP_IOController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:12:17Z
+# Generated : 2026-08-31T12:21:24Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #
@@ -291,7 +291,7 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # ---------------------------------------------------------------------------
 
 # Root of the repository (two levels up from generated/tests/)
-_REPO_ROOT = Path(__file__).parent.parent.parent
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
 
 def build_harness(repo_root: Path = _REPO_ROOT) -> Path:

--- a/examples/basic_ecu/generated/tests/conftest.py
+++ b/examples/basic_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T13:12:55Z
+# Generated : 2026-08-31T12:18:59Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #
@@ -33,6 +33,15 @@ from __future__ import annotations
 import asyncio, os, logging
 from typing import Optional
 import pytest
+
+# [SEC-FIRMWARE-CONFTEST-01, 2026-08-31 campaign] pytest only auto-loads
+# conftest.py, never a sibling conftest_firmware.py — so the firmware_bus
+# fixture that test_firmware_services.py.j2 depends on was never available
+# ("fixture 'firmware_bus' not found"), producing a setup error for every
+# firmware-backed test in every example. Declaring it as a plugin here
+# makes conftest_firmware.py's fixtures and --firmware/--firmware-sec-key-*
+# options available the same way pytest would treat a second conftest.py.
+pytest_plugins = ["conftest_firmware"]
 
 try:
     from xaloqi.tester import (

--- a/examples/basic_ecu/generated/tests/conftest_firmware.py
+++ b/examples/basic_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T13:12:55Z
+# Generated : 2026-08-31T12:18:59Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #
@@ -291,7 +291,7 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # ---------------------------------------------------------------------------
 
 # Root of the repository (two levels up from generated/tests/)
-_REPO_ROOT = Path(__file__).parent.parent.parent
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
 
 def build_harness(repo_root: Path = _REPO_ROOT) -> Path:

--- a/examples/basic_ecu_doip/generated/tests/conftest.py
+++ b/examples/basic_ecu_doip/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-08-30T13:13:32Z
+# Generated : 2026-08-31T12:21:24Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #
@@ -33,6 +33,15 @@ from __future__ import annotations
 import asyncio, os, logging
 from typing import Optional
 import pytest
+
+# [SEC-FIRMWARE-CONFTEST-01, 2026-08-31 campaign] pytest only auto-loads
+# conftest.py, never a sibling conftest_firmware.py — so the firmware_bus
+# fixture that test_firmware_services.py.j2 depends on was never available
+# ("fixture 'firmware_bus' not found"), producing a setup error for every
+# firmware-backed test in every example. Declaring it as a plugin here
+# makes conftest_firmware.py's fixtures and --firmware/--firmware-sec-key-*
+# options available the same way pytest would treat a second conftest.py.
+pytest_plugins = ["conftest_firmware"]
 
 try:
     from xaloqi.tester import (

--- a/examples/basic_ecu_doip/generated/tests/conftest_firmware.py
+++ b/examples/basic_ecu_doip/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP
 # Version   : 1.6.0
-# Generated : 2026-08-30T13:13:32Z
+# Generated : 2026-08-31T12:21:24Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #
@@ -291,7 +291,7 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # ---------------------------------------------------------------------------
 
 # Root of the repository (two levels up from generated/tests/)
-_REPO_ROOT = Path(__file__).parent.parent.parent
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
 
 def build_harness(repo_root: Path = _REPO_ROOT) -> Path:

--- a/examples/basic_ecu_doip_freertos/generated/tests/conftest.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-08-30T13:14:20Z
+# Generated : 2026-08-31T12:21:24Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #
@@ -33,6 +33,15 @@ from __future__ import annotations
 import asyncio, os, logging
 from typing import Optional
 import pytest
+
+# [SEC-FIRMWARE-CONFTEST-01, 2026-08-31 campaign] pytest only auto-loads
+# conftest.py, never a sibling conftest_firmware.py — so the firmware_bus
+# fixture that test_firmware_services.py.j2 depends on was never available
+# ("fixture 'firmware_bus' not found"), producing a setup error for every
+# firmware-backed test in every example. Declaring it as a plugin here
+# makes conftest_firmware.py's fixtures and --firmware/--firmware-sec-key-*
+# options available the same way pytest would treat a second conftest.py.
+pytest_plugins = ["conftest_firmware"]
 
 try:
     from xaloqi.tester import (

--- a/examples/basic_ecu_doip_freertos/generated/tests/conftest_firmware.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU_DoIP_FreeRTOS
 # Version   : 1.6.0
-# Generated : 2026-08-30T13:14:20Z
+# Generated : 2026-08-31T12:21:24Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #
@@ -291,7 +291,7 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # ---------------------------------------------------------------------------
 
 # Root of the repository (two levels up from generated/tests/)
-_REPO_ROOT = Path(__file__).parent.parent.parent
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
 
 def build_harness(repo_root: Path = _REPO_ROOT) -> Path:

--- a/examples/basic_ecu_freertos/generated/tests/conftest.py
+++ b/examples/basic_ecu_freertos/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T13:15:18Z
+# Generated : 2026-08-31T12:21:25Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #
@@ -33,6 +33,15 @@ from __future__ import annotations
 import asyncio, os, logging
 from typing import Optional
 import pytest
+
+# [SEC-FIRMWARE-CONFTEST-01, 2026-08-31 campaign] pytest only auto-loads
+# conftest.py, never a sibling conftest_firmware.py — so the firmware_bus
+# fixture that test_firmware_services.py.j2 depends on was never available
+# ("fixture 'firmware_bus' not found"), producing a setup error for every
+# firmware-backed test in every example. Declaring it as a plugin here
+# makes conftest_firmware.py's fixtures and --firmware/--firmware-sec-key-*
+# options available the same way pytest would treat a second conftest.py.
+pytest_plugins = ["conftest_firmware"]
 
 try:
     from xaloqi.tester import (

--- a/examples/basic_ecu_freertos/generated/tests/conftest_firmware.py
+++ b/examples/basic_ecu_freertos/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BasicECU
 # Version   : 0.1.0
-# Generated : 2026-08-30T13:15:18Z
+# Generated : 2026-08-31T12:21:25Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #
@@ -291,7 +291,7 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # ---------------------------------------------------------------------------
 
 # Root of the repository (two levels up from generated/tests/)
-_REPO_ROOT = Path(__file__).parent.parent.parent
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
 
 def build_harness(repo_root: Path = _REPO_ROOT) -> Path:

--- a/examples/bms_ecu/generated/tests/conftest.py
+++ b/examples/bms_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:22Z
+# Generated : 2026-08-31T12:21:25Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #
@@ -33,6 +33,15 @@ from __future__ import annotations
 import asyncio, os, logging
 from typing import Optional
 import pytest
+
+# [SEC-FIRMWARE-CONFTEST-01, 2026-08-31 campaign] pytest only auto-loads
+# conftest.py, never a sibling conftest_firmware.py — so the firmware_bus
+# fixture that test_firmware_services.py.j2 depends on was never available
+# ("fixture 'firmware_bus' not found"), producing a setup error for every
+# firmware-backed test in every example. Declaring it as a plugin here
+# makes conftest_firmware.py's fixtures and --firmware/--firmware-sec-key-*
+# options available the same way pytest would treat a second conftest.py.
+pytest_plugins = ["conftest_firmware"]
 
 try:
     from xaloqi.tester import (

--- a/examples/bms_ecu/generated/tests/conftest_firmware.py
+++ b/examples/bms_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : BMS_MainController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:22Z
+# Generated : 2026-08-31T12:21:25Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #
@@ -291,7 +291,7 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # ---------------------------------------------------------------------------
 
 # Root of the repository (two levels up from generated/tests/)
-_REPO_ROOT = Path(__file__).parent.parent.parent
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
 
 def build_harness(repo_root: Path = _REPO_ROOT) -> Path:

--- a/examples/motor_controller_ecu/generated/tests/conftest.py
+++ b/examples/motor_controller_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:27Z
+# Generated : 2026-08-31T12:21:25Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #
@@ -33,6 +33,15 @@ from __future__ import annotations
 import asyncio, os, logging
 from typing import Optional
 import pytest
+
+# [SEC-FIRMWARE-CONFTEST-01, 2026-08-31 campaign] pytest only auto-loads
+# conftest.py, never a sibling conftest_firmware.py — so the firmware_bus
+# fixture that test_firmware_services.py.j2 depends on was never available
+# ("fixture 'firmware_bus' not found"), producing a setup error for every
+# firmware-backed test in every example. Declaring it as a plugin here
+# makes conftest_firmware.py's fixtures and --firmware/--firmware-sec-key-*
+# options available the same way pytest would treat a second conftest.py.
+pytest_plugins = ["conftest_firmware"]
 
 try:
     from xaloqi.tester import (

--- a/examples/motor_controller_ecu/generated/tests/conftest_firmware.py
+++ b/examples/motor_controller_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : MotorController_Inverter
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:27Z
+# Generated : 2026-08-31T12:21:25Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #
@@ -291,7 +291,7 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # ---------------------------------------------------------------------------
 
 # Root of the repository (two levels up from generated/tests/)
-_REPO_ROOT = Path(__file__).parent.parent.parent
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
 
 def build_harness(repo_root: Path = _REPO_ROOT) -> Path:

--- a/examples/robot_joint_controller_ecu/generated/tests/conftest.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:31Z
+# Generated : 2026-08-31T12:21:25Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #
@@ -33,6 +33,15 @@ from __future__ import annotations
 import asyncio, os, logging
 from typing import Optional
 import pytest
+
+# [SEC-FIRMWARE-CONFTEST-01, 2026-08-31 campaign] pytest only auto-loads
+# conftest.py, never a sibling conftest_firmware.py — so the firmware_bus
+# fixture that test_firmware_services.py.j2 depends on was never available
+# ("fixture 'firmware_bus' not found"), producing a setup error for every
+# firmware-backed test in every example. Declaring it as a plugin here
+# makes conftest_firmware.py's fixtures and --firmware/--firmware-sec-key-*
+# options available the same way pytest would treat a second conftest.py.
+pytest_plugins = ["conftest_firmware"]
 
 try:
     from xaloqi.tester import (

--- a/examples/robot_joint_controller_ecu/generated/tests/conftest_firmware.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : RobotJointController
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:31Z
+# Generated : 2026-08-31T12:21:25Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #
@@ -291,7 +291,7 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # ---------------------------------------------------------------------------
 
 # Root of the repository (two levels up from generated/tests/)
-_REPO_ROOT = Path(__file__).parent.parent.parent
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
 
 def build_harness(repo_root: Path = _REPO_ROOT) -> Path:

--- a/examples/safeboot_ecu/generated/tests/conftest.py
+++ b/examples/safeboot_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:59Z
+# Generated : 2026-08-31T12:21:25Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #
@@ -33,6 +33,15 @@ from __future__ import annotations
 import asyncio, os, logging
 from typing import Optional
 import pytest
+
+# [SEC-FIRMWARE-CONFTEST-01, 2026-08-31 campaign] pytest only auto-loads
+# conftest.py, never a sibling conftest_firmware.py — so the firmware_bus
+# fixture that test_firmware_services.py.j2 depends on was never available
+# ("fixture 'firmware_bus' not found"), producing a setup error for every
+# firmware-backed test in every example. Declaring it as a plugin here
+# makes conftest_firmware.py's fixtures and --firmware/--firmware-sec-key-*
+# options available the same way pytest would treat a second conftest.py.
+pytest_plugins = ["conftest_firmware"]
 
 try:
     from xaloqi.tester import (

--- a/examples/safeboot_ecu/generated/tests/conftest_firmware.py
+++ b/examples/safeboot_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SafeBootECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:15:59Z
+# Generated : 2026-08-31T12:21:25Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #
@@ -291,7 +291,7 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # ---------------------------------------------------------------------------
 
 # Root of the repository (two levels up from generated/tests/)
-_REPO_ROOT = Path(__file__).parent.parent.parent
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
 
 def build_harness(repo_root: Path = _REPO_ROOT) -> Path:

--- a/examples/sensor_ecu/generated/tests/conftest.py
+++ b/examples/sensor_ecu/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:16:03Z
+# Generated : 2026-08-31T12:21:26Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #
@@ -33,6 +33,15 @@ from __future__ import annotations
 import asyncio, os, logging
 from typing import Optional
 import pytest
+
+# [SEC-FIRMWARE-CONFTEST-01, 2026-08-31 campaign] pytest only auto-loads
+# conftest.py, never a sibling conftest_firmware.py — so the firmware_bus
+# fixture that test_firmware_services.py.j2 depends on was never available
+# ("fixture 'firmware_bus' not found"), producing a setup error for every
+# firmware-backed test in every example. Declaring it as a plugin here
+# makes conftest_firmware.py's fixtures and --firmware/--firmware-sec-key-*
+# options available the same way pytest would treat a second conftest.py.
+pytest_plugins = ["conftest_firmware"]
 
 try:
     from xaloqi.tester import (

--- a/examples/sensor_ecu/generated/tests/conftest_firmware.py
+++ b/examples/sensor_ecu/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:16:03Z
+# Generated : 2026-08-31T12:21:26Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #
@@ -291,7 +291,7 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # ---------------------------------------------------------------------------
 
 # Root of the repository (two levels up from generated/tests/)
-_REPO_ROOT = Path(__file__).parent.parent.parent
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
 
 def build_harness(repo_root: Path = _REPO_ROOT) -> Path:

--- a/examples/sensor_ecu_freertos/generated/tests/conftest.py
+++ b/examples/sensor_ecu_freertos/generated/tests/conftest.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:16:46Z
+# Generated : 2026-08-31T12:21:26Z
 #
 # PURPOSE: pytest conftest — shared fixtures backed by xaloqi-tester.
 #
@@ -33,6 +33,15 @@ from __future__ import annotations
 import asyncio, os, logging
 from typing import Optional
 import pytest
+
+# [SEC-FIRMWARE-CONFTEST-01, 2026-08-31 campaign] pytest only auto-loads
+# conftest.py, never a sibling conftest_firmware.py — so the firmware_bus
+# fixture that test_firmware_services.py.j2 depends on was never available
+# ("fixture 'firmware_bus' not found"), producing a setup error for every
+# firmware-backed test in every example. Declaring it as a plugin here
+# makes conftest_firmware.py's fixtures and --firmware/--firmware-sec-key-*
+# options available the same way pytest would treat a second conftest.py.
+pytest_plugins = ["conftest_firmware"]
 
 try:
     from xaloqi.tester import (

--- a/examples/sensor_ecu_freertos/generated/tests/conftest_firmware.py
+++ b/examples/sensor_ecu_freertos/generated/tests/conftest_firmware.py
@@ -4,7 +4,7 @@
 #
 # ECU       : SensorECU
 # Version   : 1.0.0
-# Generated : 2026-08-30T13:16:46Z
+# Generated : 2026-08-31T12:21:26Z
 #
 # PURPOSE: pytest conftest for firmware-backed integration tests.
 #
@@ -291,7 +291,7 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # ---------------------------------------------------------------------------
 
 # Root of the repository (two levels up from generated/tests/)
-_REPO_ROOT = Path(__file__).parent.parent.parent
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
 
 def build_harness(repo_root: Path = _REPO_ROOT) -> Path:


### PR DESCRIPTION
## What

INSTALL.md Step 6 ("All tests should pass") was false: every
`test_firmware_services.py` test errored with `fixture 'firmware_bus' not
found`, in every example. Two independent bugs, fixed in the template
(companion PR [EDS-toolchain#67](https://github.com/Xaloqi/EDS-toolchain/pull/67)) and regenerated here across all 11
examples that have a `tests/` directory:

**1. `conftest.py` never registered `conftest_firmware.py` as a pytest
plugin** — pytest only auto-loads `conftest.py`, never a sibling file, so
the `firmware_bus` fixture and `--firmware`/`--firmware-sec-key-*` options
were never available. 104 setup errors per example, confirmed in the
original campaign run.

**2. Once (1) is fixed, `_REPO_ROOT` pointed at the wrong directory** —
computed with 3 parent hops from
`examples/<ecu>/generated/tests/conftest_firmware.py`, landing on
`examples/<ecu>` instead of the real repo root 5 levels up.
`build_harness()` never found `build_harness.sh` there, so every firmware
test cleanly *skipped* — meaning even with (1) fixed, zero firmware tests
could ever actually run in any example, ever, until now.

## Verification

For basic_ecu (the example `build_harness.sh`'s shared harness binary is
built from), with both fixes: `pytest test_firmware_services.py --firmware`
builds the real C harness and runs **56 passed, 1 skipped** (a real,
config-dependent skip) — the first genuine pass/fail signal this file has
ever produced.

Full suite (simulator + firmware together): 186 passed, 4 failed, 3
skipped. The 4 failures are the pre-existing ClearDTC/RoutineControl bugs
fixed in [#141](https://github.com/Xaloqi/EDS/pull/141) on a separate
branch — confirmed identical signatures, unrelated to and unaffected by
this fix. `build_tests.sh` 44/44 and `build_harness.sh --run` 68/68
unaffected — this is Python-test-only, no C changed.

Also ran `--firmware` against a second example (sensor_ecu) as a sanity
check of the fixture *mechanism* generically: 40 passed, 20 failed — the
mechanism itself works correctly (builds, launches, tears down cleanly,
zero setup errors), but `build_harness.sh`'s sources are hardcoded to
basic_ecu's DIDs/routines/DTCs, so the other 10 examples' firmware tests
fail on real, comprehensible protocol mismatches instead of a
context-free "fixture not found". That's a separate, larger architectural
gap (a per-example-aware harness build), filed as a follow-up issue
rather than fixed here.

The 22 changed files are exactly: 11× `conftest.py` (+9 lines, the plugin
declaration) and 11× `conftest_firmware.py` (1 line, the parent-hop fix) —
verified with a content-only diff (timestamp lines excluded) before
committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)