### PR TITLE
fix: version identity was broken (1.12.0 not reflected in core, CMake, SECURITY.md, or generated examples)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,19 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 All four found and fixed during the 2026-08-31 validation campaign; see
 `xaloqi-knowledge/campaigns/2026-08-31-validation-campaign.md`.
 
+- **Version identity was broken: several files still claimed old
+  versions instead of the current 1.12.0.** (#149) `core/uds_types.h`'s
+  `UDS_SUITE_VERSION_MAJOR/MINOR/PATCH` and `UDS_SUITE_VERSION_STRING`
+  still read 1.10.0; `CMakeLists.txt`'s `project(... VERSION 1.10.0)`
+  (and its header comment) likewise; `SECURITY.md`'s supported-versions
+  table still listed "1.7.x (current)"; and all 12
+  `examples/*/generated/safety_config.h` files still defined
+  `UDS_STACK_VERSION "1.7.0"`. None of these matched README.md's version
+  badge, CHANGELOG.md's top entry, or `tools/codegen.py`'s `__version__`
+  (all 1.12.0), so a build, a security report, or a generated ECU could
+  each report a different EDS version depending on which file was
+  consulted. All now read 1.12.0.
+
 ### Documentation
 
 - **The Requirements Traceability Matrix and MISRA Deviation Log counts in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@
 #
 # SAFETY CONTEXT : Contains ASIL-B candidate modules (ISO 26262 Part 6).
 # CODING STANDARD: MISRA C:2012 alignment intended.
-# VERSION        : 1.10.0
+# VERSION        : 1.12.0
 # SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 
@@ -74,7 +74,7 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(zephyr_diagnostics_suite
-    VERSION     1.10.0
+    VERSION     1.12.0
     LANGUAGES   C
     DESCRIPTION "Production-grade UDS/ISO-TP diagnostics stack for Zephyr RTOS"
 )

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@
 
 | Version | Security fixes |
 |---|---|
-| 1.7.x (current) | ✅ Yes |
-| 1.6.x | ✅ Yes (critical only) |
-| < 1.6 | ❌ No — please upgrade |
+| 1.12.x (current) | ✅ Yes |
+| 1.11.x | ✅ Yes (critical only) |
+| < 1.11 | ❌ No — please upgrade |
 
 Only the current release branch receives routine security fixes. Pre-release and
 modified versions are not supported. Update to the latest tagged release before

--- a/core/uds_types.h
+++ b/core/uds_types.h
@@ -32,14 +32,14 @@ extern "C" {
  *   - #define UDS_STACK_VERSION in generated/safety_config.h (template)
  *   - "Stack version" field in docs/INTEGRATION_GUIDE.md
  *
- * Bumped to 1.10.0 for the v1.10.0 release.
+ * Bumped to 1.12.0 for the v1.12.0 release.
  * -------------------------------------------------------------------------- */
 #define UDS_SUITE_VERSION_MAJOR  (1U)
-#define UDS_SUITE_VERSION_MINOR  (10U)
+#define UDS_SUITE_VERSION_MINOR  (12U)
 #define UDS_SUITE_VERSION_PATCH  (0U)
 
 /** Compile-time version string — matches UDS_STACK_VERSION in safety_config.h. */
-#define UDS_SUITE_VERSION_STRING "1.10.0"
+#define UDS_SUITE_VERSION_STRING "1.12.0"
 
 /* --------------------------------------------------------------------------
  * Buffer and protocol sizing constants

--- a/examples/ardep_ecu/generated/safety_config.h
+++ b/examples/ardep_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.7.0"
+#define UDS_STACK_VERSION "1.12.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu/generated/safety_config.h
+++ b/examples/basic_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.7.0"
+#define UDS_STACK_VERSION "1.12.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu_doip/generated/safety_config.h
+++ b/examples/basic_ecu_doip/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.7.0"
+#define UDS_STACK_VERSION "1.12.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu_doip_freertos/generated/safety_config.h
+++ b/examples/basic_ecu_doip_freertos/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.7.0"
+#define UDS_STACK_VERSION "1.12.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu_freertos/generated/safety_config.h
+++ b/examples/basic_ecu_freertos/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.7.0"
+#define UDS_STACK_VERSION "1.12.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/bms_ecu/generated/safety_config.h
+++ b/examples/bms_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.7.0"
+#define UDS_STACK_VERSION "1.12.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/motor_controller_ecu/generated/safety_config.h
+++ b/examples/motor_controller_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.7.0"
+#define UDS_STACK_VERSION "1.12.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/robot_joint_controller_ecu/generated/safety_config.h
+++ b/examples/robot_joint_controller_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.7.0"
+#define UDS_STACK_VERSION "1.12.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/safeboot_ecu/generated/safety_config.h
+++ b/examples/safeboot_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.7.0"
+#define UDS_STACK_VERSION "1.12.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/safeboot_freertos_ecu/generated/safety_config.h
+++ b/examples/safeboot_freertos_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.7.0"
+#define UDS_STACK_VERSION "1.12.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/sensor_ecu/generated/safety_config.h
+++ b/examples/sensor_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.7.0"
+#define UDS_STACK_VERSION "1.12.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/sensor_ecu_freertos/generated/safety_config.h
+++ b/examples/sensor_ecu_freertos/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.7.0"
+#define UDS_STACK_VERSION "1.12.0"
 
 /* =============================================================================
  * ASIL level identification


### PR DESCRIPTION
## Summary

Version identity had drifted across the repo: several files still claimed old versions instead of the current authoritative version, **1.12.0** (matching README.md's badge, CHANGELOG.md's top `[Unreleased]` entry, and `tools/codegen.py`'s `__version__`).

Fixed:

- `core/uds_types.h:37-42` — `UDS_SUITE_VERSION_MAJOR/MINOR/PATCH` and `UDS_SUITE_VERSION_STRING` were `1.10.0` → bumped to `1.12.0`.
- `CMakeLists.txt:77` (`project(... VERSION 1.10.0)`) and the `VERSION` line in the header comment → bumped to `1.12.0`.
- `SECURITY.md` — supported-versions table said "1.7.x (current)" → now lists 1.12.x as current, 1.11.x as critical-only (one-minor-back, following the table's existing format).
- All 12 `examples/*/generated/safety_config.h` files — `#define UDS_STACK_VERSION "1.7.0"` → bumped to `"1.12.0"`. These are committed generated output; only the version-literal line was hand-edited in each file (verified with `git diff` that nothing else changed).

A `CHANGELOG.md` entry was added under `[Unreleased] -> ### Fixed`.

## Testing

- `bash build_tests.sh` → **44/44 passed**.
- `bash build_harness.sh --run` — skipped; `harness/` sources are a gitignored commercial ZIP deliverable not present in this checkout (per repo convention), so this gate does not apply here.
- `git diff` reviewed for every changed file to confirm only the intended version literals moved — no other content in the 12 generated `safety_config.h` files changed.

## Tooling gap (companion fix, separate repo)

`xaloqi-knowledge/scripts/check_versions.py` didn't check any of the four locations above, which is why it previously reported "no drift" while all of this was live. That script has been extended (in the `xaloqi-knowledge` repo, committed directly to `master` per that repo's convention) to also pull these values from a local EDS checkout and compare them against the same authoritative README version it already extracts. Re-run against this fixed EDS checkout, it now passes cleanly.

Fixes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)