### PR TITLE
docs: clarify ISO-TP TX-confirmation contract + strengthen stack-allocation guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,6 +507,17 @@ jobs:
           fi
           echo "PASS: zero dynamic allocation in core/ transport/ config/ examples/basic_ecu/generated/"
 
+      # [#152] core/uds_types.h's EDS_MSG_BUF_MAX_STACK_BYTES _Static_assert
+      # documents its own limitation: it only checks sizeof(uds_msg_buf_t)
+      # against a configured threshold, which does not by itself catch a
+      # stack-declared uds_msg_buf_t (an integrator who raises the threshold,
+      # e.g. -DEDS_MSG_BUF_MAX_STACK_BYTES=8192 for a host build, gets zero
+      # protection from that check alone). This grep-based gate closes that
+      # gap for the runtime stack — see scripts/verify_no_stack_uds_msg_buf.sh
+      # for the exact pattern and its exclusions (comments, 'static' storage).
+      - name: Assert no stack-scoped uds_msg_buf_t declarations (#152)
+        run: bash scripts/verify_no_stack_uds_msg_buf.sh
+
       - name: Install build tools
         run: |
           sudo apt-get update -qq

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,52 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **CI guard: `uds_msg_buf_t` can no longer be silently stack-allocated
+  without a build failure.** (#152) `core/uds_types.h`'s
+  `EDS_MSG_BUF_MAX_STACK_BYTES` `_Static_assert` documents its own
+  limitation — it checks `sizeof(uds_msg_buf_t)` against a configured
+  threshold, which is necessary but not sufficient: an integrator who
+  raises the threshold for a host build (e.g.
+  `-DEDS_MSG_BUF_MAX_STACK_BYTES=8192`) got zero protection from it. New
+  `scripts/verify_no_stack_uds_msg_buf.sh`, wired into the
+  `integration-tests` CI job, greps `core/`, `transport/`, `platform/`, and
+  `config/` for non-static, non-comment `uds_msg_buf_t <name>;`
+  declarations — the shape of a stack (automatic-storage) local — and fails
+  the build if it finds one. Verified against a real positive case: a fake
+  stack-declared `uds_msg_buf_t` was temporarily added to
+  `platform/zephyr/zephyr_can.c`, confirmed to make the script fail with
+  the exact line flagged, then removed and confirmed clean again.
+
+### Documentation
+
+- **`can_transport_transmit()`'s CONFIRMED-vs-queued contract was
+  undocumented, even though ISO-TP's N_As/N_Ar timers depend entirely on
+  it.** (#152) `transport/can_transport.h` said only that a successful
+  return meant the frame "was accepted for transmission" — never whether
+  that meant queued into the driver or physically confirmed on the bus.
+  `transport/isotp.h`/`isotp.c` already treat `can_transport_transmit()`'s
+  return as the N_As/N_Ar transmission-confirmation event, so the actual
+  timing semantics depended on an unstated contract. Audited both platform
+  HALs: `platform/zephyr/zephyr_can.c` satisfies a CONFIRMED contract today
+  (`can_send()` with `callback=NULL` blocks until the controller confirms
+  the frame or a `K_MSEC(25)` timeout elapses); `platform/freertos/freertos_can.c`
+  is a thin, timing-agnostic pass-through to a customer-supplied
+  `eds_can_send_fn_t`, so its actual behavior depends on that customer
+  implementation — and `docs/INTEGRATION_GUIDE.md`'s own reference example
+  used a bare `HAL_CAN_AddTxMessage()` call, which returns as soon as the
+  frame is queued into a TX mailbox, silently defeating N_As/N_Ar for
+  anyone who copied it as-is. No shipped runtime-stack behavior needed to
+  change (the FreeRTOS shim itself is agnostic, not wrong), but the
+  documented contract and the guide's example did. Now: `can_transport.h`'s
+  `can_transmit_fn`/`can_transport_ops_t.transmit`/`can_transport_transmit()`
+  doc comments state the CONFIRMED contract explicitly, `isotp.h`'s N_As/N_Ar
+  notes cross-reference it, `platform_api.h`'s `eds_can_send_fn_t` doc states
+  the same requirement for customer FreeRTOS implementations, and
+  `INTEGRATION_GUIDE.md`'s example now polls for mailbox completion instead
+  of returning on enqueue, with a prominent contract callout above it.
+
 ### Security
 
 - **SecurityAccess stayed unlocked across an S3 inactivity timeout.** (#140)

--- a/core/uds_types.h
+++ b/core/uds_types.h
@@ -290,6 +290,15 @@ typedef struct uds_msg_buf {
  * The enforcement of "no stack allocation of this type" is a code-review
  * and MISRA-C Rule 18.8 concern; this check catches the common case of the
  * type being sized beyond any reasonable stack budget.
+ *
+ * [#152] "A code-review concern" now also has an automated backstop: CI runs
+ * scripts/verify_no_stack_uds_msg_buf.sh, a grep-based gate over core/,
+ * transport/, platform/, and config/ that fails the build on any non-static
+ * function-scope declaration of uds_msg_buf_t — exactly the case an
+ * integrator raising EDS_MSG_BUF_MAX_STACK_BYTES (above) would otherwise get
+ * zero protection against from this _Static_assert alone. It is, like this
+ * assert, necessary-but-not-sufficient (a plain grep, not a real parser) —
+ * see that script's header comment for its exact scope and limitations.
  */
 #ifndef EDS_MSG_BUF_MAX_STACK_BYTES
 #define EDS_MSG_BUF_MAX_STACK_BYTES  (256U)

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -526,6 +526,18 @@ Everything else (ISO-TP assembly, UDS dispatch, session management, security, DT
 
 #### Step 1 — Implement your CAN send function
 
+> **Contract: this callback must be CONFIRMED, not queued.** Do not return
+> `UDS_STATUS_OK` as soon as the frame is handed to a TX mailbox/queue — wait
+> until the controller confirms the frame was actually placed on the bus (or
+> the transmission has definitively failed). EDS's ISO-TP layer arms its
+> N_As/N_Ar timers (ISO 15765-2 Table 5, 25 ms by default) immediately before
+> calling this function and disarms them the instant it returns, so a
+> queued-only implementation silently defeats those timers instead of
+> failing loudly — see the contract note on `eds_can_send_fn_t` in
+> `platform_api.h`. This mirrors what the reference Zephyr port does (it
+> blocks in `can_send()` until the controller confirms the frame, up to a
+> 25 ms timeout).
+
 ```c
 #include "platform_api.h"
 
@@ -541,9 +553,23 @@ static uds_status_t my_can_send(const eds_can_frame_t *frame)
         .RTR   = CAN_RTR_DATA,
     };
     uint32_t mailbox;
+    uint32_t start_ms = HAL_GetTick();
+
     if (HAL_CAN_AddTxMessage(&hcan1, &hdr, frame->data, &mailbox) != HAL_OK) {
         return UDS_STATUS_ERR_CAN_TX_FAILED;
     }
+
+    /* HAL_CAN_AddTxMessage() only enqueues the frame into a TX mailbox — it
+     * does not wait for the bus to carry it. Poll the mailbox until it
+     * clears (confirmed) or the N_As/N_Ar budget elapses (failed). A
+     * production, interrupt-driven implementation should instead wait on a
+     * semaphore signalled from HAL_CAN_TxMailboxCompleteCallback(). */
+    while (HAL_CAN_IsTxMessagePending(&hcan1, mailbox)) {
+        if ((HAL_GetTick() - start_ms) > 20U) {
+            return UDS_STATUS_ERR_CAN_TX_FAILED;
+        }
+    }
+
     return UDS_STATUS_OK;
 }
 ```

--- a/platform/freertos/freertos_can.c
+++ b/platform/freertos/freertos_can.c
@@ -97,6 +97,16 @@ static bool s_initialized = false;
 
 /* --------------------------------------------------------------------------
  * can_transport_ops_t — transmit
+ *
+ * This shim is timing-agnostic: it forwards directly to the customer's
+ * s_can_send_fn() and returns whatever that function returns. It does NOT
+ * itself wait for or confirm transmission. Satisfying the CONFIRMED contract
+ * required by can_transport_transmit() (see transport/can_transport.h's
+ * can_transmit_fn doc) is therefore the responsibility of the registered
+ * eds_can_send_fn_t implementation — see its contract note in
+ * platform/platform_api.h. A customer callback that returns as soon as the
+ * frame is queued (not confirmed) silently defeats ISO-TP's N_As/N_Ar
+ * timers.
  * -------------------------------------------------------------------------- */
 
 static uds_status_t freertos_can_transmit(

--- a/platform/platform_api.h
+++ b/platform/platform_api.h
@@ -193,6 +193,25 @@ uint32_t eds_platform_uptime_ms(void);
  *
  * @param[in] frame  Frame to transmit.
  * @return UDS_STATUS_OK on success, UDS_STATUS_ERR_PLATFORM on failure.
+ *
+ * @note CONTRACT: This function sits directly behind can_transport_ops_t's
+ *       transmit member (platform/freertos/freertos_can.c's
+ *       freertos_can_transmit() is a thin, timing-agnostic pass-through to
+ *       whatever is registered here), so it must satisfy the same CONFIRMED
+ *       contract documented on transport/can_transport.h's can_transmit_fn
+ *       typedef: do not return UDS_STATUS_OK until the frame's transmission
+ *       is confirmed by the CAN controller, not merely handed to a TX
+ *       mailbox/queue. ISO-TP's N_As/N_Ar timers (transport/isotp.h) are
+ *       armed immediately before the call into this function and disarmed
+ *       the instant it returns, so a "queued-only" implementation (e.g. a
+ *       bare STM32 HAL_CAN_AddTxMessage() with no wait for the completion
+ *       event) silently defeats those timers instead of violating them
+ *       loudly. Bound the wait to the N_As/N_Ar budget (25 ms by default,
+ *       ISOTP_TIMEOUT_AS_MS / ISOTP_TIMEOUT_AR_MS) and return
+ *       UDS_STATUS_ERR_PLATFORM on expiry — mirroring how the reference
+ *       Zephyr port confirms transmission (platform/zephyr/zephyr_can.c
+ *       blocks in can_send() with a K_MSEC(25) timeout). See the corrected
+ *       FreeRTOS example in docs/INTEGRATION_GUIDE.md §4.2 Step 1.
  */
 typedef uds_status_t (*eds_can_send_fn_t)(const eds_can_frame_t *frame);
 

--- a/platform/zephyr/zephyr_can.c
+++ b/platform/zephyr/zephyr_can.c
@@ -180,7 +180,12 @@ static uds_status_t zephyr_can_transmit(
 #endif
     (void)memcpy(zf.data, frame->data, (size_t)frame->dlc);
 
-    /* Timeout = 25 ms = ISO 15765-2 N_As. */
+    /* CONFIRMED contract (transport/can_transport.h's can_transmit_fn):
+     * passing callback=NULL to can_send() makes this call synchronous — it
+     * blocks the caller until the controller confirms the frame was placed
+     * on the bus, or until the timeout elapses. That confirmation is what
+     * ISO-TP's N_As/N_Ar timers actually bound, so the timeout below is set
+     * to the N_As/N_Ar budget itself (25 ms = ISO 15765-2 N_As). */
     rc = can_send(plat->can_dev, &zf, K_MSEC(25), NULL, NULL);
 
     if (rc == -ENETDOWN) {

--- a/scripts/verify_no_stack_uds_msg_buf.sh
+++ b/scripts/verify_no_stack_uds_msg_buf.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Xaloqi EDS
+# scripts/verify_no_stack_uds_msg_buf.sh
+#
+# PURPOSE: CI gate for issue #152, part 2.
+#
+#          core/uds_types.h's EDS_MSG_BUF_MAX_STACK_BYTES _Static_assert
+#          documents its own limitation: it only checks sizeof(uds_msg_buf_t)
+#          against a configured threshold, which is necessary but NOT
+#          sufficient to catch a stack-allocated uds_msg_buf_t (4097 bytes by
+#          default) — an integrator who raises the threshold (e.g. to 8192 for
+#          a host build) gets zero protection from that check alone. This
+#          script is the "real check" the comment says is otherwise "a
+#          code-review... concern": a grep-based scan that flags any
+#          function-scope (stack) declaration of uds_msg_buf_t.
+#
+# SCOPE:   *.c files under core/ transport/ platform/ config/ (the runtime
+#          stack — see CONTRIBUTING.md's dual-license table). Header files are
+#          excluded deliberately: in this codebase uds_msg_buf_t only ever
+#          appears in headers as a struct member, a function parameter/return
+#          type, or a documentation-comment example — never as an executable
+#          declaration — so scoping to *.c is what "exclude header
+#          declarations" (issue #152) means in practice here.
+#
+# WHAT IS FLAGGED: a bare "uds_msg_buf_t <name>;" declaration — the shape a
+#          stack (automatic-storage) local variable takes. This excludes,
+#          by construction of the pattern:
+#            - pointers/parameters ("uds_msg_buf_t *req", "const uds_msg_buf_t *req")
+#            - function prototypes (they don't end the identifier in ';' alone
+#              on style used across this codebase, and are excluded by the
+#              'static' function-local exclusion below where relevant)
+#          and, by explicit filtering:
+#            - comment lines (documentation examples, e.g. uds_periodic.h)
+#            - anything declared 'static' — a static local has STATIC storage
+#              duration (it lives in .bss/.data, not on the stack) whether it
+#              is declared at file scope or inside a function body, so it is
+#              exactly the safe pattern this codebase uses everywhere
+#              (see core/uds_safety.c, platform/freertos/freertos_platform_api.c).
+#
+# LIMITATION: this is intentionally grep-based, not a real parser (per issue
+#          #152's own guidance — "keep it simple"). It cannot see across
+#          preprocessor conditionals or macro-generated declarations. It is a
+#          necessary-but-not-sufficient gate, same as the _Static_assert it
+#          complements — not a replacement for code review.
+#
+# USAGE:
+#   bash scripts/verify_no_stack_uds_msg_buf.sh
+#
+# EXIT CODES:
+#   0  No stack-scoped uds_msg_buf_t declarations found.
+#   1  One or more were found (or an unrecognised non-static, non-comment
+#      match was found that isn't in the KNOWN_SAFE allowlist below and
+#      needs a human to classify it).
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${ROOT}"
+
+# ---------------------------------------------------------------------------
+# Known-safe non-static occurrences, as "file:content" pairs — currently
+# empty because every non-static match in *.c today is a false positive this
+# script already filters (comments/static). If a future legitimate case can't
+# be expressed by those filters (e.g. a struct member declared inside a .c
+# file), add an exact "path/to/file.c:<trimmed line text>" entry here with a
+# comment explaining why it's safe, rather than loosening the pattern.
+# ---------------------------------------------------------------------------
+KNOWN_SAFE=(
+)
+
+SCAN_DIRS=(core transport platform config)
+PATTERN='uds_msg_buf_t[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*;'
+
+echo ""
+echo "================================================================"
+echo "  Xaloqi EDS — uds_msg_buf_t stack-allocation guard (issue #152)"
+echo "================================================================"
+echo ""
+echo "Scanning *.c under: ${SCAN_DIRS[*]}"
+echo "Pattern: ${PATTERN}"
+echo ""
+
+matches="$(grep -rnE "${PATTERN}" --include='*.c' "${SCAN_DIRS[@]}" 2>/dev/null || true)"
+
+fail=0
+checked=0
+
+while IFS= read -r m; do
+    [ -z "${m}" ] && continue
+    checked=$((checked + 1))
+
+    file="${m%%:*}"
+    rest="${m#*:}"
+    content="${rest#*:}"
+
+    trimmed="$(printf '%s' "${content}" | sed -e 's/^[[:space:]]*//')"
+
+    # Skip comment lines (doc examples such as core/uds_periodic.h's sample
+    # "static uds_msg_buf_t s_periodic_frame;" inside a /** ... */ block).
+    case "${trimmed}" in
+        '*'*|'//'*|'/*'*)
+            continue
+            ;;
+    esac
+
+    # Skip anything with static storage duration — file-scope or
+    # function-local 'static' is not stack allocation.
+    case "${trimmed}" in
+        static*)
+            continue
+            ;;
+    esac
+
+    # Anything left is a non-static, non-comment "uds_msg_buf_t <name>;" —
+    # exactly the shape of a stack (automatic storage) declaration. Allow it
+    # only if explicitly allowlisted as a known-safe case.
+    allowed=0
+    for safe in "${KNOWN_SAFE[@]:-}"; do
+        [ -z "${safe}" ] && continue
+        if [ "${file}:${trimmed}" = "${safe}" ]; then
+            allowed=1
+            break
+        fi
+    done
+
+    if [ "${allowed}" -eq 1 ]; then
+        continue
+    fi
+
+    echo "FAIL: possible stack-scoped uds_msg_buf_t declaration"
+    echo "      ${m}"
+    fail=1
+done <<< "${matches}"
+
+echo "Checked ${checked} raw match(es)."
+echo ""
+
+if [ "${fail}" -ne 0 ]; then
+    echo "================================================================"
+    echo "  FAIL: stack-allocation guard found a non-static, non-comment"
+    echo "  'uds_msg_buf_t <name>;' declaration outside the known-safe set."
+    echo ""
+    echo "  uds_msg_buf_t is UDS_MAX_PAYLOAD_LEN + 2 bytes (4097 by default)."
+    echo "  Allocating it on a task's stack risks silent stack corruption or"
+    echo "  an MPU fault. Use a 'static' (file-scope or function-local)"
+    echo "  declaration instead — see core/uds_safety.c or"
+    echo "  platform/freertos/freertos_platform_api.c for the pattern, and"
+    echo "  core/uds_types.h's EDS_MSG_BUF_MAX_STACK_BYTES comment for the"
+    echo "  full rationale."
+    echo "================================================================"
+    exit 1
+fi
+
+echo "PASS: no stack-scoped uds_msg_buf_t declarations found."
+exit 0

--- a/transport/can_transport.h
+++ b/transport/can_transport.h
@@ -52,11 +52,39 @@ typedef struct can_transport can_transport_t;
  * @param[in] self   Pointer to the CAN transport instance.
  * @param[in] frame  CAN frame to transmit.
  *
- * @return UDS_STATUS_OK if frame was accepted for transmission.
- * @return UDS_STATUS_ERR_CAN_TX_FAILED if transmission failed.
+ * @return UDS_STATUS_OK once transmission of this frame is CONFIRMED —
+ *         accepted by the CAN controller / physically placed on the bus —
+ *         not merely enqueued into a driver queue or TX mailbox.
+ * @return UDS_STATUS_ERR_CAN_TX_FAILED if transmission failed or the
+ *         confirmation wait exceeded the timeout below.
  * @return UDS_STATUS_ERR_CAN_BUS_OFF if controller is in bus-off state.
  *
- * @note TIMING: Must not block indefinitely. Non-blocking preferred.
+ * @note CONTRACT: This is the CONFIRMED contract, not a "queued" one.
+ *       transport/isotp.c arms ISO 15765-2 N_As/N_Ar (the sender/receiver
+ *       "transmission confirmation" timers, ISO 15765-2:2016 Table 5)
+ *       immediately before calling this function and disarms them the
+ *       instant it returns — so a return of UDS_STATUS_OK IS, at this
+ *       layer, the transmission-confirmation event the ISO-TP timers exist
+ *       to bound. An implementation that returns as soon as the frame is
+ *       merely queued (e.g. handed to a TX mailbox without waiting for the
+ *       controller to actually place it on the bus) silently defeats N_As/
+ *       N_Ar: the timer is armed and disarmed before the real transmission
+ *       has happened or failed, so it can never catch a stuck or lost frame.
+ *       See transport/isotp.h's N_As/N_Ar notes on isotp_tick_1ms() for how
+ *       the timers consume this return.
+ * @note TIMING: Must not block indefinitely — bound the confirmation wait
+ *       to (at most) the ISO_TP N_As/N_Ar budget (ISOTP_TIMEOUT_AS_MS /
+ *       ISOTP_TIMEOUT_AR_MS in transport/isotp.h, 25 ms by default) and
+ *       return UDS_STATUS_ERR_CAN_TX_FAILED on expiry. Bounded blocking is
+ *       expected and is how the reference Zephyr port satisfies this
+ *       contract (platform/zephyr/zephyr_can.c calls can_send() with a
+ *       K_MSEC(25) timeout and no async callback, which blocks the caller
+ *       until the controller confirms the frame or the timeout elapses).
+ *       A platform that instead reports success on enqueue only (e.g. a
+ *       bare "add to TX mailbox" HAL call with no wait for the completion
+ *       event) does NOT satisfy this contract even though it never blocks
+ *       indefinitely — see docs/INTEGRATION_GUIDE.md's FreeRTOS CAN send
+ *       example for the corrected pattern.
  * @note SAFETY: ASIL-B relevant — transmission failure must be reported.
  */
 typedef uds_status_t (*can_transmit_fn)(
@@ -101,7 +129,12 @@ typedef uds_status_t (*can_get_status_fn)(
  * the ISO-TP layer at initialization time.
  */
 typedef struct can_transport_ops {
-    can_transmit_fn    transmit;    /**< Required: frame transmission function. */
+    can_transmit_fn    transmit;    /**< Required: frame transmission function.
+                                      *   CONFIRMED contract — must not return
+                                      *   UDS_STATUS_OK until the frame is
+                                      *   confirmed transmitted, not merely
+                                      *   queued. See can_transmit_fn's doc
+                                      *   comment above. */
     can_receive_fn     receive;     /**< Required: frame reception poll function. */
     can_get_status_fn  get_status;  /**< Required: controller status query. */
 } can_transport_ops_t;
@@ -132,10 +165,17 @@ struct can_transport {
  * @param[in] can    Initialized CAN transport instance.
  * @param[in] frame  CAN frame to transmit.
  *
- * @return UDS_STATUS_OK on success.
+ * @return UDS_STATUS_OK once the frame's transmission is CONFIRMED (not
+ *         merely queued) — this call forwards directly to ops->transmit(),
+ *         which defines and must satisfy the CONFIRMED contract documented
+ *         on the can_transmit_fn typedef above. Callers (transport/isotp.c)
+ *         rely on this: ISO-TP's N_As/N_Ar timers are armed immediately
+ *         before this call and disarmed the instant it returns, treating
+ *         that return as the transmission-confirmation event.
  * @return UDS_STATUS_ERR_NULL_PTR if any pointer is NULL.
  * @return UDS_STATUS_ERR_CAN_NOT_READY if transport not ready.
- * @return Return value of ops->transmit() otherwise.
+ * @return Return value of ops->transmit() otherwise (e.g.
+ *         UDS_STATUS_ERR_CAN_TX_FAILED, UDS_STATUS_ERR_CAN_BUS_OFF).
  */
 uds_status_t can_transport_transmit(
     can_transport_t       *can,

--- a/transport/isotp.h
+++ b/transport/isotp.h
@@ -40,6 +40,12 @@ extern "C" {
  * that frame's transmission confirmation. It is NOT a whole-transfer
  * watchdog: the wait for a Flow Control frame is bounded by
  * ISOTP_TIMEOUT_BS_MS and the consecutive-frame cadence by STmin.
+ *
+ * "Transmission confirmation" is, at this layer, can_transport_transmit()
+ * returning UDS_STATUS_OK — see the CONFIRMED contract documented on
+ * transport/can_transport.h's can_transmit_fn typedef. Every platform CAN
+ * HAL (can_transport_ops_t.transmit) must satisfy that contract for this
+ * timer to mean what its name says.
  */
 #ifndef ISOTP_TIMEOUT_AS_MS
 #define ISOTP_TIMEOUT_AS_MS   (25U)
@@ -55,6 +61,10 @@ extern "C" {
  * when the FC N_PDU is passed to the data link layer and stops on that
  * frame's transmission confirmation. It is NOT the wait for consecutive
  * frames — that window is ISOTP_TIMEOUT_CR_MS.
+ *
+ * As with N_As above, "transmission confirmation" means
+ * can_transport_transmit() returning UDS_STATUS_OK under the CONFIRMED
+ * contract in transport/can_transport.h.
  */
 #ifndef ISOTP_TIMEOUT_AR_MS
 #define ISOTP_TIMEOUT_AR_MS   (25U)
@@ -363,7 +373,9 @@ uds_status_t isotp_transmit(
  *
  * @note As is scoped to one frame's transmission confirmation and is stopped
  *       by the TX path as soon as can_transport_transmit() returns, so it does
- *       not bound the FC wait (Bs) or a multi-frame CF sequence (STmin).
+ *       not bound the FC wait (Bs) or a multi-frame CF sequence (STmin). This
+ *       is only meaningful because can_transport_transmit() is CONFIRMED, not
+ *       queued — see transport/can_transport.h's can_transmit_fn contract.
  * @note Ar is the receiver-side mirror of As, scoped to the Flow Control
  *       frame's transmission confirmation and stopped by isotp_send_fc() as
  *       soon as can_transport_transmit() returns. It does not bound the wait


### PR DESCRIPTION
Fixes #152

## Summary

Two independent, low-risk hardening fixes surfaced by an external qualification audit. Both turned out to be documentation-clarity fixes, not runtime-stack behavior changes — but Part 1's audit surfaced a real, worth-flagging finding (see below).

## Part 1 — `can_transport_transmit()` TX-confirmation contract

**Finding: the two platforms do NOT disagree in shipped code, but the FreeRTOS integration guide's own reference example demonstrated the wrong contract.**

Audited both platform HALs as instructed:

- **`platform/zephyr/zephyr_can.c`** — CONFIRMED semantics today. `zephyr_can_transmit()` calls `can_send(dev, &zf, K_MSEC(25), NULL, NULL)`. Passing `callback=NULL` to Zephyr's CAN API makes the call synchronous: it blocks the calling thread until the controller confirms the frame was placed on the bus, or until the 25 ms timeout elapses (`isotp.c`'s own pre-existing comment at line ~746 already documented this: *"can_transport_transmit() is permitted to block (the Zephyr port blocks in can_send() for up to K_MSEC(25))"*). This is exactly the confirmation event ISO-TP's N_As/N_Ar (ISO 15765-2 Table 5) are scoped to.
- **`platform/freertos/freertos_can.c`** — `freertos_can_transmit()` is a thin, timing-agnostic pass-through to a customer-supplied `eds_can_send_fn_t` (`s_can_send_fn(&ef)`). It does not itself enforce any confirmation semantics — that responsibility falls entirely on the integrator's callback, and `platform_api.h`'s `eds_can_send_fn_t` doc previously said only "Must be callable from task context," with no statement about queued-vs-confirmed timing.
- **The concrete, customer-facing artifact that *does* demonstrate a contract** is `docs/INTEGRATION_GUIDE.md`'s `my_can_send()` example, which used a bare `HAL_CAN_AddTxMessage()` call — this STM32 HAL function only enqueues the frame into a TX mailbox and returns immediately; it does **not** wait for the controller to actually place the frame on the bus. Any integrator who copy-pasted this example as-is would get N_As/N_Ar timers that are armed and disarmed almost instantly regardless of whether the frame was ever really transmitted — silently defeating the very timers the ISO-TP layer relies on to catch a stuck or lost frame, with no loud failure anywhere.

Per the issue's instruction ("do NOT change behavior unless the two platforms actually disagree... flag that specific finding prominently"): the shipped runtime-stack HAL code doesn't disagree (`freertos_can.c` is agnostic, not wrong), so no behavior change was made there. But the guide's example was actively teaching the wrong contract, so it's fixed here (docs-only, not runtime-stack code) rather than just flagged.

**Changes:**
- `transport/can_transport.h` — explicit CONFIRMED-contract doc comments on the `can_transmit_fn` typedef, the `can_transport_ops_t.transmit` vtable member, and `can_transport_transmit()`'s own doc.
- `transport/isotp.h` — N_As/N_Ar doc-comment cross-references to the now-explicit contract (comment-only; no signature or logic changes; this file is adjacent to CONTRIBUTING.md's heightened-review list for `transport/isotp.c`, so I treated it with the same care and made no functional edits).
- `platform/platform_api.h` — `eds_can_send_fn_t`'s doc now states the same CONFIRMED requirement for customer FreeRTOS implementations, with the N_As/N_Ar budget (25 ms) as the bound to honor.
- `platform/freertos/freertos_can.c` — comment above `freertos_can_transmit()` stating it's a pass-through and where the real contract obligation lives.
- `platform/zephyr/zephyr_can.c` — comment explaining why `can_send(..., NULL, NULL)` already satisfies the contract.
- `docs/INTEGRATION_GUIDE.md` — the `my_can_send()` example now polls `HAL_CAN_IsTxMessagePending()` for mailbox completion instead of returning on enqueue, with a prominent contract callout above it.

No changes to `transport/isotp.c` (heightened-review file — untouched) or to any platform HAL's actual transmit *logic* (only added comments).

## Part 2 — stack-allocation guard for `uds_msg_buf_t`

`core/uds_types.h`'s `EDS_MSG_BUF_MAX_STACK_BYTES` `_Static_assert` already documented its own limitation: it's a necessary-but-not-sufficient check against `sizeof(uds_msg_buf_t)`, and an integrator who raises the threshold (e.g. `-DEDS_MSG_BUF_MAX_STACK_BYTES=8192` for a host build) gets zero real protection from it alone.

Added `scripts/verify_no_stack_uds_msg_buf.sh`, wired into the `integration-tests` CI job right after the existing "Assert zero dynamic allocation" step. It greps `*.c` under `core/`, `transport/`, `platform/`, `config/` for `uds_msg_buf_t <name>;`-shaped declarations, then filters out comment lines and anything with `static` storage duration (file-scope or function-local — neither is stack allocation). Anything left fails the build.

**Verified against a real positive case**, per the issue's instructions:
1. Ran the script clean → `PASS: no stack-scoped uds_msg_buf_t declarations found.`
2. Temporarily added `uds_msg_buf_t fake_stack_buf;` inside `zephyr_can_transmit()` in `platform/zephyr/zephyr_can.c`.
3. Re-ran the script → it failed with exit code 1 and named the exact injected line:
   ```
   FAIL: possible stack-scoped uds_msg_buf_t declaration
         platform/zephyr/zephyr_can.c:140:    uds_msg_buf_t          fake_stack_buf;  /* [TEST-INJECT-152] fake positive case */
   ```
4. Removed the fake declaration, confirmed `git diff` was clean, re-ran the script → clean pass again.

Also cross-referenced from `core/uds_types.h`'s existing comment so the documented limitation now points at its automated backstop.

## Testing

- `bash build_tests.sh` → **44/44 passing** (both before and after all changes).
- New CI script manually run clean and against the injected positive case (above).
- `.github/workflows/ci.yml` validated with `python3 -c "import yaml; yaml.safe_load(...)"`.
- `bash -n scripts/verify_no_stack_uds_msg_buf.sh` — syntax check.

## Notes for reviewer

- Both parts turned out to be doc/small-code changes as the issue anticipated — no behavior change to the shipped runtime stack.
- `transport/isotp.c` was not touched.
- The one "real finding" is the `docs/INTEGRATION_GUIDE.md` example mismatch described above under Part 1 — flagging it explicitly here as requested, even though the fix for it is a docs change rather than a stack-code behavior change.
