### PR TITLE
fix(uds): SID 0x19 sub-functions 0x0B/0x19 implement the wrong ISO 14229-1 sub-function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,32 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 All four found and fixed during the 2026-08-31 validation campaign; see
 `xaloqi-knowledge/campaigns/2026-08-31-validation-campaign.md`.
 
+- **SID 0x19 (ReadDTCInformation): sub-functions 0x0B and 0x19 implemented
+  the wrong ISO 14229-1 sub-function.** (#148) `core/uds_services/service_0x19.c`
+  defined `SVC_0x19_SUBFN_REPORT_FAULT_DETECTION_CTR` as `0x0BU` and
+  `SVC_0x19_SUBFN_REPORT_DTC_PERMANENT_STATUS` as `0x19U`. Per ISO 14229-1
+  Table 239, 0x0B is actually `reportFirstTestFailedDTC` (§11.3.11) and 0x19
+  is `reportUserDefMemoryDTCExtDataRecordByDTCNumber` — neither implemented
+  by this ECU; `reportDTCFaultDetectionCounter` is really sub-function 0x14
+  (§11.3.20) and `reportDTCWithPermanentStatus` is really 0x15 (§11.3.25). A
+  real UDS tester sending the standard 0x14/0x15 got "sub-function not
+  supported," while 0x0B/0x19 — which the standard defines as entirely
+  different services — got this ECU's reinterpretation of them. Fixed by
+  renumbering the two existing (behaviorally correct) handlers to their
+  ISO-correct codes 0x14 and 0x15; 0x0B and 0x19 now fall through to the
+  same "sub-function not supported" response as every other unimplemented
+  sub-function in the dispatch switch (reportFirstTestFailedDTC and
+  reportUserDefMemoryDTCExtDataRecordByDTCNumber remain unimplemented — out
+  of scope for this fix). Updated the hand-written
+  `tests/unit_runnable/test_service_0x19.c` regression suite and the
+  generated `test_report_fault_detection_counter_sub0b` /
+  `test_report_dtc_permanent_status_sub19` tests (renamed to `..._sub14` /
+  `..._sub15`) across all 11 `examples/*/generated/tests/test_services.py`
+  files that carry them. Found while triaging #145. The private
+  EDS-toolchain template that generates `test_services.py` needs the
+  equivalent fix so future codegen doesn't regenerate the wrong values;
+  filed as a follow-up note in the fix PR, not fixed here (different repo).
+
 ### Documentation
 
 - **The Requirements Traceability Matrix and MISRA Deviation Log counts in

--- a/core/uds_services/service_0x19.c
+++ b/core/uds_services/service_0x19.c
@@ -45,6 +45,17 @@
  *     Response: [0x59, 0x0A, availabilityMask, {dtc3B, statusByte}...]
  *     Returns all registered DTCs regardless of status.
  *
+ *   0x14 — reportDTCFaultDetectionCounter (ISO 14229-1 §11.3.20)
+ *     Request : [0x19, 0x14]
+ *     Response: [0x59, 0x14, {dtc3B, faultDetectionCounter}...]
+ *     Returns pre-confirmed (testFailed==0) DTCs with counter < 0xFF.
+ *     No DTCStatusAvailabilityMask byte in this response.
+ *
+ *   0x15 — reportDTCWithPermanentStatus (ISO 14229-1 §11.3.25)
+ *     Request : [0x19, 0x15]
+ *     Response: [0x59, 0x15, availabilityMask, {dtc3B, statusByte}...]
+ *     Returns DTCs marked permanent (is_permanent == true).
+ *
  * DTC FORMAT IN RESPONSES (ISO 14229-1 §D.2):
  *   [DTC_HB, DTC_MB, DTC_LB, statusByte] — 4 bytes per DTC
  *   DTC bytes are the 3 most-significant bytes of the 24-bit DTC code.
@@ -80,8 +91,8 @@
 #define SVC_0x19_SUBFN_REPORT_DTC_SNAPSHOT_BY_DTC    (0x04U)
 #define SVC_0x19_SUBFN_REPORT_DTC_EXT_DATA_BY_DTC    (0x06U)
 #define SVC_0x19_SUBFN_REPORT_SUPPORTED_DTCS         (0x0AU)
-#define SVC_0x19_SUBFN_REPORT_FAULT_DETECTION_CTR    (0x0BU)
-#define SVC_0x19_SUBFN_REPORT_DTC_PERMANENT_STATUS   (0x19U)
+#define SVC_0x19_SUBFN_REPORT_FAULT_DETECTION_CTR    (0x14U)
+#define SVC_0x19_SUBFN_REPORT_DTC_PERMANENT_STATUS   (0x15U)
 
 /** suppressPosRspMsgIndicationBit mask for sub-function byte. */
 #define SVC_0x19_SUPPRESS_BIT                         (0x80U)
@@ -110,8 +121,8 @@
 /**
  * @brief Fault detection counter value that indicates a confirmed DTC.
  *
- * ISO 14229-1 §11.3.11: counter value 0xFF is reserved for DTCs that are
- * already confirmed. Such DTCs are excluded from the 0x0B response.
+ * ISO 14229-1 §11.3.20: counter value 0xFF is reserved for DTCs that are
+ * already confirmed. Such DTCs are excluded from the 0x14 response.
  */
 #define SVC_0x19_FDC_CONFIRMED                        (0xFFU)
 
@@ -417,16 +428,18 @@ static uds_status_t handle_report_supported_dtcs(
 }
 
 /**
- * 0x0B — reportDTCFaultDetectionCounter
+ * 0x14 — reportDTCFaultDetectionCounter
  *
- * Request : [0x19, 0x0B]
- * Response: [0x59, 0x0B, {dtcHB, dtcMB, dtcLB, faultDetectionCounter}...]
+ * Request : [0x19, 0x14]
+ * Response: [0x59, 0x14, {dtcHB, dtcMB, dtcLB, faultDetectionCounter}...]
+ *
+ * ISO 14229-1 §11.3.20.
  *
  * Returns a 4-byte record for each DTC where testFailed == 0 (not yet
  * confirmed) and whose fault_detection_counter < 0xFF.
  *
  * NOTE: No DTCStatusAvailabilityMask byte in this response — ISO 14229-1
- *       §11.3.11 response format differs from 0x01/0x02/0x0A.
+ *       §11.3.20 response format differs from 0x01/0x02/0x0A.
  */
 static uds_status_t handle_report_fault_detection_counter(
     const uds_msg_buf_t *req,
@@ -466,7 +479,7 @@ static uds_status_t handle_report_fault_detection_counter(
             continue;
         }
 
-        /* 0xFF is reserved (confirmed) — exclude per ISO 14229-1 §11.3.11 */
+        /* 0xFF is reserved (confirmed) — exclude per ISO 14229-1 §11.3.20 */
         if (entry->fault_detection_counter == (uint8_t)SVC_0x19_FDC_CONFIRMED) {
             continue;
         }
@@ -482,10 +495,12 @@ static uds_status_t handle_report_fault_detection_counter(
 }
 
 /**
- * 0x19 — reportDTCWithPermanentStatus
+ * 0x15 — reportDTCWithPermanentStatus
  *
- * Request : [0x19, 0x19]
- * Response: [0x59, 0x19, availabilityMask, {dtcHB, dtcMB, dtcLB, statusByte}...]
+ * Request : [0x19, 0x15]
+ * Response: [0x59, 0x15, availabilityMask, {dtcHB, dtcMB, dtcLB, statusByte}...]
+ *
+ * ISO 14229-1 §11.3.25.
  *
  * Returns all DTCs marked permanent (is_permanent == true). These DTCs
  * are not clearable by SID 0x14 — only by application-driven drive-cycle

--- a/examples/ardep_ecu/generated/tests/test_services.py
+++ b/examples/ardep_ecu/generated/tests/test_services.py
@@ -397,18 +397,18 @@ class TestReadDTCInformation:
             f"DTC section length {dtc_section_len} is not a multiple of 4"
         )
 
-    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_fault_detection_counter_sub14(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
-        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Sub 0x14 (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.20.
+        Response: [0x59, 0x14, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
         Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x14]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x14 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x14, f"sub-function echo must be 0x14, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 2, "response must be at least 2 bytes"
         # No availability mask — DTC section starts at byte 2, stride 4
         dtc_section_len = len(pdu) - 2
@@ -417,18 +417,18 @@ class TestReadDTCInformation:
             f"(3-byte DTC code + 1-byte counter per record)"
         )
 
-    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_dtc_permanent_status_sub15(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
-        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Sub 0x15 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x15, availMask, {dtc3B, statusByte}...]
         Empty list (3 bytes) is valid when no DTCs are marked permanent.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x15]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x15 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x15, f"sub-function echo must be 0x15, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
         # DTC section after availability mask byte
         dtc_section_len = len(pdu) - 3

--- a/examples/basic_ecu/generated/tests/test_services.py
+++ b/examples/basic_ecu/generated/tests/test_services.py
@@ -397,18 +397,18 @@ class TestReadDTCInformation:
             f"DTC section length {dtc_section_len} is not a multiple of 4"
         )
 
-    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_fault_detection_counter_sub14(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
-        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Sub 0x14 (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.20.
+        Response: [0x59, 0x14, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
         Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x14]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x14 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x14, f"sub-function echo must be 0x14, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 2, "response must be at least 2 bytes"
         # No availability mask — DTC section starts at byte 2, stride 4
         dtc_section_len = len(pdu) - 2
@@ -417,18 +417,18 @@ class TestReadDTCInformation:
             f"(3-byte DTC code + 1-byte counter per record)"
         )
 
-    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_dtc_permanent_status_sub15(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
-        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Sub 0x15 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x15, availMask, {dtc3B, statusByte}...]
         Empty list (3 bytes) is valid when no DTCs are marked permanent.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x15]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x15 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x15, f"sub-function echo must be 0x15, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
         # DTC section after availability mask byte
         dtc_section_len = len(pdu) - 3

--- a/examples/basic_ecu_doip/generated/tests/test_services.py
+++ b/examples/basic_ecu_doip/generated/tests/test_services.py
@@ -397,18 +397,18 @@ class TestReadDTCInformation:
             f"DTC section length {dtc_section_len} is not a multiple of 4"
         )
 
-    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_fault_detection_counter_sub14(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
-        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Sub 0x14 (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.20.
+        Response: [0x59, 0x14, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
         Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x14]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x14 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x14, f"sub-function echo must be 0x14, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 2, "response must be at least 2 bytes"
         # No availability mask — DTC section starts at byte 2, stride 4
         dtc_section_len = len(pdu) - 2
@@ -417,18 +417,18 @@ class TestReadDTCInformation:
             f"(3-byte DTC code + 1-byte counter per record)"
         )
 
-    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_dtc_permanent_status_sub15(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
-        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Sub 0x15 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x15, availMask, {dtc3B, statusByte}...]
         Empty list (3 bytes) is valid when no DTCs are marked permanent.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x15]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x15 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x15, f"sub-function echo must be 0x15, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
         # DTC section after availability mask byte
         dtc_section_len = len(pdu) - 3

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_services.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_services.py
@@ -397,18 +397,18 @@ class TestReadDTCInformation:
             f"DTC section length {dtc_section_len} is not a multiple of 4"
         )
 
-    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_fault_detection_counter_sub14(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
-        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Sub 0x14 (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.20.
+        Response: [0x59, 0x14, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
         Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x14]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x14 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x14, f"sub-function echo must be 0x14, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 2, "response must be at least 2 bytes"
         # No availability mask — DTC section starts at byte 2, stride 4
         dtc_section_len = len(pdu) - 2
@@ -417,18 +417,18 @@ class TestReadDTCInformation:
             f"(3-byte DTC code + 1-byte counter per record)"
         )
 
-    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_dtc_permanent_status_sub15(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
-        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Sub 0x15 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x15, availMask, {dtc3B, statusByte}...]
         Empty list (3 bytes) is valid when no DTCs are marked permanent.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x15]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x15 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x15, f"sub-function echo must be 0x15, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
         # DTC section after availability mask byte
         dtc_section_len = len(pdu) - 3

--- a/examples/basic_ecu_freertos/generated/tests/test_services.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_services.py
@@ -397,18 +397,18 @@ class TestReadDTCInformation:
             f"DTC section length {dtc_section_len} is not a multiple of 4"
         )
 
-    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_fault_detection_counter_sub14(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
-        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Sub 0x14 (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.20.
+        Response: [0x59, 0x14, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
         Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x14]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x14 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x14, f"sub-function echo must be 0x14, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 2, "response must be at least 2 bytes"
         # No availability mask — DTC section starts at byte 2, stride 4
         dtc_section_len = len(pdu) - 2
@@ -417,18 +417,18 @@ class TestReadDTCInformation:
             f"(3-byte DTC code + 1-byte counter per record)"
         )
 
-    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_dtc_permanent_status_sub15(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
-        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Sub 0x15 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x15, availMask, {dtc3B, statusByte}...]
         Empty list (3 bytes) is valid when no DTCs are marked permanent.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x15]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x15 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x15, f"sub-function echo must be 0x15, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
         # DTC section after availability mask byte
         dtc_section_len = len(pdu) - 3

--- a/examples/bms_ecu/generated/tests/test_services.py
+++ b/examples/bms_ecu/generated/tests/test_services.py
@@ -397,18 +397,18 @@ class TestReadDTCInformation:
             f"DTC section length {dtc_section_len} is not a multiple of 4"
         )
 
-    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_fault_detection_counter_sub14(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
-        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Sub 0x14 (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.20.
+        Response: [0x59, 0x14, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
         Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x14]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x14 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x14, f"sub-function echo must be 0x14, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 2, "response must be at least 2 bytes"
         # No availability mask — DTC section starts at byte 2, stride 4
         dtc_section_len = len(pdu) - 2
@@ -417,18 +417,18 @@ class TestReadDTCInformation:
             f"(3-byte DTC code + 1-byte counter per record)"
         )
 
-    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_dtc_permanent_status_sub15(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
-        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Sub 0x15 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x15, availMask, {dtc3B, statusByte}...]
         Empty list (3 bytes) is valid when no DTCs are marked permanent.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x15]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x15 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x15, f"sub-function echo must be 0x15, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
         # DTC section after availability mask byte
         dtc_section_len = len(pdu) - 3

--- a/examples/motor_controller_ecu/generated/tests/test_services.py
+++ b/examples/motor_controller_ecu/generated/tests/test_services.py
@@ -397,18 +397,18 @@ class TestReadDTCInformation:
             f"DTC section length {dtc_section_len} is not a multiple of 4"
         )
 
-    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_fault_detection_counter_sub14(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
-        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Sub 0x14 (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.20.
+        Response: [0x59, 0x14, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
         Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x14]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x14 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x14, f"sub-function echo must be 0x14, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 2, "response must be at least 2 bytes"
         # No availability mask — DTC section starts at byte 2, stride 4
         dtc_section_len = len(pdu) - 2
@@ -417,18 +417,18 @@ class TestReadDTCInformation:
             f"(3-byte DTC code + 1-byte counter per record)"
         )
 
-    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_dtc_permanent_status_sub15(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
-        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Sub 0x15 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x15, availMask, {dtc3B, statusByte}...]
         Empty list (3 bytes) is valid when no DTCs are marked permanent.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x15]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x15 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x15, f"sub-function echo must be 0x15, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
         # DTC section after availability mask byte
         dtc_section_len = len(pdu) - 3

--- a/examples/robot_joint_controller_ecu/generated/tests/test_services.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_services.py
@@ -397,18 +397,18 @@ class TestReadDTCInformation:
             f"DTC section length {dtc_section_len} is not a multiple of 4"
         )
 
-    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_fault_detection_counter_sub14(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
-        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Sub 0x14 (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.20.
+        Response: [0x59, 0x14, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
         Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x14]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x14 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x14, f"sub-function echo must be 0x14, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 2, "response must be at least 2 bytes"
         # No availability mask — DTC section starts at byte 2, stride 4
         dtc_section_len = len(pdu) - 2
@@ -417,18 +417,18 @@ class TestReadDTCInformation:
             f"(3-byte DTC code + 1-byte counter per record)"
         )
 
-    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_dtc_permanent_status_sub15(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
-        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Sub 0x15 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x15, availMask, {dtc3B, statusByte}...]
         Empty list (3 bytes) is valid when no DTCs are marked permanent.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x15]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x15 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x15, f"sub-function echo must be 0x15, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
         # DTC section after availability mask byte
         dtc_section_len = len(pdu) - 3

--- a/examples/safeboot_ecu/generated/tests/test_services.py
+++ b/examples/safeboot_ecu/generated/tests/test_services.py
@@ -397,18 +397,18 @@ class TestReadDTCInformation:
             f"DTC section length {dtc_section_len} is not a multiple of 4"
         )
 
-    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_fault_detection_counter_sub14(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
-        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Sub 0x14 (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.20.
+        Response: [0x59, 0x14, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
         Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x14]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x14 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x14, f"sub-function echo must be 0x14, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 2, "response must be at least 2 bytes"
         # No availability mask — DTC section starts at byte 2, stride 4
         dtc_section_len = len(pdu) - 2
@@ -417,18 +417,18 @@ class TestReadDTCInformation:
             f"(3-byte DTC code + 1-byte counter per record)"
         )
 
-    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_dtc_permanent_status_sub15(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
-        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Sub 0x15 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x15, availMask, {dtc3B, statusByte}...]
         Empty list (3 bytes) is valid when no DTCs are marked permanent.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x15]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x15 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x15, f"sub-function echo must be 0x15, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
         # DTC section after availability mask byte
         dtc_section_len = len(pdu) - 3

--- a/examples/sensor_ecu/generated/tests/test_services.py
+++ b/examples/sensor_ecu/generated/tests/test_services.py
@@ -397,18 +397,18 @@ class TestReadDTCInformation:
             f"DTC section length {dtc_section_len} is not a multiple of 4"
         )
 
-    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_fault_detection_counter_sub14(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
-        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Sub 0x14 (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.20.
+        Response: [0x59, 0x14, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
         Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x14]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x14 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x14, f"sub-function echo must be 0x14, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 2, "response must be at least 2 bytes"
         # No availability mask — DTC section starts at byte 2, stride 4
         dtc_section_len = len(pdu) - 2
@@ -417,18 +417,18 @@ class TestReadDTCInformation:
             f"(3-byte DTC code + 1-byte counter per record)"
         )
 
-    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_dtc_permanent_status_sub15(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
-        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Sub 0x15 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x15, availMask, {dtc3B, statusByte}...]
         Empty list (3 bytes) is valid when no DTCs are marked permanent.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x15]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x15 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x15, f"sub-function echo must be 0x15, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
         # DTC section after availability mask byte
         dtc_section_len = len(pdu) - 3

--- a/examples/sensor_ecu_freertos/generated/tests/test_services.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_services.py
@@ -397,18 +397,18 @@ class TestReadDTCInformation:
             f"DTC section length {dtc_section_len} is not a multiple of 4"
         )
 
-    def test_report_fault_detection_counter_sub0b(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_fault_detection_counter_sub14(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x0B (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.11.
-        Response: [0x59, 0x0B, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
+        Sub 0x14 (reportDTCFaultDetectionCounter) — ISO 14229-1 §11.3.20.
+        Response: [0x59, 0x14, {dtc3B, counter}...] — no DTCStatusAvailabilityMask.
         Empty list (2 bytes) is valid when no DTCs are in pre-confirmed state.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x0B]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x14]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x0B not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x14 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x0B, f"sub-function echo must be 0x0B, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x14, f"sub-function echo must be 0x14, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 2, "response must be at least 2 bytes"
         # No availability mask — DTC section starts at byte 2, stride 4
         dtc_section_len = len(pdu) - 2
@@ -417,18 +417,18 @@ class TestReadDTCInformation:
             f"(3-byte DTC code + 1-byte counter per record)"
         )
 
-    def test_report_dtc_permanent_status_sub19(self, uds_bus: IsoTpTransport) -> None:
+    def test_report_dtc_permanent_status_sub15(self, uds_bus: IsoTpTransport) -> None:
         """
-        Sub 0x19 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
-        Response: [0x59, 0x19, availMask, {dtc3B, statusByte}...]
+        Sub 0x15 (reportDTCWithPermanentStatus) — ISO 14229-1 §11.3.25.
+        Response: [0x59, 0x15, availMask, {dtc3B, statusByte}...]
         Empty list (3 bytes) is valid when no DTCs are marked permanent.
         """
-        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x19]))
+        pdu = uds_bus.request(bytes([SID_READ_DTC_INFO, 0x15]))
         assert pdu is not None
         if pdu[0] == SID_NEGATIVE_RESPONSE:
-            pytest.skip(f"ReadDTCInformation 0x19 not available (NRC 0x{pdu[2]:02X})")
+            pytest.skip(f"ReadDTCInformation 0x15 not available (NRC 0x{pdu[2]:02X})")
         assert pdu[0] == (SID_READ_DTC_INFO + POSITIVE_RESPONSE_OFFSET)
-        assert pdu[1] == 0x19, f"sub-function echo must be 0x19, got 0x{pdu[1]:02X}"
+        assert pdu[1] == 0x15, f"sub-function echo must be 0x15, got 0x{pdu[1]:02X}"
         assert len(pdu) >= 3, "response must be at least 3 bytes (RSID + sub + availMask)"
         # DTC section after availability mask byte
         dtc_section_len = len(pdu) - 3

--- a/tests/unit_runnable/test_service_0x19.c
+++ b/tests/unit_runnable/test_service_0x19.c
@@ -655,7 +655,7 @@ ZTEST(test_service_0x19, tc025_null_req)
         "NULL req must return ERR_NULL_PTR");
 }
 
-/* ---- Sub-function 0x0B — reportDTCFaultDetectionCounter --------------- */
+/* ---- Sub-function 0x14 — reportDTCFaultDetectionCounter --------------- */
 
 /**
  * TC-0x19-026: All DTCs have testFailed=1 → nothing qualifies → 2-byte response.
@@ -672,7 +672,7 @@ ZTEST(test_service_0x19, tc026_fdc_all_test_failed_empty)
     uds_msg_buf_t req;
     memset(&req, 0, sizeof(req));
     req.data[0] = 0x19U;
-    req.data[1] = 0x0BU;
+    req.data[1] = 0x14U;
     req.length  = 2U;
 
     uds_msg_buf_t resp = {0};
@@ -680,7 +680,7 @@ ZTEST(test_service_0x19, tc026_fdc_all_test_failed_empty)
 
     zassert_equal(rc, UDS_STATUS_OK, "must return OK even with empty result");
     zassert_equal(resp.data[0], 0x59U, "response SID must be 0x59");
-    zassert_equal(resp.data[1], 0x0BU, "echo sub-function must be 0x0B");
+    zassert_equal(resp.data[1], 0x14U, "echo sub-function must be 0x14");
     zassert_equal(resp.length, 2U, "no qualifying DTCs → 2-byte header only");
 }
 
@@ -700,7 +700,7 @@ ZTEST(test_service_0x19, tc027_fdc_qualifying_dtc_returned)
     uds_msg_buf_t req;
     memset(&req, 0, sizeof(req));
     req.data[0] = 0x19U;
-    req.data[1] = 0x0BU;
+    req.data[1] = 0x14U;
     req.length  = 2U;
 
     uds_msg_buf_t resp = {0};
@@ -712,8 +712,8 @@ ZTEST(test_service_0x19, tc027_fdc_qualifying_dtc_returned)
 }
 
 /**
- * TC-0x19-028: Response header for 0x0B is [0x59, 0x0B] — NO availability mask.
- * ISO 14229-1 §11.3.11 response differs from 0x01/0x02/0x0A.
+ * TC-0x19-028: Response header for 0x14 is [0x59, 0x14] — NO availability mask.
+ * ISO 14229-1 §11.3.20 response differs from 0x01/0x02/0x0A.
  */
 ZTEST(test_service_0x19, tc028_fdc_no_availability_mask_in_header)
 {
@@ -722,14 +722,14 @@ ZTEST(test_service_0x19, tc028_fdc_no_availability_mask_in_header)
     uds_msg_buf_t req;
     memset(&req, 0, sizeof(req));
     req.data[0] = 0x19U;
-    req.data[1] = 0x0BU;
+    req.data[1] = 0x14U;
     req.length  = 2U;
 
     uds_msg_buf_t resp = {0};
     uds_service_0x19_handler(&g_srv, &req, &resp);
 
     zassert_equal(resp.data[0], 0x59U, "response SID must be 0x59");
-    zassert_equal(resp.data[1], 0x0BU, "echo sub-function must be 0x0B");
+    zassert_equal(resp.data[1], 0x14U, "echo sub-function must be 0x14");
     /* data[2] is first byte of first DTC record (or not present if empty list),
      * NOT an availability mask. Verify header length is exactly 2. */
     zassert_true(resp.length >= 2U, "response must be at least 2 bytes");
@@ -748,7 +748,7 @@ ZTEST(test_service_0x19, tc029_fdc_counter_ff_excluded)
     uds_msg_buf_t req;
     memset(&req, 0, sizeof(req));
     req.data[0] = 0x19U;
-    req.data[1] = 0x0BU;
+    req.data[1] = 0x14U;
     req.length  = 2U;
 
     uds_msg_buf_t resp = {0};
@@ -760,7 +760,7 @@ ZTEST(test_service_0x19, tc029_fdc_counter_ff_excluded)
 }
 
 /**
- * TC-0x19-030: Counter byte in 0x0B record matches value set via set_fault_counter.
+ * TC-0x19-030: Counter byte in 0x14 record matches value set via set_fault_counter.
  */
 ZTEST(test_service_0x19, tc030_fdc_counter_value_in_record)
 {
@@ -772,7 +772,7 @@ ZTEST(test_service_0x19, tc030_fdc_counter_value_in_record)
     uds_msg_buf_t req;
     memset(&req, 0, sizeof(req));
     req.data[0] = 0x19U;
-    req.data[1] = 0x0BU;
+    req.data[1] = 0x14U;
     req.length  = 2U;
 
     uds_msg_buf_t resp = {0};
@@ -786,7 +786,7 @@ ZTEST(test_service_0x19, tc030_fdc_counter_value_in_record)
 }
 
 /**
- * TC-0x19-031: Sub-function 0x0B with request length 1 → ERR_INVALID_PARAM.
+ * TC-0x19-031: Sub-function 0x14 with request length 1 → ERR_INVALID_PARAM.
  */
 ZTEST(test_service_0x19, tc031_fdc_short_request_rejected)
 {
@@ -804,7 +804,7 @@ ZTEST(test_service_0x19, tc031_fdc_short_request_rejected)
         "request with no sub-function byte must be rejected");
 }
 
-/* ---- Sub-function 0x19 — reportDTCWithPermanentStatus ----------------- */
+/* ---- Sub-function 0x15 — reportDTCWithPermanentStatus ----------------- */
 
 /**
  * TC-0x19-032: No permanent DTCs registered → 3-byte response only.
@@ -817,7 +817,7 @@ ZTEST(test_service_0x19, tc032_permanent_empty_list)
     uds_msg_buf_t req;
     memset(&req, 0, sizeof(req));
     req.data[0] = 0x19U;
-    req.data[1] = 0x19U;
+    req.data[1] = 0x15U;
     req.length  = 2U;
 
     uds_msg_buf_t resp = {0};
@@ -839,7 +839,7 @@ ZTEST(test_service_0x19, tc033_permanent_dtc_returned)
     uds_msg_buf_t req;
     memset(&req, 0, sizeof(req));
     req.data[0] = 0x19U;
-    req.data[1] = 0x19U;
+    req.data[1] = 0x15U;
     req.length  = 2U;
 
     uds_msg_buf_t resp = {0};
@@ -857,7 +857,7 @@ ZTEST(test_service_0x19, tc033_permanent_dtc_returned)
 }
 
 /**
- * TC-0x19-034: Response header for 0x19: [0x59, 0x19, 0xFF (availability mask)].
+ * TC-0x19-034: Response header for 0x15: [0x59, 0x15, 0xFF (availability mask)].
  */
 ZTEST(test_service_0x19, tc034_permanent_response_header)
 {
@@ -866,14 +866,14 @@ ZTEST(test_service_0x19, tc034_permanent_response_header)
     uds_msg_buf_t req;
     memset(&req, 0, sizeof(req));
     req.data[0] = 0x19U;
-    req.data[1] = 0x19U;
+    req.data[1] = 0x15U;
     req.length  = 2U;
 
     uds_msg_buf_t resp = {0};
     uds_service_0x19_handler(&g_srv, &req, &resp);
 
     zassert_equal(resp.data[0], 0x59U, "response SID must be 0x59");
-    zassert_equal(resp.data[1], 0x19U, "echo sub-function must be 0x19");
+    zassert_equal(resp.data[1], 0x15U, "echo sub-function must be 0x15");
     zassert_equal(resp.data[2], 0xFFU, "availability mask must be 0xFF");
 }
 


### PR DESCRIPTION
## Summary

Fixes #148. `core/uds_services/service_0x19.c` (SID 0x19, ReadDTCInformation)
had two sub-functions implemented under the wrong ISO 14229-1 codes:

- `SVC_0x19_SUBFN_REPORT_FAULT_DETECTION_CTR` was `0x0BU`, doc'd as
  `reportDTCFaultDetectionCounter`. Per Table 239, 0x0B is actually
  `reportFirstTestFailedDTC` (§11.3.11); `reportDTCFaultDetectionCounter`
  is really **0x14** (§11.3.20).
- `SVC_0x19_SUBFN_REPORT_DTC_PERMANENT_STATUS` was `0x19U`, doc'd as
  `reportDTCWithPermanentStatus`. Per the standard, 0x19 is actually
  `reportUserDefMemoryDTCExtDataRecordByDTCNumber`; `reportDTCWithPermanentStatus`
  is really **0x15** (§11.3.25).

Net effect: a real tester sending the standard 0x14/0x15 got "sub-function
not supported," while 0x0B/0x19 — which ISO defines as entirely different
services — got this ECU's reinterpretation of them.

## Fix

Renumbered the constants so the existing, behaviorally-correct handler
bodies move to their ISO-correct codes (0x14, 0x15). `reportFirstTestFailedDTC`
(0x0B) and `reportUserDefMemoryDTCExtDataRecordByDTCNumber` (0x19) are **not**
implemented here — out of scope; the dispatch `switch` now falls through to
the standard "sub-function not supported" response for those codes, same as
every other unimplemented sub-function. Doc comments and ISO clause citations
updated to match (§11.3.11 removed from the fault-detection-counter function
since it no longer applies there).

## Tests

- `tests/unit_runnable/test_service_0x19.c`: TC-0x19-026..034 re-pointed at
  0x14/0x15.
- `examples/*/generated/tests/test_services.py` (11 examples — ardep_ecu,
  basic_ecu, basic_ecu_doip, basic_ecu_doip_freertos, basic_ecu_freertos,
  bms_ecu, motor_controller_ecu, robot_joint_controller_ecu, safeboot_ecu,
  sensor_ecu, sensor_ecu_freertos): `test_report_fault_detection_counter_sub0b`
  → `..._sub14`, `test_report_dtc_permanent_status_sub19` → `..._sub15`,
  request/assertion bytes and ISO clause updated to match. These are
  committed generated output; I don't have access to the private
  EDS-toolchain template that produces `test_services.py`, so hand-edited
  directly. **Follow-up note (different repo, not fixed here):** the
  EDS-toolchain template needs the equivalent fix so future codegen doesn't
  regenerate the old wrong sub-function values.

### Regression-test verification (per this repo's "a new test isn't done
until it has failed" lesson)

Reverted only `core/uds_services/service_0x19.c` to pre-fix (test file left
updated) and reran:

```
test_service_0x19                              FAIL
  [FAIL] test_service_0x19__tc026_fdc_all_test_failed_empty
  [FAIL] test_service_0x19__tc027_fdc_qualifying_dtc_returned
  [FAIL] test_service_0x19__tc028_fdc_no_availability_mask_in_header
  [FAIL] test_service_0x19__tc029_fdc_counter_ff_excluded
  [FAIL] test_service_0x19__tc030_fdc_counter_value_in_record
  [FAIL] test_service_0x19__tc032_permanent_empty_list
  [FAIL] test_service_0x19__tc033_permanent_dtc_returned
  [FAIL] test_service_0x19__tc034_permanent_response_header
```

Failure message names the real defect, not an unrelated error:

```
tests/unit_runnable/test_service_0x19.c:681: Expected 81 but got 0 ((UDS_STATUS_OK))
```

`81` = `0x51` = `UDS_STATUS_ERR_SUBFUNCTION_NOT_SUP` — i.e. the pre-fix code
genuinely rejects the ISO-correct sub-function codes 0x14/0x15, exactly the
bug in #148. Restored the fix: `44 passed, 0 failed`.

### Before / after (`bash build_tests.sh`)

- Pre-fix core + updated tests: `43 passed, 1 failed` (test_service_0x19,
  8 sub-tests failing as above)
- Post-fix (this PR): `44 passed, 0 failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
