### PR TITLE
fix: give the Python test suite a canonical root entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,34 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **The Python test suite had no canonical entrypoint — root-level `pytest`
+  collection failed outright.** (#150) Every `examples/*/generated/tests/`
+  directory's `conftest.py` declares `pytest_plugins = ["conftest_firmware"]`
+  (added by #143), which pytest only allows in a conftest.py sitting at its
+  own session rootdir; a bare `pytest` from the repo root tried to walk all
+  12 example trees in one session and hard-errored on every one of them
+  ("Defining 'pytest_plugins' in a non-top-level conftest is no longer
+  supported"), collecting only 11 stray tests. A new root-level `pytest.ini`
+  (`testpaths = tests`) scopes a bare root `pytest` run to this repo's own
+  hand-written `tests/` suite — each example's `generated/tests/` already
+  ships its own committed `pytest.ini`/`conftest.py` and is self-contained
+  exactly as README.md and CI already document
+  (`cd examples/<name>/generated/tests && pytest ...`); regenerating those
+  12 generated trees to share a root conftest was not an option here — they
+  are produced by `tools/testgen.py`, a commercial gitignored deliverable
+  not present in a bare public checkout, and must never be hand-edited. New
+  `run_python_tests.sh` (mirrors `build_tests.sh`'s role for the C suite) is
+  the canonical "run everything" command: `tests/` plus every example, each
+  scoped to its own directory, with a pass/`[ENV]`/fail summary per suite.
+  Also fixed: `tests/test_license_expiry.py` hard-errored at collection
+  (`ModuleNotFoundError: No module named '_license'`) in any checkout
+  without the commercial `tools/_license.py` module — it now degrades to a
+  `[ENV]`-tagged skip under pytest (and to a plain printed message, exit 0,
+  when run standalone). Skip reasons for known environment gaps (missing
+  `xaloqi-tester`, missing DoIP ECU binary, missing `_license` module) now
+  carry a `[ENV]` prefix so they're greppable and visibly distinct from a
+  real test failure, per the issue's second ask.
+
 - **CI's "Integration Tests (generated, simulator mode)" job has executed
   zero tests since the initial public release.** (#141, #142) `conftest.py`'s
   `from xaloqi.tester import ...` failed at import time because the job

--- a/README.md
+++ b/README.md
@@ -239,9 +239,19 @@ bash build_tests.sh
 # 68 harness integration tests (Professional tier — requires harness/ sources)
 # bash build_harness.sh
 
-# Generated pytest suite (simulator mode)
+# Generated pytest suite (simulator mode) — one example
 cd examples/basic_ecu/generated/tests && pytest test_services.py test_did_*.py -v --can-interface=simulator
+
+# Whole Python suite (repo tests/ + every example, each correctly scoped) —
+# the canonical entrypoint; prints a pass/skip/fail summary per suite
+bash run_python_tests.sh
 ```
+
+> A bare `pytest` from the repo root only collects `tests/` (see
+> `pytest.ini`) — every example's `generated/tests/` is its own
+> self-contained pytest project and must be run scoped to its own
+> directory, exactly as shown above. `run_python_tests.sh` runs all of them
+> for you.
 
 ### GUI configurator
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,30 @@
+# =============================================================================
+# Xaloqi EDS — root-level pytest configuration (issue #150)
+#
+# PURPOSE: Give bare `pytest` / `python3 -m pytest`, run from the repo root,
+#          a canonical, non-exploding default: collect only this repo's own
+#          hand-written suite under tests/.
+#
+# WHY NOT COLLECT examples/*/generated/tests/ TOO:
+#   Each of the 12 examples' generated/tests/ directories ships its own
+#   committed pytest.ini and conftest.py (produced by tools/testgen.py, a
+#   commercial gitignored deliverable — see CLAUDE.md/#67), and each
+#   conftest.py declares `pytest_plugins = ["conftest_firmware"]`. Modern
+#   pytest only allows `pytest_plugins` in a conftest.py that sits at the
+#   *session's own rootdir* — fine when a suite is run scoped to its own
+#   directory (each example dir's local pytest.ini makes it its own
+#   rootdir, exactly as README.md and CI already document:
+#   `cd examples/<name>/generated/tests && pytest ...`), but not when a
+#   single pytest session tries to walk all 12 example trees plus tests/
+#   from one shared root — pytest then treats every example's conftest.py
+#   as "non-top-level" and hard-errors on the pytest_plugins line.
+#
+#   Restructuring this into one shared root conftest would mean hand-editing
+#   12 generated/ files (against repo policy, and impossible here anyway
+#   without the gitignored codegen templates that produced them). Scoping
+#   root collection to tests/ avoids all of that — see run_python_tests.sh
+#   for the canonical command that runs the *whole* Python suite (tests/
+#   plus every example, each correctly scoped to its own directory).
+# =============================================================================
+[pytest]
+testpaths = tests

--- a/run_python_tests.sh
+++ b/run_python_tests.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Xaloqi EDS
+# run_python_tests.sh  (project root)
+#
+# PURPOSE: Canonical entrypoint for the whole Python test suite (issue #150).
+#          Mirrors build_tests.sh's role for the C suite: one command, run
+#          from anywhere in the repo, that exercises everything correctly
+#          scoped and prints a clear pass/skip/fail summary.
+#
+# WHY THIS EXISTS INSTEAD OF A SHARED ROOT conftest.py:
+#   Bare `pytest` from the repo root only collects tests/ (see pytest.ini —
+#   testpaths = tests) because every examples/*/generated/tests/ directory
+#   is a self-contained pytest project: its own committed pytest.ini (its
+#   own rootdir) and its own conftest.py declaring
+#   `pytest_plugins = ["conftest_firmware"]`, which pytest only allows in a
+#   conftest.py sitting at that session's rootdir. Walking all 12 example
+#   trees plus tests/ in one shared session breaks that. Those generated/
+#   files are produced by tools/testgen.py (a commercial, gitignored
+#   deliverable — CLAUDE.md/#67) and must never be hand-edited, so this
+#   script runs each suite scoped to its own directory instead — exactly
+#   the invocation README.md and CI already document
+#   (`cd examples/<name>/generated/tests && pytest ...`).
+#
+# WHAT IT RUNS:
+#   1. tests/                         — this repo's own hand-written suite
+#   2. examples/*/generated/tests/    — each example's generated suite,
+#      one pytest session per example directory (its own pytest.ini
+#      applies: simulator mode by default, --strict-markers, etc.)
+#
+# SKIP CLASSIFICATION:
+#   A suite that fails collection or has 1+ real test failures is FAIL.
+#   A suite where every test passed (0 failed) is PASS, but if it produced
+#   zero passes and only skips (an optional dependency — xaloqi-tester,
+#   pycryptodome — or firmware_bus is unavailable, or a firmware binary/ECU
+#   binary is missing) it is reported as [ENV] instead of a bare PASS, so
+#   "nothing meaningful ran here because this environment is incomplete" is
+#   never mistaken for "verified and all green". Look for "[ENV]" in the
+#   underlying pytest skip reasons to grep the exact cause.
+#
+# USAGE:
+#   bash run_python_tests.sh              # full suite (all examples + tests/)
+#   bash run_python_tests.sh --quick       # skip basic_ecu's 12-file, ~110s
+#                                          # robustness campaign (still runs
+#                                          # in its own dedicated CI job)
+#
+# EXIT CODES:
+#   0  No suite reported a real test failure or collection error.
+#   1  At least one suite failed.
+# =============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${SCRIPT_DIR}"
+export XALOQI_LICENSE_SKIP=1
+
+QUICK=0
+for arg in "$@"; do
+    case "$arg" in
+        --quick)
+            QUICK=1
+            ;;
+        -h|--help)
+            echo "Usage: bash run_python_tests.sh [--quick]"
+            echo "  --quick   Skip basic_ecu's robustness campaign (12 files, ~110s)."
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+ROBUSTNESS_IGNORE=(
+    --ignore=test_robustness_A_codegen.py
+    --ignore=test_robustness_B_protocol.py
+    --ignore=test_robustness_C_security.py
+    --ignore=test_robustness_D_customer_journey.py
+    --ignore=test_robustness_E_data_integrity.py
+    --ignore=test_robustness_F_codegen_limits.py
+    --ignore=test_robustness_G_resilience.py
+    --ignore=test_robustness_H_protocol_precision.py
+    --ignore=test_robustness_I_nrc_wdbi_sa.py
+    --ignore=test_robustness_J_sovd_cda.py
+    --ignore=test_robustness_K_error_quality.py
+    --ignore=test_robustness_L_codegen_output_fidelity.py
+)
+
+TOTAL_SUITES=0
+FAIL_SUITES=0
+ENV_SUITES=0
+declare -a SUMMARY_LINES
+
+# run_suite LABEL DIR [extra pytest args...]
+run_suite() {
+    local label="$1" dir="$2"
+    shift 2
+    TOTAL_SUITES=$((TOTAL_SUITES + 1))
+
+    local out rc tail_line
+    out="$(cd "$dir" && python3 -m pytest . -q "$@" 2>&1)"
+    rc=$?
+    tail_line="$(printf '%s\n' "$out" | tail -n 1)"
+
+    local passed failed
+    passed="$(printf '%s\n' "$tail_line" | grep -oE '[0-9]+ passed' | grep -oE '^[0-9]+' || echo 0)"
+    failed="$(printf '%s\n' "$tail_line" | grep -oE '[0-9]+ failed' | grep -oE '^[0-9]+' || echo 0)"
+    local errored=0
+    printf '%s\n' "$tail_line" | grep -qE '[0-9]+ error' && errored=1
+
+    if [ "$rc" -ne 0 ] || [ "$failed" -gt 0 ] || [ "$errored" -eq 1 ]; then
+        FAIL_SUITES=$((FAIL_SUITES + 1))
+        SUMMARY_LINES+=("FAIL  ${label}: ${tail_line}")
+        echo "===== ${label}: FAIL ====="
+        printf '%s\n' "$out"
+        echo "===================================================="
+    elif [ "$passed" -eq 0 ]; then
+        # Collected fine, zero failures, but nothing actually ran/passed —
+        # an environment gap (missing optional dependency / firmware
+        # binary / license module), not a verified pass.
+        ENV_SUITES=$((ENV_SUITES + 1))
+        SUMMARY_LINES+=("[ENV] ${label}: ${tail_line}")
+    else
+        SUMMARY_LINES+=("PASS  ${label}: ${tail_line}")
+    fi
+}
+
+echo "======================================================================"
+echo " Xaloqi EDS — canonical Python test suite (issue #150)"
+echo " XALOQI_LICENSE_SKIP=1"
+echo "======================================================================"
+
+START_TS=$(date +%s)
+
+echo
+echo "--- tests/ (repo-level suite) ---"
+run_suite "tests/" "${ROOT}/tests"
+
+for dir in "${ROOT}"/examples/*/generated/tests; do
+    [ -d "$dir" ] || continue
+    example_name="$(basename "$(dirname "$(dirname "$dir")")")"
+    echo
+    echo "--- examples/${example_name}/generated/tests ---"
+    if [ "$QUICK" -eq 1 ] && [ -f "${dir}/test_robustness_A_codegen.py" ]; then
+        run_suite "examples/${example_name}" "$dir" "${ROBUSTNESS_IGNORE[@]}"
+    else
+        run_suite "examples/${example_name}" "$dir"
+    fi
+done
+
+END_TS=$(date +%s)
+
+echo
+echo "======================================================================"
+echo " Summary (${TOTAL_SUITES} suites, $((END_TS - START_TS))s)"
+echo "======================================================================"
+for line in "${SUMMARY_LINES[@]}"; do
+    echo " $line"
+done
+echo "----------------------------------------------------------------------"
+echo " ${FAIL_SUITES} failed, ${ENV_SUITES} environment-incomplete, $((TOTAL_SUITES - FAIL_SUITES - ENV_SUITES)) passed clean"
+echo "======================================================================"
+
+if [ "$FAIL_SUITES" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/tests/test_doip_integration.py
+++ b/tests/test_doip_integration.py
@@ -62,7 +62,7 @@ import pytest
 # ---------------------------------------------------------------------------
 xaloqi = pytest.importorskip(
     "xaloqi",
-    reason="xaloqi-tester not installed — skipping DoIP integration tests"
+    reason="[ENV] xaloqi-tester not installed — skipping DoIP integration tests"
 )
 from xaloqi.tester import DoipBus, Session, UdsTester
 
@@ -89,7 +89,7 @@ def doip_ecu() -> Generator[subprocess.Popen, None, None]:
     """Build (if needed) and launch basic_ecu_doip on native_sim."""
     if not os.path.exists(_ECU_BINARY):
         pytest.skip(
-            f"ECU binary not found: {_ECU_BINARY}\n"
+            f"[ENV] ECU binary not found: {_ECU_BINARY}\n"
             f"Build first with:\n"
             f"  west build -b native_sim examples/basic_ecu_doip -- \\\n"
             f"      -DEXTRA_CONF_FILE=boards/native_sim/native_sim_doip.conf"

--- a/tests/test_license_expiry.py
+++ b/tests/test_license_expiry.py
@@ -22,7 +22,29 @@ from pathlib import Path
 from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
-import _license
+
+# [ENV] tools/_license.py is a commercial, gitignored deliverable (CLAUDE.md /
+# issue #67) — it is never present in a bare public checkout. Without this
+# guard, pytest's collection of tests/ (issue #150) hard-errors here with a
+# bare ModuleNotFoundError, indistinguishable at a glance from a real test
+# failure. The "[ENV] " prefix lets `pytest`/run_python_tests.sh output tell
+# "this environment is missing an optional/commercial component" apart from
+# an actual regression.
+_ENV_SKIP_REASON = (
+    "[ENV] tools/_license.py not present (commercial gitignored deliverable, "
+    "not part of the public repo checkout)"
+)
+try:
+    import _license
+except ImportError:
+    if __name__ == "__main__":
+        # `python3 tests/test_license_expiry.py` direct invocation.
+        print(_ENV_SKIP_REASON)
+        sys.exit(0)
+    # Collected by pytest — turn the import error into a proper SKIP report
+    # instead of a collection error.
+    import pytest
+    pytest.skip(_ENV_SKIP_REASON, allow_module_level=True)
 
 
 def _real_expires_at() -> int:


### PR DESCRIPTION
## Summary

Fixes #150. Root-level `pytest` collection was broken outright: every `examples/*/generated/tests/` directory's `conftest.py` declares `pytest_plugins = ["conftest_firmware"]` (added by #143), which pytest only allows in a conftest.py that sits at its own session rootdir. A bare `pytest` from the repo root tried to walk all 12 example trees plus `tests/` in one shared session and hard-errored on every one of them.

## Architecture chosen — and why

**Root-level `pytest.ini` (`testpaths = tests`) + a new `run_python_tests.sh` canonical script, not a shared root conftest.**

Each example's `generated/tests/` directory is already a fully self-contained pytest project — its own committed `pytest.ini` (its own rootdir) and its own `conftest.py`. That's exactly why the documented, CI-used invocation (`cd examples/<name>/generated/tests && pytest ...`) already works today: pytest finds the *nearest* ini file walking up from cwd and stops there, so each example's conftest.py is legitimately "top-level" relative to its own directory. The failure only happens when one pytest session is asked to walk *all* of them from a single shared root.

A shared-root-conftest restructure was considered per the issue's suggestion, but isn't achievable here: all 12 examples' `conftest.py`/`conftest_firmware.py`/`pytest.ini` files are marked `GENERATED — do NOT edit manually`, produced by `tools/testgen.py` + `tools/templates/` — a commercial, gitignored deliverable (CLAUDE.md/#67) that is **not present in this checkout** (confirmed: `tools/testgen.py` doesn't exist here). Hand-editing generated/ files instead of regenerating them is explicitly against repo policy, and regeneration isn't possible without the missing tool.

So the fix scopes root-level collection down to what's actually meant to run at the root — this repo's own hand-written `tests/` — via a root `pytest.ini`, and adds `run_python_tests.sh` (mirroring `build_tests.sh`'s role for the C suite) as the one canonical command that runs the *whole* Python suite: `tests/` plus every example, each still scoped to its own directory exactly as documented, aggregated into one pass/`[ENV]`/fail summary. Verified empirically that adding the root `pytest.ini` does not change per-example scoped behavior (pytest still resolves each example's own nearer `pytest.ini` as its rootdir).

Also fixed while in scope: `tests/test_license_expiry.py` independently hard-errored at collection (`ModuleNotFoundError: _license`) in any checkout without the commercial `tools/_license.py` module (always true for a bare public checkout) — it now degrades to a skip cleanly. Per the issue's second ask, skip reasons for known environment gaps (missing `xaloqi-tester`, missing DoIP ECU binary, missing `_license`) now carry a `[ENV]` prefix, greppable and visibly distinct from a real failure. The per-example *generated* conftest skip messages (e.g. "xaloqi-tester or pycryptodome required") were **not** touched — same reason: generated/, no codegen tool available to regenerate them.

## Before / after (repo root)

**Before:**
```
$ XALOQI_LICENSE_SKIP=1 python3 -m pytest --collect-only -q
...
!!!!!!!!!!!!!!!!!!! Interrupted: 12 errors during collection !!!!!!!!!!!!!!!!!!!
11 tests collected, 12 errors in 0.28s
```

**After:**
```
$ XALOQI_LICENSE_SKIP=1 python3 -m pytest
collected 11 items / 1 skipped
tests/test_doip_integration.py sssssssssss                               [100%]
============================= 12 skipped in 0.02s ==============================
$ echo $?
0
```

`bash run_python_tests.sh` (full run, all 12 example suites + tests/): **0 failed, 1 environment-incomplete (`tests/`, correctly tagged `[ENV]` since it's all-skip in a bare checkout), 11 passed clean** — including `basic_ecu`'s full 12-file robustness campaign (466 passed).

## Verification

- Root `pytest --collect-only`: 0 collection errors (was 12).
- Root `pytest`: exit 0 (was: interrupted).
- `run_python_tests.sh` (full + `--quick`): exit 0, 0 failed, both runs.
- Per-example scoped invocation unchanged — `basic_ecu`: **134 passed, 59 skipped** without `--firmware` (matches the exact pre-fix baseline; O-45's firmware-fixture fix not regressed).
- `bash build_tests.sh`: 44/44 (C suite untouched by this change).
- Filed #164 separately for a pre-existing, unrelated doc bug found along the way (`docs/TESTING_STRATEGY.md` references a `tests/integration/` directory that doesn't exist) — out of scope for this PR.

## Note on issue #150's own text

The issue body's "Suggested fix" section ends with "**Do not implement yet — planning/tracking issue.**" I implemented anyway per this task's explicit instructions (branch → implement → verify → PR). Flagging this discrepancy for visibility before merge, in case #150 was intended to stay planning-only for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)