### PR TITLE
docs: RTM/MISRA count accuracy + CHANGELOG backfill for the 2026-08-31 validation campaign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,96 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+### Security
+
+- **SecurityAccess stayed unlocked across an S3 inactivity timeout.** (#140)
+  `uds_security_reset()` was only ever called from one site —
+  `service_0x10.c`, when an explicit 0x10 DiagnosticSessionControl(default)
+  request transitions the session to DEFAULT. The S3 timeout drives that
+  exact same transition (`uds_session_tick_1ms()` forces the session back to
+  DEFAULT on expiry), but through a path that never touched security. A
+  level unlocked before S3 expiry stayed unlocked after the forced return to
+  DEFAULT — any tester, not necessarily the one that performed the seed/key
+  exchange, could re-enter a non-default session with a bare
+  DiagnosticSessionControl request and inherit the previous unlock, no
+  seed/key exchange of its own. `uds_server_tick_1ms()` now calls
+  `uds_security_reset()` whenever `uds_session_tick_1ms()` reports the S3
+  timeout, mirroring the explicit path exactly. Found by the 2026-08-31
+  validation campaign; new unit test
+  `test_s3_timeout_resets_security_unlock` in `test_uds_server.c`.
+
+### Fixed
+
+- **CI's "Integration Tests (generated, simulator mode)" job has executed
+  zero tests since the initial public release.** (#141, #142) `conftest.py`'s
+  `from xaloqi.tester import ...` failed at import time because the job
+  never installed `xaloqi-tester`, so every generated test hit the
+  `_XALOQI_AVAILABLE` skip guard — confirmed on the actual v1.12.0 release
+  run's log: `136 skipped in 0.28s`. The pass/fail gate,
+  `grep -q "failed" && exit 1 || true`, passed trivially on that all-skipped
+  output. #142 installs `xaloqi-tester` from real PyPI and replaces the gate
+  with an explicit passed/failed count (zero failed, at least 134 passed).
+  Installing it for the first time surfaced two real, independent bugs,
+  fixed in #141:
+  - `test_request_results()`'s own docstring claimed "requestRoutineResults
+    after start", but the generated test never called Start — the real UDS
+    stack correctly rejects an un-started RequestResults with NRC 0x22
+    (`conditionsNotCorrect`) via `service_0x31.c`'s `routine_started` gate.
+    28 generated `test_routine_*.py` files across all 12 examples asserted a
+    positive response instead. Template fix in
+    [EDS-toolchain#66](https://github.com/Xaloqi/EDS-toolchain/pull/66);
+    regenerated here.
+  - `examples/basic_ecu/generated/tests/test_phase1_protocol_edge_cases.py`
+    (hand-written, not template-generated) called ClearDiagnosticInformation
+    (SID 0x14) directly in the default session, in three of its four tests.
+    `core/uds_access_table.c` deliberately restricts 0x14 to non-default
+    sessions, so two tests asserted `pdu[0] == 0x54` and got NRC 0x7F
+    instead; a third discarded ClearDTC's response entirely and only
+    happened to pass because there were never any DTCs to clear in the
+    first place. All three now enter EXTENDED session first, and the third
+    asserts ClearDTC actually succeeded before checking the post-clear DTC
+    list.
+
+- **`test_firmware_services.py`'s `firmware_bus` fixture was unreachable,
+  and once reachable, pointed at the wrong repo root — INSTALL.md Step 6's
+  "All tests should pass" was false for every firmware-backed test.** (#143)
+  pytest only auto-loads `conftest.py`, never a sibling
+  `conftest_firmware.py`, so `firmware_bus` errored with `fixture
+  'firmware_bus' not found` in every example (104 setup errors per example).
+  Fixing that (`pytest_plugins = ["conftest_firmware"]`, template fix in
+  [EDS-toolchain#67](https://github.com/Xaloqi/EDS-toolchain/pull/67))
+  surfaced a second, previously-unreachable bug: `_REPO_ROOT` was computed
+  with too few parent hops from
+  `examples/<ecu>/generated/tests/conftest_firmware.py`, landing on
+  `examples/<ecu>` instead of the actual repo root — `build_harness()` never
+  found `build_harness.sh`, so every firmware test cleanly skipped instead
+  of erroring, and zero firmware tests could ever actually run, in any
+  example, ever, until now. `pytest test_firmware_services.py --firmware`
+  now builds the real C harness and runs 56 passed, 1 skipped for
+  `basic_ecu` — the first genuine pass/fail signal this file has ever
+  produced. (A separate, larger gap — `build_harness.sh` only ever builds
+  one generic harness hardcoded to `basic_ecu`'s DIDs/routines/DTCs, so the
+  other 11 examples' firmware tests still fail on protocol mismatch rather
+  than a "fixture not found" — is tracked as
+  [#144](https://github.com/Xaloqi/EDS/issues/144), not fixed here.)
+
+All four found and fixed during the 2026-08-31 validation campaign; see
+`xaloqi-knowledge/campaigns/2026-08-31-validation-campaign.md`.
+
+### Documentation
+
+- **The Requirements Traceability Matrix and MISRA Deviation Log counts in
+  INSTALL.md were both wrong.** (#146) "X ASIL-B requirements, all COVERED"
+  — of the RTM's 30 total rows, 16 are ASIL-B and 14 are QM. "38
+  deviations" / "38 documented deviations" — the log actually contains 39
+  records (10 in Rev 1.0, 28 in Rev 1.1, 1 — `DEV-MEM-01` — in Rev 1.2,
+  whose revision-history entry was never reflected in the summary count).
+  Fixed in both places INSTALL.md states each. Companion fix at the source:
+  [EDS-Safety#4](https://github.com/Xaloqi/EDS-Safety/pull/4), which also
+  fixes an unquoted comma in the RTM CSV's `REQ-FLASH-003` row that shifted
+  every following column for any standard CSV parser. Found by the
+  2026-08-31 validation campaign.
+
 ## [1.12.0] — 2026-08-30
 
 ### Changed

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,8 +33,8 @@ It installs by extracting into the public EDS repo you already cloned.
   - Safety Manual EDS-SM-001 Rev 1.3 (PDF)
   - Hazard Analysis and Risk Assessment (EDS-HARA-001)
   - Tool Qualification Argument (EDS-TQA-001)
-  - Requirements Traceability Matrix — 30 ASIL-B requirements, all COVERED
-  - MISRA C:2012 Deviation Log — 38 deviations, 0 open violations
+  - Requirements Traceability Matrix — 30 requirements (16 ASIL-B, 14 QM), all COVERED
+  - MISRA C:2012 Deviation Log — 39 deviations, 0 open violations
   - Security Integration Guide
   - Customer Notice (integration responsibilities, ASIL-B candidate status)
 
@@ -496,8 +496,8 @@ The `safety_docs/` directory contains the complete ISO 26262-aligned documentati
 | Safety Manual Rev 1.3 | `EDS_Safety_Manual_EDS-SM-001_Rev1.3.pdf` | Component safety manual — integration responsibilities, safety boundaries |
 | HARA | `EDS-HARA-001.md` | 6 hazard events, ASIL decomposition argument |
 | TQA | `EDS-TQA-001.md` | Tool qualification argument (TCL1 per ISO 26262-8 §11) |
-| RTM | `EDS_Requirements_Traceability_Matrix.csv` | 30 ASIL-B requirements, all COVERED |
-| MISRA log | `MISRA_DEVIATION_LOG.md` | 38 documented deviations, 0 open violations |
+| RTM | `EDS_Requirements_Traceability_Matrix.csv` | 30 requirements (16 ASIL-B, 14 QM), all COVERED |
+| MISRA log | `MISRA_DEVIATION_LOG.md` | 39 documented deviations, 0 open violations |
 | Security guide | `SECURITY_INTEGRATION.md` | OEM key provisioning for AES-128-CMAC |
 | Customer notice | `CUSTOMER_NOTICE.md` | ASIL-B candidate status, integrator responsibilities |
 


### PR DESCRIPTION
## What

Two documentation tasks, same branch:

**1. RTM and MISRA deviation-count claims in INSTALL.md were both wrong**
(original commit, unchanged):
- "X ASIL-B requirements, all COVERED" — of the RTM's 30 total rows, **16
  are ASIL-B and 14 are QM**. Fixed in both places INSTALL.md states it.
- "38 deviations" / "38 documented deviations" — `MISRA_DEVIATION_LOG.md`
  actually contains **39** deviation records (10 in Rev 1.0, 28 in Rev 1.1,
  1 — `DEV-MEM-01` — in Rev 1.2, whose revision-history entry was never
  reflected in the summary count). Fixed in both places.

  Companion fix at the source: [EDS-Safety#4](https://github.com/Xaloqi/EDS-Safety/pull/4)
  (merged) — also fixes an unquoted comma in the RTM CSV's `REQ-FLASH-003`
  row that shifted every following column for any standard CSV parser.

**2. CHANGELOG backfill (new commit).** #140, #141, #142, #143 all merged
without a CHANGELOG entry — the `[Unreleased]` section was empty despite a
Critical security regression (SecurityAccess surviving an S3 timeout), a
CI job that had executed zero tests since the initial public release, and
the two real protocol bugs that surfaced once it started actually running
them. Backfilled all four under Security/Fixed, plus this PR's own
INSTALL.md fix under Documentation. See
`xaloqi-knowledge/campaigns/2026-08-31-validation-campaign.md` for the
full campaign record.

## Verification

```
$ python3 xaloqi-knowledge/scripts/check_release_docs.py
✓ No hard version-header/badge drift detected.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)