### PR TITLE
ci: harden the Robustness Campaign gate with a real minimum-passed floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2141,17 +2141,29 @@ jobs:
             test_robustness_L_codegen_output_fidelity.py \
             --tb=no -q 2>&1 | tail -2)
           echo "$result"
-          echo "$result" | grep -q "failed" && exit 1 || true
           # Template-dependent tests (Phases A/D/F/L) skip on CI where the
           # Jinja2 template symlink is absent (commercial-only).  Count
-          # passed+skipped so the integrity check holds in both environments.
+          # passed+skipped so the integrity check holds in both environments
+          # — but passed+skipped alone can't tell "439 ran, 0 failed" from
+          # "439 collected, all silently skipped" (2026-08-31 campaign,
+          # lessons/run-013 — that's exactly how the Integration Tests job's
+          # missing xaloqi-tester install went unnoticed for months). The
+          # bare `grep -q "failed"` this replaced had the same blind spot
+          # and added nothing beyond what the floors below already cover.
+          # 332 is this job's real passed count on public CI today (no
+          # commercial templates); a customer with the full ZIP sees 439/0.
+          failed=$(echo "$result" | grep -oE '[0-9]+ failed' | grep -oE '^[0-9]+' || echo 0)
           passed=$(echo "$result" | grep -oE '[0-9]+ passed' | grep -oE '^[0-9]+' || echo 0)
           skipped=$(echo "$result" | grep -oE '[0-9]+ skipped' | grep -oE '^[0-9]+' || echo 0)
           total=$((passed + skipped))
-          echo "passed+skipped: $total (passed=$passed, skipped=$skipped)"
+          echo "passed=$passed failed=$failed skipped=$skipped total=$total"
+          [ "$failed" -eq 0 ] \
+            || (echo "ERROR: $failed test(s) failed" && exit 1)
+          [ "$passed" -ge 332 ] \
+            || (echo "ERROR: only $passed passed (expected >= 332) — suite may be silently skipping" && exit 1)
           [ "$total" -ge 439 ] \
             || (echo "ERROR: Expected passed+skipped >= 439, got $total — test count regression" && exit 1)
-          echo "PASS: campaign integrity confirmed (439 tests accounted for)"
+          echo "PASS: campaign integrity confirmed (439 tests accounted for, $passed genuinely executed)"
 
   # ── Job 7: Harness integration tests (real compiled C UDS stack) ───────────
   #


### PR DESCRIPTION
Process-improvement proposal from the 2026-08-31 validation campaign
([lessons/run-013](https://github.com/Xaloqi/xaloqi-knowledge/blob/master/lessons/run-013-ci-gate-must-assert-positive-success-not-only-absence-of-failure.md)).

## What

The "Assert full campaign total" step had two checks: a bare
`grep -q "failed" && exit 1 || true` (the exact anti-pattern that hid the
Integration Tests job's zero-executed-tests bug for months — passes
trivially on all-skipped output) and a `passed+skipped >= 439` arithmetic
check. The second check is real, but it has the identical blind spot on
its own: a hypothetical regression that made all 439 tests skip would show
`passed=0 skipped=439 total=439` and this check would report PASS.

## Verification

Proved the gap directly — fed the gate a synthetic
`"439 skipped in 0.28s"` string:
```
passed=0 failed=0 skipped=439 total=439
passed check: correctly FAILS the all-skip scenario   (new)
```
vs. the old logic, which would have reported PASS on that same string.

Removed the now-fully-redundant bare `grep` (it added nothing beyond what
the arithmetic already covers) and added an explicit `failed == 0` check
plus a `passed >= 332` floor — 332 is this job's real passed count on
public CI today (107 of 439 skip because the commercial Jinja2 templates
aren't present; a customer with the full ZIP sees 439/0). Verified against
the actual production log ([run 33399654527](https://github.com/Xaloqi/EDS/actions/runs/33399654527)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)