### PR TITLE
fix: add explicit timeout to per-example nested pytest subprocess (#153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,22 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 All four found and fixed during the 2026-08-31 validation campaign; see
 `xaloqi-knowledge/campaigns/2026-08-31-validation-campaign.md`.
 
+- **`test_robustness_D_customer_journey.py`'s per-example nested pytest
+  subprocess had no `timeout=`, so how long it could hang was whatever the
+  outer test runner happened to impose rather than anything deterministic.**
+  (#153) `TestAllECUExamplesPytest.test_ecu_pytest_simulator_all_pass`
+  spawns a nested `pytest ... --can-interface=simulator` per example via the
+  `_run()` helper (a thin `subprocess.run(..., capture_output=True,
+  text=True)` wrapper) with no bound at all — an external qualification
+  evaluator's environment hung on this for the FreeRTOS sensor example even
+  though that example's suite completed cleanly (`109 skipped`) when run
+  directly. Measured real per-example runtime (`basic_ecu`'s suite driving
+  all 11 examples sequentially: 98.71s / 11 ≈ 9s/example, individual runs
+  5–9s) and added an explicit `timeout=90` (~10x the slowest observed
+  example) to that call, catching `subprocess.TimeoutExpired` and failing
+  with `"nested pytest timed out after 90s for {ecu}"` — a message that
+  reads as a timeout, not a generic subprocess or assertion error.
+
 ### Documentation
 
 - **The Requirements Traceability Matrix and MISRA Deviation Log counts in

--- a/examples/basic_ecu/generated/tests/test_robustness_D_customer_journey.py
+++ b/examples/basic_ecu/generated/tests/test_robustness_D_customer_journey.py
@@ -291,28 +291,42 @@ class TestAllECUExamplesCodegen:
 class TestAllECUExamplesPytest:
     """All 11 ECU example generated test suites must pass in simulator mode."""
 
+    # Sized from a real measurement, not a guess (see #153): the slowest
+    # individual example's nested `pytest ... --can-interface=simulator` run
+    # measured ~8-9s on a dev machine (basic_ecu suite: 98.71s / 11 examples
+    # sequentially). 90s is ~10x that, leaving headroom for slower/loaded CI
+    # environments (this is exactly the scenario that hung the wrapper for
+    # sensor_ecu_freertos in an external evaluator's environment even though
+    # the suite completed cleanly when run directly).
+    NESTED_PYTEST_TIMEOUT_S = 90
+
     @pytest.mark.parametrize("ecu", ALL_EXAMPLES)
     def test_ecu_pytest_simulator_all_pass(self, ecu):
         test_dir = os.path.join(EDS_ROOT, "examples", ecu, "generated", "tests")
         if not os.path.isdir(test_dir):
             pytest.skip(f"Generated tests not found for {ecu}")
-        r = _run([
-            sys.executable, "-m", "pytest", test_dir,
-            "--can-interface=simulator", "-q", "--tb=short",
-            "--ignore", os.path.join(test_dir, "test_firmware_services.py"),
-            "--ignore", os.path.join(test_dir, "test_robustness_A_codegen.py"),
-            "--ignore", os.path.join(test_dir, "test_robustness_B_protocol.py"),
-            "--ignore", os.path.join(test_dir, "test_robustness_C_security.py"),
-            "--ignore", os.path.join(test_dir, "test_robustness_D_customer_journey.py"),
-            "--ignore", os.path.join(test_dir, "test_robustness_E_data_integrity.py"),
-            "--ignore", os.path.join(test_dir, "test_robustness_F_codegen_limits.py"),
-            "--ignore", os.path.join(test_dir, "test_robustness_G_resilience.py"),
-            "--ignore", os.path.join(test_dir, "test_robustness_H_protocol_precision.py"),
-            "--ignore", os.path.join(test_dir, "test_robustness_I_nrc_wdbi_sa.py"),
-            "--ignore", os.path.join(test_dir, "test_robustness_J_sovd_cda.py"),
-            "--ignore", os.path.join(test_dir, "test_robustness_K_error_quality.py"),
-            "--ignore", os.path.join(test_dir, "test_robustness_L_codegen_output_fidelity.py"),
-        ], cwd=test_dir)
+        try:
+            r = _run([
+                sys.executable, "-m", "pytest", test_dir,
+                "--can-interface=simulator", "-q", "--tb=short",
+                "--ignore", os.path.join(test_dir, "test_firmware_services.py"),
+                "--ignore", os.path.join(test_dir, "test_robustness_A_codegen.py"),
+                "--ignore", os.path.join(test_dir, "test_robustness_B_protocol.py"),
+                "--ignore", os.path.join(test_dir, "test_robustness_C_security.py"),
+                "--ignore", os.path.join(test_dir, "test_robustness_D_customer_journey.py"),
+                "--ignore", os.path.join(test_dir, "test_robustness_E_data_integrity.py"),
+                "--ignore", os.path.join(test_dir, "test_robustness_F_codegen_limits.py"),
+                "--ignore", os.path.join(test_dir, "test_robustness_G_resilience.py"),
+                "--ignore", os.path.join(test_dir, "test_robustness_H_protocol_precision.py"),
+                "--ignore", os.path.join(test_dir, "test_robustness_I_nrc_wdbi_sa.py"),
+                "--ignore", os.path.join(test_dir, "test_robustness_J_sovd_cda.py"),
+                "--ignore", os.path.join(test_dir, "test_robustness_K_error_quality.py"),
+                "--ignore", os.path.join(test_dir, "test_robustness_L_codegen_output_fidelity.py"),
+            ], cwd=test_dir, timeout=self.NESTED_PYTEST_TIMEOUT_S)
+        except subprocess.TimeoutExpired:
+            pytest.fail(
+                f"nested pytest timed out after {self.NESTED_PYTEST_TIMEOUT_S}s "
+                f"for {ecu} (test_dir={test_dir})")
         # Exit 5 = no tests ran (all skipped when xaloqi-tester absent); treat as pass
         assert r.returncode in (0, 5), (
             f"Generated pytest suite failed for {ecu}:\n{r.stdout[-3000:] + r.stderr[-1000:]}")


### PR DESCRIPTION
## Summary

`test_robustness_D_customer_journey.py`'s `TestAllECUExamplesPytest.test_ecu_pytest_simulator_all_pass` spawns a nested `pytest ... --can-interface=simulator` per example via the `_run()` helper (a thin `subprocess.run(..., capture_output=True, text=True)` wrapper) with **no `timeout=` anywhere**. Whatever bounded the run was whatever the outer test runner/CI happened to impose — environment-dependent, not deterministic. This is what hung the wrapper on the FreeRTOS sensor example in an external evaluator's environment, even though that example's suite completed cleanly (`109 skipped`) when run directly.

## Fix

Added an explicit `timeout=90` (seconds) to the nested `pytest` `_run()` call in `test_ecu_pytest_simulator_all_pass`, and now catch `subprocess.TimeoutExpired` there, failing with:

```
nested pytest timed out after 90s for {ecu} (test_dir=...)
```

— a message that reads as a timeout, distinct from a generic subprocess or assertion failure, per the issue's suggested fix.

### How 90s was picked (not a guess)

Measured real runtime first:
- `basic_ecu`'s suite driving all 11 examples sequentially: **98.71s / 11 ≈ 9s/example** average.
- Individual example runs measured directly: **5–9s** (`sensor_ecu_freertos` — the example named in the issue — measured 6.4s; `robot_joint_controller_ecu` was the slowest observed at 8.2s).

90s is ~10x the slowest observed per-example runtime, leaving generous headroom for slower/loaded CI environments (exactly the class of environment where this hung for the external evaluator).

## Verification

1. Full suite still passes with the new timeout in place: `11 passed in 96.39s`.
2. Per this repo's CLAUDE.md rule ("a new regression test isn't done until it has failed"): temporarily forced `NESTED_PYTEST_TIMEOUT_S` down to `0.01` in a scratch copy and confirmed the `TimeoutExpired` path actually fires and produces the intended message:
   ```
   Failed: nested pytest timed out after 0.01s for basic_ecu_doip_freertos (test_dir=...)
   ```
   (not a generic pytest/subprocess error) — then reverted to the real fix.
3. `bash build_tests.sh` gate: 44 passed, 0 failed.

## Scope correction: "12 places" → 1

The task brief for this fix assumed `test_robustness_D_customer_journey.py` is committed generated output duplicated identically across all 12 `examples/*/generated/tests/` directories (same class as prior template/committed-output drift findings O-27/O-37 in `xaloqi-knowledge/reviews/FINDINGS.md`). That's not the case here:

- Only **one copy exists in this repo**, at `examples/basic_ecu/generated/tests/test_robustness_D_customer_journey.py`.
- Its own header comment says: *"Manually written, not generated by testgen.py. Do not delete."* — it is not `tools/testgen.py`/`tools/templates` template output.
- It doesn't need a copy per example because `TestAllECUExamplesPytest` already drives all 11 other examples from this single file, reaching each one's `generated/tests` dir via `EDS_ROOT`-relative paths (`ALL_EXAMPLES` list).

So this PR fixes the one place the bug actually exists. **Flagging per the task brief, unverified**: if the private EDS-toolchain repo maintains its own mirror/golden-copy of this hand-written test file (as opposed to a per-example Jinja template), that copy would need the equivalent `timeout=`/`TimeoutExpired` fix too — I did not attempt this, it's a different (private) repo.

Fixes #153
