### PR TITLE
fix: build_harness.sh only ever built one generic harness hardcoded to basic_ecu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,39 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   than a "fixture not found" — is tracked as
   [#144](https://github.com/Xaloqi/EDS/issues/144), not fixed here.)
 
-All four found and fixed during the 2026-08-31 validation campaign; see
+- **`build_harness.sh` only ever built one generic harness, hardcoded to
+  `basic_ecu`'s generated sources — every other example's firmware-backed
+  tests failed on protocol mismatch, not a real defect.** (#144) Once #143
+  made `firmware_bus` reachable, running `test_firmware_services.py
+  --firmware` for any example besides the `basic_ecu` family compiled and
+  launched a harness binary built from `examples/basic_ecu/generated/{did_
+  handlers,did_safety_wrappers,routine_handlers}.c` regardless of which
+  example's tests were actually running — e.g. `sensor_ecu` failed 20 of 60
+  tests with wrong DID content, wrong routine IDs, and a wrong DTC set,
+  because it was really talking to basic_ecu's firmware. `build_harness.sh`
+  now takes a `--example <name>` flag (or `EXAMPLE` env var, default
+  `basic_ecu`) and builds against that example's own `generated/` sources
+  and include path; the default output binary is now
+  `/tmp/harness_ecu_test_<example>` so builds for different examples never
+  collide or clobber each other's cached binary. `conftest_firmware.py`'s
+  `harness_binary()` / `build_harness()` derive their own example name from
+  `Path(__file__)` (they already live inside
+  `examples/<name>/generated/tests/`) rather than requiring a caller to
+  specify it, and stay session-scoped — one build per example's own test
+  session is still correct. Verified by building and running
+  `--firmware` for `basic_ecu` (56 passed, 1 skipped, unchanged) and all 10
+  other examples with a `tests/` dir: every DID/routine protocol-mismatch
+  failure is gone. `sensor_ecu`, `motor_controller_ecu`, `ardep_ecu`,
+  `bms_ecu`, `robot_joint_controller_ecu`, and `safeboot_ecu` each now
+  fail only on DTC-registration assertions, traced to a separate,
+  narrower pre-existing bug — `harness/harness_ecu.c` hardcodes DTC
+  registration to `basic_ecu`'s two DTCs regardless of example — tracked as
+  [#158](https://github.com/Xaloqi/EDS/issues/158); `sensor_ecu` and
+  `sensor_ecu_freertos` additionally hit a hardcoded byte-count in a
+  generated WriteDID test, tracked as
+  [#160](https://github.com/Xaloqi/EDS/issues/160). Neither is fixed here.
+
+All five found and fixed during the 2026-08-31 validation campaign; see
 `xaloqi-knowledge/campaigns/2026-08-31-validation-campaign.md`.
 
 ### Documentation

--- a/build_harness.sh
+++ b/build_harness.sh
@@ -9,41 +9,90 @@
 # -Wduplicated-cond -Wimplicit-fallthrough=5 (zero warnings on all sources).
 #
 # Usage:
-#   ./build_harness.sh              # Build only (MISRA-clean flags)
-#   ./build_harness.sh --run        # Build and run all 68 integration tests
-#   ./build_harness.sh --run --hw   # Build for AF_CAN hardware (vcan0)
-#   ./build_harness.sh --fast       # Build without Wpedantic (faster CI)
+#   ./build_harness.sh                        # Build only (MISRA-clean flags)
+#   ./build_harness.sh --run                  # Build and run all 68 integration tests
+#   ./build_harness.sh --run --hw             # Build for AF_CAN hardware (vcan0)
+#   ./build_harness.sh --fast                 # Build without Wpedantic (faster CI)
+#   ./build_harness.sh --example sensor_ecu   # Build against examples/sensor_ecu/generated
+#                                              # instead of the default (basic_ecu). The
+#                                              # EXAMPLE env var works the same way.
 #
 # Requirements:
 #   gcc, pthreads (standard Linux development toolchain, gcc >= 8 recommended)
 #   For --hw mode: Linux with SocketCAN + vcan module loaded
 #
 # Output:
-#   /tmp/harness_ecu_test  (override with OUTPUT=/path/to/binary)
+#   /tmp/harness_ecu_test_<example>  (override with OUTPUT=/path/to/binary)
 # =============================================================================
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="${SCRIPT_DIR}"
-OUTPUT="${OUTPUT:-/tmp/harness_ecu_test}"
+EXAMPLE="${EXAMPLE:-basic_ecu}"
 HW_MODE=0
 RUN_MODE=0
 FAST_MODE=0
 
-for arg in "$@"; do
-    case "$arg" in
-        --run)  RUN_MODE=1  ;;
-        --hw)   HW_MODE=1   ;;
-        --fast) FAST_MODE=1 ;;
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --run)  RUN_MODE=1;  shift ;;
+        --hw)   HW_MODE=1;   shift ;;
+        --fast) FAST_MODE=1; shift ;;
+        --example)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --example requires a value, e.g. --example sensor_ecu" >&2
+                exit 1
+            fi
+            EXAMPLE="$2"
+            shift 2
+            ;;
+        --example=*)
+            EXAMPLE="${1#--example=}"
+            shift
+            ;;
         --help)
-            echo "Usage: $0 [--run] [--hw] [--fast]"
-            echo "  --run   Build then execute all 68 integration tests"
-            echo "  --hw    Build with AF_CAN hardware support (Linux+SocketCAN)"
-            echo "  --fast  Omit -Wpedantic for faster incremental CI builds"
+            echo "Usage: $0 [--run] [--hw] [--fast] [--example <name>]"
+            echo "  --run             Build then execute all integration tests"
+            echo "  --hw              Build with AF_CAN hardware support (Linux+SocketCAN)"
+            echo "  --fast            Omit -Wpedantic for faster incremental CI builds"
+            echo "  --example <name>  Build against examples/<name>/generated instead of"
+            echo "                    the default (basic_ecu). EXAMPLE env var also works."
             exit 0
+            ;;
+        *)
+            shift
             ;;
     esac
 done
+
+# ---------------------------------------------------------------------------
+# Resolve which example's generated/ sources to build against (issue #144:
+# this used to be hardcoded to basic_ecu for every example, so any other
+# example's firmware-backed tests silently ran against basic_ecu's binary).
+# ---------------------------------------------------------------------------
+EXAMPLE_GENERATED="${ROOT}/examples/${EXAMPLE}/generated"
+
+if [[ ! -d "${EXAMPLE_GENERATED}" ]]; then
+    echo "ERROR: examples/${EXAMPLE}/generated not found." >&2
+    echo "" >&2
+    echo "Available examples:" >&2
+    for d in "${ROOT}"/examples/*/; do
+        [[ -d "${d}generated" ]] && echo "  - $(basename "${d%/}")" >&2
+    done
+    exit 1
+fi
+
+if [[ ! -f "${EXAMPLE_GENERATED}/did_handlers.c" ]]; then
+    echo "ERROR: ${EXAMPLE_GENERATED}/did_handlers.c not found." >&2
+    echo "" >&2
+    echo "Regenerate it with:" >&2
+    echo "  python3 tools/codegen.py \\" >&2
+    echo "             --config examples/${EXAMPLE}/diagnostics_config.yaml \\" >&2
+    echo "             --out examples/${EXAMPLE}/generated/ --safety-wrappers --asil-level B --no-manifest" >&2
+    exit 1
+fi
+
+OUTPUT="${OUTPUT:-/tmp/harness_ecu_test_${EXAMPLE}}"
 
 # ---------------------------------------------------------------------------
 # Harness sources are a Professional-tier deliverable (issue #68).
@@ -112,9 +161,9 @@ STACK_SRCS=(
     "$ROOT/config/dtc_database.c"
     "$ROOT/config/dtc_mirror.c"
     "$ROOT/config/routine_database.c"
-    "$ROOT/examples/basic_ecu/generated/did_handlers.c"
-    "$ROOT/examples/basic_ecu/generated/did_safety_wrappers.c"
-    "$ROOT/examples/basic_ecu/generated/routine_handlers.c"
+    "$ROOT/examples/${EXAMPLE}/generated/did_handlers.c"
+    "$ROOT/examples/${EXAMPLE}/generated/did_safety_wrappers.c"
+    "$ROOT/examples/${EXAMPLE}/generated/routine_handlers.c"
     "$ROOT/platform/zephyr/nvm_store_mock.c"
     "$ROOT/platform/uds_flash_ops.c"
     "$ROOT/platform/zephyr/harness_flash_mock.c"
@@ -131,7 +180,7 @@ INCLUDES=(
     "-I$ROOT/config"
     "-I$ROOT/platform"
     "-I$ROOT/platform/zephyr"
-    "-I$ROOT/examples/basic_ecu/generated"
+    "-I$ROOT/examples/${EXAMPLE}/generated"
     "-I$ROOT/harness"
     "-I$ROOT/tests/mocks"
     "-I$ROOT/tests/runner"
@@ -180,7 +229,7 @@ fi
 # ---------------------------------------------------------------------------
 ALL_SRCS=("${HARNESS_SRCS[@]}" "${STACK_SRCS[@]}")
 
-echo "[build_harness] Phase 7 MISRA-clean build..."
+echo "[build_harness] Phase 7 MISRA-clean build (example: ${EXAMPLE})..."
 gcc "${CFLAGS[@]}" "${INCLUDES[@]}" "${ALL_SRCS[@]}" \
     -lpthread \
     -o "$OUTPUT"

--- a/examples/ardep_ecu/generated/tests/conftest_firmware.py
+++ b/examples/ardep_ecu/generated/tests/conftest_firmware.py
@@ -293,23 +293,34 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # Root of the repository (two levels up from generated/tests/)
 _REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
+# This example's own name, e.g. "sensor_ecu" for
+# examples/sensor_ecu/generated/tests/conftest_firmware.py. Derived from our
+# own location rather than hardcoded, so the harness is always built against
+# *this* example's generated/ sources instead of a fixed example (#144).
+_EXAMPLE_NAME: str = Path(__file__).resolve().parent.parent.parent.name
 
-def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
+
+def build_harness(repo_root: Path = _REPO_ROOT, example: str = _EXAMPLE_NAME) -> Path:
     """
-    Build the harness binary using build_harness.sh.
+    Build the harness binary using build_harness.sh, against `example`'s own
+    generated/ sources (see #144 — this used to always build basic_ecu's
+    sources regardless of which example's tests were running).
 
     Returns the path to the compiled binary.
     Raises RuntimeError if the build fails.
     """
-    binary = Path("/tmp/harness_ecu_test")
+    # Per-example binary name/path: builds for different examples (e.g. run
+    # in parallel, or leftover from a previous run) never collide or clobber
+    # each other's cached binary.
+    binary = Path(f"/tmp/harness_ecu_test_{example}")
     build_script = repo_root / "build_harness.sh"
 
     if not build_script.exists():
         raise RuntimeError(f"build_harness.sh not found at {build_script}")
 
-    log.info("Building harness binary...")
+    log.info("Building harness binary for example '%s'...", example)
     result = subprocess.run(
-        ["bash", str(build_script), "--fast"],
+        ["bash", str(build_script), "--fast", "--example", example],
         capture_output=True,
         text=True,
         cwd=str(repo_root),
@@ -317,7 +328,7 @@ def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"Harness build failed (rc={result.returncode}):\n"
+            f"Harness build failed for example '{example}' (rc={result.returncode}):\n"
             f"STDOUT:\n{result.stdout}\n"
             f"STDERR:\n{result.stderr}"
         )
@@ -548,7 +559,7 @@ class FirmwareIsoTpTransport:
 def harness_binary() -> Path:
     """Build the harness binary once per session. Skips if build fails."""
     try:
-        binary = build_harness(_REPO_ROOT)
+        binary = build_harness(_REPO_ROOT, _EXAMPLE_NAME)
         assert binary.exists(), f"Harness binary not found after build: {binary}"
         return binary
     except Exception as exc:

--- a/examples/basic_ecu/generated/tests/conftest_firmware.py
+++ b/examples/basic_ecu/generated/tests/conftest_firmware.py
@@ -293,23 +293,34 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # Root of the repository (two levels up from generated/tests/)
 _REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
+# This example's own name, e.g. "sensor_ecu" for
+# examples/sensor_ecu/generated/tests/conftest_firmware.py. Derived from our
+# own location rather than hardcoded, so the harness is always built against
+# *this* example's generated/ sources instead of a fixed example (#144).
+_EXAMPLE_NAME: str = Path(__file__).resolve().parent.parent.parent.name
 
-def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
+
+def build_harness(repo_root: Path = _REPO_ROOT, example: str = _EXAMPLE_NAME) -> Path:
     """
-    Build the harness binary using build_harness.sh.
+    Build the harness binary using build_harness.sh, against `example`'s own
+    generated/ sources (see #144 — this used to always build basic_ecu's
+    sources regardless of which example's tests were running).
 
     Returns the path to the compiled binary.
     Raises RuntimeError if the build fails.
     """
-    binary = Path("/tmp/harness_ecu_test")
+    # Per-example binary name/path: builds for different examples (e.g. run
+    # in parallel, or leftover from a previous run) never collide or clobber
+    # each other's cached binary.
+    binary = Path(f"/tmp/harness_ecu_test_{example}")
     build_script = repo_root / "build_harness.sh"
 
     if not build_script.exists():
         raise RuntimeError(f"build_harness.sh not found at {build_script}")
 
-    log.info("Building harness binary...")
+    log.info("Building harness binary for example '%s'...", example)
     result = subprocess.run(
-        ["bash", str(build_script), "--fast"],
+        ["bash", str(build_script), "--fast", "--example", example],
         capture_output=True,
         text=True,
         cwd=str(repo_root),
@@ -317,7 +328,7 @@ def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"Harness build failed (rc={result.returncode}):\n"
+            f"Harness build failed for example '{example}' (rc={result.returncode}):\n"
             f"STDOUT:\n{result.stdout}\n"
             f"STDERR:\n{result.stderr}"
         )
@@ -548,7 +559,7 @@ class FirmwareIsoTpTransport:
 def harness_binary() -> Path:
     """Build the harness binary once per session. Skips if build fails."""
     try:
-        binary = build_harness(_REPO_ROOT)
+        binary = build_harness(_REPO_ROOT, _EXAMPLE_NAME)
         assert binary.exists(), f"Harness binary not found after build: {binary}"
         return binary
     except Exception as exc:

--- a/examples/basic_ecu_doip/generated/tests/conftest_firmware.py
+++ b/examples/basic_ecu_doip/generated/tests/conftest_firmware.py
@@ -293,23 +293,34 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # Root of the repository (two levels up from generated/tests/)
 _REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
+# This example's own name, e.g. "sensor_ecu" for
+# examples/sensor_ecu/generated/tests/conftest_firmware.py. Derived from our
+# own location rather than hardcoded, so the harness is always built against
+# *this* example's generated/ sources instead of a fixed example (#144).
+_EXAMPLE_NAME: str = Path(__file__).resolve().parent.parent.parent.name
 
-def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
+
+def build_harness(repo_root: Path = _REPO_ROOT, example: str = _EXAMPLE_NAME) -> Path:
     """
-    Build the harness binary using build_harness.sh.
+    Build the harness binary using build_harness.sh, against `example`'s own
+    generated/ sources (see #144 — this used to always build basic_ecu's
+    sources regardless of which example's tests were running).
 
     Returns the path to the compiled binary.
     Raises RuntimeError if the build fails.
     """
-    binary = Path("/tmp/harness_ecu_test")
+    # Per-example binary name/path: builds for different examples (e.g. run
+    # in parallel, or leftover from a previous run) never collide or clobber
+    # each other's cached binary.
+    binary = Path(f"/tmp/harness_ecu_test_{example}")
     build_script = repo_root / "build_harness.sh"
 
     if not build_script.exists():
         raise RuntimeError(f"build_harness.sh not found at {build_script}")
 
-    log.info("Building harness binary...")
+    log.info("Building harness binary for example '%s'...", example)
     result = subprocess.run(
-        ["bash", str(build_script), "--fast"],
+        ["bash", str(build_script), "--fast", "--example", example],
         capture_output=True,
         text=True,
         cwd=str(repo_root),
@@ -317,7 +328,7 @@ def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"Harness build failed (rc={result.returncode}):\n"
+            f"Harness build failed for example '{example}' (rc={result.returncode}):\n"
             f"STDOUT:\n{result.stdout}\n"
             f"STDERR:\n{result.stderr}"
         )
@@ -548,7 +559,7 @@ class FirmwareIsoTpTransport:
 def harness_binary() -> Path:
     """Build the harness binary once per session. Skips if build fails."""
     try:
-        binary = build_harness(_REPO_ROOT)
+        binary = build_harness(_REPO_ROOT, _EXAMPLE_NAME)
         assert binary.exists(), f"Harness binary not found after build: {binary}"
         return binary
     except Exception as exc:

--- a/examples/basic_ecu_doip_freertos/generated/tests/conftest_firmware.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/conftest_firmware.py
@@ -293,23 +293,34 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # Root of the repository (two levels up from generated/tests/)
 _REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
+# This example's own name, e.g. "sensor_ecu" for
+# examples/sensor_ecu/generated/tests/conftest_firmware.py. Derived from our
+# own location rather than hardcoded, so the harness is always built against
+# *this* example's generated/ sources instead of a fixed example (#144).
+_EXAMPLE_NAME: str = Path(__file__).resolve().parent.parent.parent.name
 
-def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
+
+def build_harness(repo_root: Path = _REPO_ROOT, example: str = _EXAMPLE_NAME) -> Path:
     """
-    Build the harness binary using build_harness.sh.
+    Build the harness binary using build_harness.sh, against `example`'s own
+    generated/ sources (see #144 — this used to always build basic_ecu's
+    sources regardless of which example's tests were running).
 
     Returns the path to the compiled binary.
     Raises RuntimeError if the build fails.
     """
-    binary = Path("/tmp/harness_ecu_test")
+    # Per-example binary name/path: builds for different examples (e.g. run
+    # in parallel, or leftover from a previous run) never collide or clobber
+    # each other's cached binary.
+    binary = Path(f"/tmp/harness_ecu_test_{example}")
     build_script = repo_root / "build_harness.sh"
 
     if not build_script.exists():
         raise RuntimeError(f"build_harness.sh not found at {build_script}")
 
-    log.info("Building harness binary...")
+    log.info("Building harness binary for example '%s'...", example)
     result = subprocess.run(
-        ["bash", str(build_script), "--fast"],
+        ["bash", str(build_script), "--fast", "--example", example],
         capture_output=True,
         text=True,
         cwd=str(repo_root),
@@ -317,7 +328,7 @@ def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"Harness build failed (rc={result.returncode}):\n"
+            f"Harness build failed for example '{example}' (rc={result.returncode}):\n"
             f"STDOUT:\n{result.stdout}\n"
             f"STDERR:\n{result.stderr}"
         )
@@ -548,7 +559,7 @@ class FirmwareIsoTpTransport:
 def harness_binary() -> Path:
     """Build the harness binary once per session. Skips if build fails."""
     try:
-        binary = build_harness(_REPO_ROOT)
+        binary = build_harness(_REPO_ROOT, _EXAMPLE_NAME)
         assert binary.exists(), f"Harness binary not found after build: {binary}"
         return binary
     except Exception as exc:

--- a/examples/basic_ecu_freertos/generated/tests/conftest_firmware.py
+++ b/examples/basic_ecu_freertos/generated/tests/conftest_firmware.py
@@ -293,23 +293,34 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # Root of the repository (two levels up from generated/tests/)
 _REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
+# This example's own name, e.g. "sensor_ecu" for
+# examples/sensor_ecu/generated/tests/conftest_firmware.py. Derived from our
+# own location rather than hardcoded, so the harness is always built against
+# *this* example's generated/ sources instead of a fixed example (#144).
+_EXAMPLE_NAME: str = Path(__file__).resolve().parent.parent.parent.name
 
-def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
+
+def build_harness(repo_root: Path = _REPO_ROOT, example: str = _EXAMPLE_NAME) -> Path:
     """
-    Build the harness binary using build_harness.sh.
+    Build the harness binary using build_harness.sh, against `example`'s own
+    generated/ sources (see #144 — this used to always build basic_ecu's
+    sources regardless of which example's tests were running).
 
     Returns the path to the compiled binary.
     Raises RuntimeError if the build fails.
     """
-    binary = Path("/tmp/harness_ecu_test")
+    # Per-example binary name/path: builds for different examples (e.g. run
+    # in parallel, or leftover from a previous run) never collide or clobber
+    # each other's cached binary.
+    binary = Path(f"/tmp/harness_ecu_test_{example}")
     build_script = repo_root / "build_harness.sh"
 
     if not build_script.exists():
         raise RuntimeError(f"build_harness.sh not found at {build_script}")
 
-    log.info("Building harness binary...")
+    log.info("Building harness binary for example '%s'...", example)
     result = subprocess.run(
-        ["bash", str(build_script), "--fast"],
+        ["bash", str(build_script), "--fast", "--example", example],
         capture_output=True,
         text=True,
         cwd=str(repo_root),
@@ -317,7 +328,7 @@ def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"Harness build failed (rc={result.returncode}):\n"
+            f"Harness build failed for example '{example}' (rc={result.returncode}):\n"
             f"STDOUT:\n{result.stdout}\n"
             f"STDERR:\n{result.stderr}"
         )
@@ -548,7 +559,7 @@ class FirmwareIsoTpTransport:
 def harness_binary() -> Path:
     """Build the harness binary once per session. Skips if build fails."""
     try:
-        binary = build_harness(_REPO_ROOT)
+        binary = build_harness(_REPO_ROOT, _EXAMPLE_NAME)
         assert binary.exists(), f"Harness binary not found after build: {binary}"
         return binary
     except Exception as exc:

--- a/examples/bms_ecu/generated/tests/conftest_firmware.py
+++ b/examples/bms_ecu/generated/tests/conftest_firmware.py
@@ -293,23 +293,34 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # Root of the repository (two levels up from generated/tests/)
 _REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
+# This example's own name, e.g. "sensor_ecu" for
+# examples/sensor_ecu/generated/tests/conftest_firmware.py. Derived from our
+# own location rather than hardcoded, so the harness is always built against
+# *this* example's generated/ sources instead of a fixed example (#144).
+_EXAMPLE_NAME: str = Path(__file__).resolve().parent.parent.parent.name
 
-def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
+
+def build_harness(repo_root: Path = _REPO_ROOT, example: str = _EXAMPLE_NAME) -> Path:
     """
-    Build the harness binary using build_harness.sh.
+    Build the harness binary using build_harness.sh, against `example`'s own
+    generated/ sources (see #144 — this used to always build basic_ecu's
+    sources regardless of which example's tests were running).
 
     Returns the path to the compiled binary.
     Raises RuntimeError if the build fails.
     """
-    binary = Path("/tmp/harness_ecu_test")
+    # Per-example binary name/path: builds for different examples (e.g. run
+    # in parallel, or leftover from a previous run) never collide or clobber
+    # each other's cached binary.
+    binary = Path(f"/tmp/harness_ecu_test_{example}")
     build_script = repo_root / "build_harness.sh"
 
     if not build_script.exists():
         raise RuntimeError(f"build_harness.sh not found at {build_script}")
 
-    log.info("Building harness binary...")
+    log.info("Building harness binary for example '%s'...", example)
     result = subprocess.run(
-        ["bash", str(build_script), "--fast"],
+        ["bash", str(build_script), "--fast", "--example", example],
         capture_output=True,
         text=True,
         cwd=str(repo_root),
@@ -317,7 +328,7 @@ def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"Harness build failed (rc={result.returncode}):\n"
+            f"Harness build failed for example '{example}' (rc={result.returncode}):\n"
             f"STDOUT:\n{result.stdout}\n"
             f"STDERR:\n{result.stderr}"
         )
@@ -548,7 +559,7 @@ class FirmwareIsoTpTransport:
 def harness_binary() -> Path:
     """Build the harness binary once per session. Skips if build fails."""
     try:
-        binary = build_harness(_REPO_ROOT)
+        binary = build_harness(_REPO_ROOT, _EXAMPLE_NAME)
         assert binary.exists(), f"Harness binary not found after build: {binary}"
         return binary
     except Exception as exc:

--- a/examples/motor_controller_ecu/generated/tests/conftest_firmware.py
+++ b/examples/motor_controller_ecu/generated/tests/conftest_firmware.py
@@ -293,23 +293,34 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # Root of the repository (two levels up from generated/tests/)
 _REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
+# This example's own name, e.g. "sensor_ecu" for
+# examples/sensor_ecu/generated/tests/conftest_firmware.py. Derived from our
+# own location rather than hardcoded, so the harness is always built against
+# *this* example's generated/ sources instead of a fixed example (#144).
+_EXAMPLE_NAME: str = Path(__file__).resolve().parent.parent.parent.name
 
-def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
+
+def build_harness(repo_root: Path = _REPO_ROOT, example: str = _EXAMPLE_NAME) -> Path:
     """
-    Build the harness binary using build_harness.sh.
+    Build the harness binary using build_harness.sh, against `example`'s own
+    generated/ sources (see #144 — this used to always build basic_ecu's
+    sources regardless of which example's tests were running).
 
     Returns the path to the compiled binary.
     Raises RuntimeError if the build fails.
     """
-    binary = Path("/tmp/harness_ecu_test")
+    # Per-example binary name/path: builds for different examples (e.g. run
+    # in parallel, or leftover from a previous run) never collide or clobber
+    # each other's cached binary.
+    binary = Path(f"/tmp/harness_ecu_test_{example}")
     build_script = repo_root / "build_harness.sh"
 
     if not build_script.exists():
         raise RuntimeError(f"build_harness.sh not found at {build_script}")
 
-    log.info("Building harness binary...")
+    log.info("Building harness binary for example '%s'...", example)
     result = subprocess.run(
-        ["bash", str(build_script), "--fast"],
+        ["bash", str(build_script), "--fast", "--example", example],
         capture_output=True,
         text=True,
         cwd=str(repo_root),
@@ -317,7 +328,7 @@ def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"Harness build failed (rc={result.returncode}):\n"
+            f"Harness build failed for example '{example}' (rc={result.returncode}):\n"
             f"STDOUT:\n{result.stdout}\n"
             f"STDERR:\n{result.stderr}"
         )
@@ -548,7 +559,7 @@ class FirmwareIsoTpTransport:
 def harness_binary() -> Path:
     """Build the harness binary once per session. Skips if build fails."""
     try:
-        binary = build_harness(_REPO_ROOT)
+        binary = build_harness(_REPO_ROOT, _EXAMPLE_NAME)
         assert binary.exists(), f"Harness binary not found after build: {binary}"
         return binary
     except Exception as exc:

--- a/examples/robot_joint_controller_ecu/generated/tests/conftest_firmware.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/conftest_firmware.py
@@ -293,23 +293,34 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # Root of the repository (two levels up from generated/tests/)
 _REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
+# This example's own name, e.g. "sensor_ecu" for
+# examples/sensor_ecu/generated/tests/conftest_firmware.py. Derived from our
+# own location rather than hardcoded, so the harness is always built against
+# *this* example's generated/ sources instead of a fixed example (#144).
+_EXAMPLE_NAME: str = Path(__file__).resolve().parent.parent.parent.name
 
-def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
+
+def build_harness(repo_root: Path = _REPO_ROOT, example: str = _EXAMPLE_NAME) -> Path:
     """
-    Build the harness binary using build_harness.sh.
+    Build the harness binary using build_harness.sh, against `example`'s own
+    generated/ sources (see #144 — this used to always build basic_ecu's
+    sources regardless of which example's tests were running).
 
     Returns the path to the compiled binary.
     Raises RuntimeError if the build fails.
     """
-    binary = Path("/tmp/harness_ecu_test")
+    # Per-example binary name/path: builds for different examples (e.g. run
+    # in parallel, or leftover from a previous run) never collide or clobber
+    # each other's cached binary.
+    binary = Path(f"/tmp/harness_ecu_test_{example}")
     build_script = repo_root / "build_harness.sh"
 
     if not build_script.exists():
         raise RuntimeError(f"build_harness.sh not found at {build_script}")
 
-    log.info("Building harness binary...")
+    log.info("Building harness binary for example '%s'...", example)
     result = subprocess.run(
-        ["bash", str(build_script), "--fast"],
+        ["bash", str(build_script), "--fast", "--example", example],
         capture_output=True,
         text=True,
         cwd=str(repo_root),
@@ -317,7 +328,7 @@ def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"Harness build failed (rc={result.returncode}):\n"
+            f"Harness build failed for example '{example}' (rc={result.returncode}):\n"
             f"STDOUT:\n{result.stdout}\n"
             f"STDERR:\n{result.stderr}"
         )
@@ -548,7 +559,7 @@ class FirmwareIsoTpTransport:
 def harness_binary() -> Path:
     """Build the harness binary once per session. Skips if build fails."""
     try:
-        binary = build_harness(_REPO_ROOT)
+        binary = build_harness(_REPO_ROOT, _EXAMPLE_NAME)
         assert binary.exists(), f"Harness binary not found after build: {binary}"
         return binary
     except Exception as exc:

--- a/examples/safeboot_ecu/generated/tests/conftest_firmware.py
+++ b/examples/safeboot_ecu/generated/tests/conftest_firmware.py
@@ -293,23 +293,34 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # Root of the repository (two levels up from generated/tests/)
 _REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
+# This example's own name, e.g. "sensor_ecu" for
+# examples/sensor_ecu/generated/tests/conftest_firmware.py. Derived from our
+# own location rather than hardcoded, so the harness is always built against
+# *this* example's generated/ sources instead of a fixed example (#144).
+_EXAMPLE_NAME: str = Path(__file__).resolve().parent.parent.parent.name
 
-def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
+
+def build_harness(repo_root: Path = _REPO_ROOT, example: str = _EXAMPLE_NAME) -> Path:
     """
-    Build the harness binary using build_harness.sh.
+    Build the harness binary using build_harness.sh, against `example`'s own
+    generated/ sources (see #144 — this used to always build basic_ecu's
+    sources regardless of which example's tests were running).
 
     Returns the path to the compiled binary.
     Raises RuntimeError if the build fails.
     """
-    binary = Path("/tmp/harness_ecu_test")
+    # Per-example binary name/path: builds for different examples (e.g. run
+    # in parallel, or leftover from a previous run) never collide or clobber
+    # each other's cached binary.
+    binary = Path(f"/tmp/harness_ecu_test_{example}")
     build_script = repo_root / "build_harness.sh"
 
     if not build_script.exists():
         raise RuntimeError(f"build_harness.sh not found at {build_script}")
 
-    log.info("Building harness binary...")
+    log.info("Building harness binary for example '%s'...", example)
     result = subprocess.run(
-        ["bash", str(build_script), "--fast"],
+        ["bash", str(build_script), "--fast", "--example", example],
         capture_output=True,
         text=True,
         cwd=str(repo_root),
@@ -317,7 +328,7 @@ def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"Harness build failed (rc={result.returncode}):\n"
+            f"Harness build failed for example '{example}' (rc={result.returncode}):\n"
             f"STDOUT:\n{result.stdout}\n"
             f"STDERR:\n{result.stderr}"
         )
@@ -548,7 +559,7 @@ class FirmwareIsoTpTransport:
 def harness_binary() -> Path:
     """Build the harness binary once per session. Skips if build fails."""
     try:
-        binary = build_harness(_REPO_ROOT)
+        binary = build_harness(_REPO_ROOT, _EXAMPLE_NAME)
         assert binary.exists(), f"Harness binary not found after build: {binary}"
         return binary
     except Exception as exc:

--- a/examples/sensor_ecu/generated/tests/conftest_firmware.py
+++ b/examples/sensor_ecu/generated/tests/conftest_firmware.py
@@ -293,23 +293,34 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # Root of the repository (two levels up from generated/tests/)
 _REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
+# This example's own name, e.g. "sensor_ecu" for
+# examples/sensor_ecu/generated/tests/conftest_firmware.py. Derived from our
+# own location rather than hardcoded, so the harness is always built against
+# *this* example's generated/ sources instead of a fixed example (#144).
+_EXAMPLE_NAME: str = Path(__file__).resolve().parent.parent.parent.name
 
-def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
+
+def build_harness(repo_root: Path = _REPO_ROOT, example: str = _EXAMPLE_NAME) -> Path:
     """
-    Build the harness binary using build_harness.sh.
+    Build the harness binary using build_harness.sh, against `example`'s own
+    generated/ sources (see #144 — this used to always build basic_ecu's
+    sources regardless of which example's tests were running).
 
     Returns the path to the compiled binary.
     Raises RuntimeError if the build fails.
     """
-    binary = Path("/tmp/harness_ecu_test")
+    # Per-example binary name/path: builds for different examples (e.g. run
+    # in parallel, or leftover from a previous run) never collide or clobber
+    # each other's cached binary.
+    binary = Path(f"/tmp/harness_ecu_test_{example}")
     build_script = repo_root / "build_harness.sh"
 
     if not build_script.exists():
         raise RuntimeError(f"build_harness.sh not found at {build_script}")
 
-    log.info("Building harness binary...")
+    log.info("Building harness binary for example '%s'...", example)
     result = subprocess.run(
-        ["bash", str(build_script), "--fast"],
+        ["bash", str(build_script), "--fast", "--example", example],
         capture_output=True,
         text=True,
         cwd=str(repo_root),
@@ -317,7 +328,7 @@ def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"Harness build failed (rc={result.returncode}):\n"
+            f"Harness build failed for example '{example}' (rc={result.returncode}):\n"
             f"STDOUT:\n{result.stdout}\n"
             f"STDERR:\n{result.stderr}"
         )
@@ -548,7 +559,7 @@ class FirmwareIsoTpTransport:
 def harness_binary() -> Path:
     """Build the harness binary once per session. Skips if build fails."""
     try:
-        binary = build_harness(_REPO_ROOT)
+        binary = build_harness(_REPO_ROOT, _EXAMPLE_NAME)
         assert binary.exists(), f"Harness binary not found after build: {binary}"
         return binary
     except Exception as exc:

--- a/examples/sensor_ecu_freertos/generated/tests/conftest_firmware.py
+++ b/examples/sensor_ecu_freertos/generated/tests/conftest_firmware.py
@@ -293,23 +293,34 @@ def derive_firmware_key(seed: bytes, level: int = 1, aes_keys: Optional[dict] = 
 # Root of the repository (two levels up from generated/tests/)
 _REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
+# This example's own name, e.g. "sensor_ecu" for
+# examples/sensor_ecu/generated/tests/conftest_firmware.py. Derived from our
+# own location rather than hardcoded, so the harness is always built against
+# *this* example's generated/ sources instead of a fixed example (#144).
+_EXAMPLE_NAME: str = Path(__file__).resolve().parent.parent.parent.name
 
-def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
+
+def build_harness(repo_root: Path = _REPO_ROOT, example: str = _EXAMPLE_NAME) -> Path:
     """
-    Build the harness binary using build_harness.sh.
+    Build the harness binary using build_harness.sh, against `example`'s own
+    generated/ sources (see #144 — this used to always build basic_ecu's
+    sources regardless of which example's tests were running).
 
     Returns the path to the compiled binary.
     Raises RuntimeError if the build fails.
     """
-    binary = Path("/tmp/harness_ecu_test")
+    # Per-example binary name/path: builds for different examples (e.g. run
+    # in parallel, or leftover from a previous run) never collide or clobber
+    # each other's cached binary.
+    binary = Path(f"/tmp/harness_ecu_test_{example}")
     build_script = repo_root / "build_harness.sh"
 
     if not build_script.exists():
         raise RuntimeError(f"build_harness.sh not found at {build_script}")
 
-    log.info("Building harness binary...")
+    log.info("Building harness binary for example '%s'...", example)
     result = subprocess.run(
-        ["bash", str(build_script), "--fast"],
+        ["bash", str(build_script), "--fast", "--example", example],
         capture_output=True,
         text=True,
         cwd=str(repo_root),
@@ -317,7 +328,7 @@ def build_harness(repo_root: Path = _REPO_ROOT) -> Path:
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"Harness build failed (rc={result.returncode}):\n"
+            f"Harness build failed for example '{example}' (rc={result.returncode}):\n"
             f"STDOUT:\n{result.stdout}\n"
             f"STDERR:\n{result.stderr}"
         )
@@ -548,7 +559,7 @@ class FirmwareIsoTpTransport:
 def harness_binary() -> Path:
     """Build the harness binary once per session. Skips if build fails."""
     try:
-        binary = build_harness(_REPO_ROOT)
+        binary = build_harness(_REPO_ROOT, _EXAMPLE_NAME)
         assert binary.exists(), f"Harness binary not found after build: {binary}"
         return binary
     except Exception as exc:


### PR DESCRIPTION
Fixes #144.

## The bug

`build_harness.sh` hardcoded its C source list and include path to
`examples/basic_ecu/generated/*`, so every example's `conftest_firmware.py`
built and launched the same basic_ecu-shaped harness binary regardless of
which example's tests were running. Non-basic_ecu firmware tests then
failed on real protocol mismatches (wrong DIDs, wrong routine IDs, wrong
DTC set) rather than testing that example's own generated code. This was
invisible before #143 made the `firmware_bus` fixture reachable at all.

## The fix

- `build_harness.sh` now accepts `--example <name>` (or an `EXAMPLE` env
  var; default `basic_ecu`, preserving existing default behavior/CI gate)
  and builds against `examples/<name>/generated/{did_handlers,did_safety_
  wrappers,routine_handlers}.c` and that example's include path instead of
  a hardcoded example. Missing example / missing generated sources now
  produce a clear error with regen instructions, instead of a confusing
  compile failure or (worse) silently building the wrong thing.
- Default output binary is now `/tmp/harness_ecu_test_<example>`, so builds
  for different examples never collide or clobber a stale binary (matters
  if firmware tests for multiple examples ever run in parallel or back to
  back without cleanup).
- `conftest_firmware.py`'s `harness_binary()` / `build_harness()` — a
  generated file, byte-identical across all 11 examples that have a
  `tests/` dir except for a header comment and log name — now derive their
  own example name from `Path(__file__)` (they already live inside
  `examples/<name>/generated/tests/`) rather than requiring a caller to
  specify it, and pass `--example` through to `build_harness.sh`. The
  `harness_binary` fixture stays session-scoped: one build per *example's*
  test session is still correct, it's just no longer a global "one build
  for every example" scope.

## Verification

`harness/` is a Professional-tier deliverable and is gitignored / not part
of this public repo, so it wasn't present in the fresh worktree. I extracted
it from the matching **v1.12.0** Professional ZIP (built same-day as this
repo's current `main`) purely for local verification — it was never staged
or committed (`git status` confirms it stays untracked throughout).

With that in place, `gcc` was available in the environment, so I actually
built and ran the harness — this is a real build+test verification, not
just code review.

**Before the fix** (confirming the bug as described in the issue):
- `basic_ecu --firmware`: 56 passed, 1 skipped
- `sensor_ecu --firmware`: **20 failed**, 40 passed, 1 skipped — real
  protocol mismatches (wrong DID content, wrong routine IDs, wrong DTC set)
  because it was actually talking to basic_ecu's firmware.

**After the fix**, ran `--firmware` for all 11 examples with a `tests/`
dir:

| Example | Result | 
|---|---|
| basic_ecu, basic_ecu_doip, basic_ecu_doip_freertos, basic_ecu_freertos | 56 passed, 1 skipped (unchanged) |
| sensor_ecu, sensor_ecu_freertos | 55 passed, **5** failed (was 20), 1 skipped |
| motor_controller_ecu | 107 passed, 9 failed, 1 skipped |
| ardep_ecu | 121 passed, 17 failed, 1 skipped |
| bms_ecu | 94 passed, 9 failed, 1 skipped |
| robot_joint_controller_ecu | 68 passed, 5 failed, 1 skipped |
| safeboot_ecu | 47 passed, 3 failed, 2 skipped |

Every one of the *remaining* failures is a DTC-registration assertion (or,
for sensor_ecu/sensor_ecu_freertos, one WriteDID length test) — **zero**
DID-content or routine-ID protocol mismatches remain anywhere. I traced
those remaining failures to two separate, narrower pre-existing bugs that
are out of scope for this issue and not touched by this PR:

- #158 — `harness/harness_ecu.c` (commercial, not in this repo) hardcodes
  DTC registration to basic_ecu's two DTCs (0xC00100/0xC00200) regardless
  of which example is built.
- #160 — a generated `test_firmware_services.py` WriteDID "too short" test
  hardcodes a literal byte count (`1 - 1`) instead of deriving it from the
  DID's own `data_length`, which happens to matter for sensor_ecu's
  DID_CATALOGUE[5].

Also confirmed no regression in the existing gates:
- `bash build_harness.sh --run` (default, no `--example` — i.e. basic_ecu):
  **68/68 passed**, unchanged.
- `bash build_tests.sh`: **44/44 passed**, unchanged (44 passed, 0 failed
  in this checkout; CLAUDE.md's "42/42" figure appears stale, unrelated to
  this change).

## Scope note

Per the precedent set by #143 (see that PR/commit), the actual codegen
template for `conftest_firmware.py` lives in the private EDS-toolchain
repo (`tools/templates`, gitignored here). This PR edits the generated
output directly across all 11 examples (identical patch, verified via diff
that only the pre-existing per-example header/log-name lines differ
between files) — the template-side fix in EDS-toolchain, if wanted, is a
separate PR against that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)