### PR TITLE
docs: documentation-accuracy pass — test-count clarity, OSS/commercial split, CAN FD buffer boundary, SafeBoot scope, DoIP subset wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The generator produces: DID handler stubs, ASIL-B safety wrappers, DTC registrat
 |---|---|
 | **UDS stack** | 19 services: 0x10 0x11 0x14 0x19 0x22 **0x23** 0x27 0x28 **0x2A** 0x2E 0x2F 0x31 0x34 0x35 0x36 0x37 **0x3D** 0x3E 0x85 · SID 0x23: direct memory read · SID 0x2A: periodic push (SLOW/MEDIUM/FAST) · SID 0x3D: direct memory write · SID 0x19 sub-functions: 0x01 0x02 0x03 0x04 0x06 0x0A 0x0B 0x19 |
 | **ISO-TP transport** | SF / FF / CF / FC · N_As / N_Bs / N_Cr timing · STmin sub-ms range |
-| **DoIP transport** | ISO 13400-2 server — Routing Activation · DiagnosticMessage dispatch · Positive/Negative Ack · Alive Check · Zephyr (zsock_*) and FreeRTOS+LwIP bindings · same UDS core, no code changes |
+| **DoIP transport** | DoIP diagnostic server subset (ISO 13400-2 routing activation + diagnostic messaging) — Routing Activation · DiagnosticMessage dispatch · Positive/Negative Ack · Alive Check · Zephyr (zsock_*) and FreeRTOS+LwIP bindings · same UDS core, no code changes. Vehicle identification, vehicle announcement, and entity status are out of scope — see the DoIP Feature Matrix in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) §6.2. |
 | **ASIL-B safety chain** | 5-step DID validation enforced at codegen time — cannot be bypassed at runtime |
 | **Security** | AES-128-CMAC seed / 4-byte key response ([threat model](SECURITY.md#security-architecture-notes)) · TRNG-backed · configurable per-session levels · lockout with NVM persistence |
 | **DTC persistence** | NVM mirror survives power cycles · 0x14 ClearDTC · 0x19 ReadDTCInformation |
@@ -239,8 +239,13 @@ bash build_tests.sh
 # 68 harness integration tests (Professional tier — requires harness/ sources)
 # bash build_harness.sh
 
-# Generated pytest suite (simulator mode)
-cd examples/basic_ecu/generated/tests && pytest test_services.py test_did_*.py -v --can-interface=simulator
+# Generated pytest suite (simulator mode) — requires the commercial xaloqi-tester
+# (TestLab) package for the simulator/live-transport tests below; see
+# docs/TESTING_STRATEGY.md for what pytest --collect-only's full count breaks down into
+# and which subset runs with only tools/requirements.txt installed.
+cd examples/basic_ecu/generated/tests
+pip install -r requirements_testgen.txt   # xaloqi-tester — separate from tools/requirements.txt
+pytest test_services.py test_did_*.py -v --can-interface=simulator
 ```
 
 ### GUI configurator

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -19,6 +19,19 @@ ASIL-B safety-wrapped C code ready to compile into your ECU firmware.
 **Transport:** ISO-TP over CAN (default) · DoIP over Ethernet/TCP (v1.6.0+)
 **OpenSOVD CDA:** `--sovd` flag generates `sovd_cda.json` (v1.7.0+)
 
+**Licensing split (open-core) — read this before suggesting a `codegen.py` command:**
+- **OSS runtime** (`core/`, `transport/`, `config/`, `platform/`) is GPL v2 and fully
+  usable — builds and runs standalone, no license needed.
+- **OSS generator, validation only:** `tools/codegen.py` itself is public and its
+  YAML/schema/ASIL-B validation steps run standalone (`--dry-run` will report
+  config errors without a license).
+- **Commercial, required to actually generate code:** producing output needs
+  `tools/templates/` (the Jinja2 templates), a Developer/Professional-tier deliverable
+  that is gitignored and not part of this public repo. Without it, `codegen.py` exits
+  with "Commercial License Required." Every bundled example ships its `generated/`
+  output pre-committed, so `west build` works without running codegen at all — see
+  [COMMERCIAL_NOTICE.md](../COMMERCIAL_NOTICE.md).
+
 ---
 
 ## Repository Structure
@@ -331,7 +344,10 @@ void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef *hcan)
 ## Integration Pattern — DoIP (ISO 13400-2)
 
 DoIP transport is an additive v1.6.0 feature. The UDS core, safety wrappers, and YAML schema
-are identical to CAN builds.
+are identical to CAN builds. EDS implements a **DoIP diagnostic server subset**
+(ISO 13400-2 routing activation + diagnostic messaging) — UDP vehicle identification,
+vehicle announcement, and entity status are out of scope; see `docs/ARCHITECTURE.md` §6.2
+for the full feature matrix.
 
 ### YAML change
 
@@ -486,6 +502,10 @@ FreeRTOS / bare-metal: `-DISOTP_ENABLE_CAN_FD=1`.
 
 When enabled: SF escape sequence carries up to 62-byte payloads; FF escape sequence
 encodes 32-bit FF_DL for PDU > 4095 bytes. Default is 0 (classic CAN, unchanged).
+That 4095-byte figure is the ISO-TP transport ceiling only — the UDS application-layer
+buffer (`uds_msg_buf_t` in `core/uds_types.h`) is a fixed `data[4095]` + `uint16_t length`,
+so a single diagnostic PDU is still capped at 4095 bytes at the UDS/service layer
+regardless of the CAN FD escape sequence's larger transport capacity.
 
 ---
 
@@ -556,6 +576,11 @@ demonstrate DTC behaviour without hardware.
 Setting `safeboot.enabled: true` causes codegen to generate a platform flash ops init
 call automatically in `uds_init.c`, wiring the flash driver into the UDS transfer
 services. No manual flash ops registration required.
+
+**Boundary:** SafeBoot is the diagnostic-transfer-to-flash bridge (0x34/0x36/0x37 wiring,
+CRC-32 check, secondary-slot / dual-bank write) — not a full secure-update platform.
+Image signing, anti-rollback policy, A/B/transactional apply with power-loss recovery,
+and HSM integration are integrator-supplied, out of scope.
 
 - `safeboot.platform: zephyr` (default) → generates `zephyr_flash_ops_init()` — MCUboot secondary-slot on Zephyr
 - `safeboot.platform: freertos` → generates `freertos_flash_ops_init()` — STM32H743 dual-bank, no MCUboot

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -583,6 +583,14 @@ autocomplete and schema-driven validation in addition to the in-process validato
 
 The first five examples ship with committed generated output (DID handlers, safety wrappers, uds\_init) so the public repo is immediately evaluatable without running codegen. Run `pytest` against the simulator in under 60 seconds — no CAN hardware needed.
 
+**SafeBoot scope boundary:** `safeboot_ecu` and `safeboot_freertos_ecu` demonstrate the
+UDS-to-flash bridge — 0x34/0x36/0x37 wiring, CRC-32 verification, and the MCUboot
+secondary-slot / STM32H743 dual-bank backend. EDS + SafeBoot are not a complete secure-update
+platform: image signing, anti-rollback policy, A/B/transactional apply with power-loss
+recovery, and HSM integration are integrator-supplied and out of scope. See
+[`docs/INTEGRATION_GUIDE.md` §5](INTEGRATION_GUIDE.md#safeboot) for the full boundary
+statement.
+
 ---
 
 ## 13. CI Pipeline (`.github/workflows/ci.yml`)

--- a/docs/ARDEP_UPGRADE_GUIDE.md
+++ b/docs/ARDEP_UPGRADE_GUIDE.md
@@ -89,6 +89,11 @@ west update
 
 ## Step 2 — Generate the ARDEP Diagnostic Sources
 
+> **Licensed step.** Producing generated output requires the commercial
+> `tools/templates/` Jinja2 templates (Developer/Professional tier, not part of this
+> public repo) — see [COMMERCIAL_NOTICE.md](../COMMERCIAL_NOTICE.md). No license?
+> `examples/ardep_ecu/generated/` is already committed; skip to the build step.
+
 From the EDS repository root:
 
 ```bash

--- a/docs/CODEGEN_ARCHITECTURE.md
+++ b/docs/CODEGEN_ARCHITECTURE.md
@@ -33,6 +33,15 @@
 
 ## 1. Overview
 
+> **Licensing note:** this document describes the full generator pipeline, including the
+> Jinja2 templates in `tools/templates/`. `tools/codegen.py` itself is public, and its
+> YAML/schema/ASIL-B *validation* steps run standalone — but `tools/templates/` is a
+> commercial Developer/Professional-tier deliverable, gitignored and not part of this
+> public repo, and is required to actually render the C/pytest/GUI output described
+> below. Every bundled example ships its generated output pre-committed, so the OSS
+> runtime builds and runs without ever invoking the generator. See
+> [COMMERCIAL_NOTICE.md](../COMMERCIAL_NOTICE.md).
+
 The Xaloqi EDS uses a configuration-driven architecture where all diagnostic behaviour is defined in a single YAML file and automatically transformed into production C code, a pytest test suite, and a TypeScript GUI catalog.
 
 This approach delivers several compounding advantages:

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -129,6 +129,13 @@ You should see the codegen help text. If you see a Python import error, re-run
 The code generator reads `diagnostics_config.yaml` and produces the C source files
 that implement your DID and DTC tables, safety wrappers, and init sequence.
 
+> **Licensed step.** `tools/codegen.py` is public and its YAML/schema validation runs
+> standalone, but actually *producing* the C output below requires the commercial
+> `tools/templates/` Jinja2 templates (a Developer/Professional-tier deliverable, not
+> part of this public repo) — see [COMMERCIAL_NOTICE.md](../COMMERCIAL_NOTICE.md).
+> **No license? Skip this step.** `basic_ecu`'s `generated/` output is already
+> committed to the repo, so Steps 6–8 (`west build` and run) work without it.
+
 ```bash
 # From the eds repo root
 python3 tools/codegen.py \

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -76,7 +76,7 @@ The following table covers every service defined in ISO 14229-1:2020. "Implement
 | Physical addressing | **Partial** | The Zephyr CAN RX filter in `zephyr_can.c` installs one filter for 0x7DF. Adding a second filter for a physical address (e.g. 0x7E0) requires one additional `can_add_rx_filter_msgq()` call — see `platform/zephyr/zephyr_can.c` line 271 for the comment. |
 | Extended addressing (29-bit) | **Out of scope** | `is_extended_id` field exists in `uds_can_frame_t` but 29-bit addressing is not tested and not officially supported. |
 | Mixed addressing | **Out of scope** | — |
-| CAN FD (ISO 15765-2 §9.8) | **Implemented** (v1.7.1+) | Enable with `ISOTP_ENABLE_CAN_FD=1` (`CONFIG_CAN_FD_MODE=y` on Zephyr). Adds SF escape sequence (up to 62-byte SF), FF escape sequence (32-bit FF_DL for PDU > 4095 bytes). Set `isotp_cfg_t.use_fd = true` to activate. Platform HAL wired in `zephyr_can.c` and `freertos_can.c` since v1.7.2. |
+| CAN FD (ISO 15765-2 §9.8) | **Implemented** (v1.7.1+) | Enable with `ISOTP_ENABLE_CAN_FD=1` (`CONFIG_CAN_FD_MODE=y` on Zephyr). Adds SF escape sequence (up to 62-byte SF), FF escape sequence (32-bit FF_DL for PDU > 4095 bytes). Set `isotp_cfg_t.use_fd = true` to activate. Platform HAL wired in `zephyr_can.c` and `freertos_can.c` since v1.7.2. **This is a transport-layer limit only** — the UDS application-layer buffer (`uds_msg_buf_t` in `core/uds_types.h`, `data[UDS_MAX_PAYLOAD_LEN]` + `uint16_t length`) is still capped at 4095 data bytes regardless of what CAN FD ISO-TP can reassemble underneath; see "Max PDU length" below. |
 | Max PDU length | **4095 bytes** | Defined by `UDS_MAX_PAYLOAD_LEN` in `core/uds_types.h`. Reducible at compile time to save RAM (see §2). |
 | Per-direction state and recovery | **Implemented** (unreleased) | RX and TX are independent state machines. `isotp_get_rx_state()` / `isotp_get_tx_state()` report each direction faithfully; `isotp_reset_rx()` / `isotp_reset_tx()` recover one direction without disturbing a transfer in flight in the other. `isotp_get_state()` is retained unchanged for source compatibility, but it collapses both directions — it reports the TX state whenever a transmit is in progress, so an RX error is invisible through it for the duration of that transmit. Prefer the directional accessors in new code. |
 
@@ -102,8 +102,10 @@ The following table covers every service defined in ISO 14229-1:2020. "Implement
 
 - **Functional addressing only by default**: 0x7DF RX filter installed. Physical addressing requires one additional `can_add_rx_filter_msgq()` call — not a code change, only a configuration extension.
 - **Single-ECU only**: no gateway routing. Multi-ECU addressing (ISO 15765-3 normal fixed addressing to 0x7Ex/0x18DAxxxx) is not implemented.
-- **CAN FD available but opt-in**: `ISOTP_ENABLE_CAN_FD=1` enables CAN FD ISO-TP (SF escape up to 62 bytes, FF escape for PDU > 4095 bytes). Disabled by default — classic CAN remains the tested default transport. See §1.2 above for details.
-- **DoIP available** (ISO 13400-2): see Section 5 (DoIP Integration) below. CAN and DoIP
+- **CAN FD available but opt-in**: `ISOTP_ENABLE_CAN_FD=1` enables CAN FD ISO-TP (SF escape up to 62 bytes, FF escape for PDU > 4095 bytes). Disabled by default — classic CAN remains the tested default transport. See §1.2 above for details. **This raises the transport's own ceiling, not the application-layer one**: `uds_msg_buf_t` (`core/uds_types.h`) is a fixed `data[4095]` + `uint16_t length`, so a single diagnostic PDU is still capped at 4095 bytes at the UDS/service layer no matter how large a PDU CAN FD ISO-TP can carry. Anything larger than that (e.g. large-payload OTA) needs a streaming transfer-manager layered on top of the UDS download services (0x34/0x36/0x37) — CAN FD alone does not make single-PDU large-payload transfers work end-to-end through the UDS service layer as-is.
+- **DoIP available** — a DoIP diagnostic server subset (ISO 13400-2 routing activation +
+  diagnostic messaging; vehicle identification, vehicle announcement, and entity status
+  are out of scope): see Section 5b (DoIP Integration) below. CAN and DoIP
   use the same UDS core — `ecu.transport: doip` in YAML selects the DoIP path.
 - **Strict programming session gate (optional, v1.7.2)**: some OEM toolchains (BMW, VAG) require Extended session before Programming. Enable after init:
   ```c
@@ -772,6 +774,16 @@ SafeBoot integrates platform flash storage with UDS download services
 (0x34 RequestDownload / 0x36 TransferData / 0x37 RequestTransferExit) via
 a single YAML flag. Codegen handles the wiring automatically.
 
+**Scope boundary.** EDS + SafeBoot provide the diagnostic transfer plumbing and
+boot-integration hooks: the 0x34/0x36/0x37 wiring, CRC-32 verification before image
+acceptance, and the MCUboot secondary-slot / STM32H743 dual-bank flash backend. SafeBoot
+is **not** a complete secure-update platform. Image **signing**, **anti-rollback policy**,
+**A/B or transactional apply with power-loss recovery**, and **HSM integration** are out
+of scope and must be supplied by the integrator — typically via MCUboot's own
+image-signing tooling (for the `zephyr` platform path) or a dedicated update-management
+stack layered on top. Treat SafeBoot as the UDS-to-flash bridge, not a turnkey OTA
+security solution.
+
 Two platform paths are available:
 
 | `safeboot.platform` | Flash driver | MCUboot | Reference example |
@@ -911,7 +923,12 @@ See `examples/safeboot_ecu/README.md` for the complete annotated script.
 
 ## 5b. DoIP Integration — Ethernet/TCP transport {#doip-integration}
 
-DoIP (ISO 13400-2) was added in EDS v1.6.0. It uses the same UDS server core and ASIL-B
+DoIP (ISO 13400-2) was added in EDS v1.6.0. EDS implements a **DoIP diagnostic server
+subset** — routing activation and diagnostic messaging (the entity/server side that a
+tester talks to) — not the full ISO 13400-2 surface: UDP vehicle identification, vehicle
+announcement, and entity status requests are out of scope (see the DoIP Feature Matrix
+in [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) §6.2 for the complete implemented/not-implemented
+list). It uses the same UDS server core and ASIL-B
 safety chain as the CAN/ISO-TP transport. Selecting DoIP is a YAML field change — no
 C code differences.
 

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -27,6 +27,31 @@ tests. All four layers run automatically in CI on every push and pull request.
 | DoIP FreeRTOS build | QEMU ARM Cortex-M4 | CMake + QEMU | ✅ basic_ecu_doip_freertos CI green |
 | SafeBoot FreeRTOS build | QEMU ARM Cortex-M4 (RAM stub flash) | CMake + QEMU | ✅ safeboot_freertos_ecu CI green (`freertos-safeboot` job) |
 
+### What "the generated pytest suite" (row above) actually runs on a clean checkout
+
+`cd examples/basic_ecu/generated/tests && pytest --collect-only -q` reports **632 tests
+collected** for `basic_ecu` (v1.12.0). That is a *collection* count, not a claim that
+632 tests execute — and pass — right after `pip install -r tools/requirements.txt`. A
+meaningful share need TestLab (the commercial `xaloqi-tester` package), the
+(not-publicly-included) `firmware_bus` harness, or the commercial `tools/templates/`
+ZIP — none of which are installed by default. Measured 2026-08-31 against a checkout
+with only the OSS dependencies from `tools/requirements.txt` installed (no
+`xaloqi-tester`, no `tools/templates/`, no `--firmware` toolchain):
+
+| Category | Count | What's needed to run it |
+|---|---|---|
+| Pure validation — codegen YAML/schema/ASIL-B checks, SOVD/CDA JSON generation, and other checks that never open a transport | ~292 | Nothing beyond `tools/requirements.txt` |
+| Simulator / live-transport — DID read/write, session control, security access, routine control, DTC handling (`test_did_*.py`, `test_services.py`, `test_routine_*.py`, `test_phase1_protocol_edge_cases.py`) | ~136 | The commercial `xaloqi-tester` (TestLab) package. See `examples/*/generated/tests/requirements_testgen.txt`. `pycryptodome` alone is **not** a substitute — the transport primitives (`VirtualBus`, `IsoTpEngine`, `UdsTester`) are built on `xaloqi-tester`, not just its AES-CMAC helper. |
+| Firmware-backed (`test_firmware_services.py` and firmware-gated cases in other files) | ~57 | `pytest --firmware` plus a local cross-toolchain and the `firmware_bus` harness (not included in this public repo) |
+| Codegen-output-fidelity (`test_robustness_L_codegen_output_fidelity.py` and similar) | ~107 | The commercial `tools/templates/` Jinja2 ZIP — a Developer/Professional deliverable, see [COMMERCIAL_NOTICE.md](../COMMERCIAL_NOTICE.md) |
+| Currently fail rather than skip cleanly when `tools/templates/` is absent — a test-classification gap in `test_robustness_A_codegen.py` / `_F_codegen_limits.py` / `_K_error_quality.py`, not a runtime defect | ~40 | Tracked in [#165](https://github.com/Xaloqi/EDS/issues/165) |
+
+**Takeaway:** on a bare public-repo checkout, expect roughly 292 of 632 collected tests
+(~46%) to run and pass with no extra install; the rest require TestLab, the firmware
+harness, or the commercial templates ZIP, and are designed to skip — mostly cleanly —
+when those aren't present. Counts drift as the YAML config and generated suite evolve;
+re-run `pytest --collect-only -q` and `pytest -rs` locally for the current numbers.
+
 ---
 
 ## 2. Testing Goals


### PR DESCRIPTION
Fixes #154.

Consolidated documentation-accuracy pass covering all five items from #154. Text-only changes to `README.md` and `docs/*.md` — no code or behavior change. Each item was swept across the whole repo, not fixed in a single file, per the pattern noted in #154 (docs/ has previously lagged behind root README fixes).

## 1. "632 collected tests" isn't 632 executable-on-a-clean-checkout
`docs/TESTING_STRATEGY.md` now has a breakdown, measured against a clean checkout with only `tools/requirements.txt` installed (verified today):
- **~292** pure-validation tests (codegen YAML/schema/ASIL-B checks, SOVD/CDA generation) — run with no extra install
- **~136** simulator/live-transport tests — need the commercial `xaloqi-tester` (TestLab) package (confirmed: `pycryptodome` alone does *not* unlock these — the transport primitives themselves are built on `xaloqi-tester`)
- **~57** firmware-backed tests — need `--firmware` + local toolchain
- **~107** codegen-output-fidelity tests — need the commercial `tools/templates/` ZIP
- **~40** currently fail rather than skip cleanly when templates are absent — a pre-existing test-classification gap, filed separately as #165 (not fixed here, out of scope for a docs-only pass)

README's "Run the test suite" section now points at this breakdown and flags the separate `requirements_testgen.txt` install.

## 2. OSS runtime vs. OSS generator validation vs. commercial templates
`README.md`'s "Open-core" section and Quick Start already covered this reasonably well. The gap was in docs/ (matches the known "docs/ frozen" pattern): added the same three-way split near the top of `docs/AI_CONTEXT.md`, `docs/CODEGEN_ARCHITECTURE.md`, and as inline callouts before the `codegen.py` step in `docs/GETTING_STARTED.md` (Step 5) and `docs/ARDEP_UPGRADE_GUIDE.md` (Step 2).

## 3. CAN FD > 4095-byte transport vs. UDS application-layer buffer
Added a note to both `docs/INTEGRATION_GUIDE.md` callouts (§1.2 table row, §1.4 bullet) and the matching `docs/AI_CONTEXT.md` CAN FD section: `uds_msg_buf_t` (`core/uds_types.h`) is a fixed `data[4095]` + `uint16_t length` — a single diagnostic PDU is capped at 4095 bytes at the UDS/application layer regardless of what CAN FD ISO-TP can carry underneath.

## 4. SafeBoot vs. a complete secure-update platform
Added an explicit boundary statement wherever SafeBoot is introduced: `docs/INTEGRATION_GUIDE.md` §5 (primary), `docs/AI_CONTEXT.md`'s SafeBoot section, and `docs/ARCHITECTURE.md`'s ECU-examples section. EDS + SafeBoot provide diagnostic transfer + boot-integration hooks; signing, anti-rollback policy, A/B/transactional apply, and HSM integration are integrator-supplied and out of scope.

## 5. DoIP: "diagnostic server subset," not full ISO 13400
`docs/ARCHITECTURE.md` §6.2 already scoped this correctly internally (full feature matrix with explicit "out of scope" rows). Reworded the external-facing copy to match: README's "What you get" table, `docs/INTEGRATION_GUIDE.md` (§1.4 bullet and §5b intro), and `docs/AI_CONTEXT.md`'s DoIP integration section now say "DoIP diagnostic server subset (ISO 13400-2 routing activation + diagnostic messaging)" and cross-reference the ARCHITECTURE.md feature matrix instead of implying full ISO 13400 coverage.

---

**Files touched:** `README.md`, `docs/AI_CONTEXT.md`, `docs/ARCHITECTURE.md`, `docs/ARDEP_UPGRADE_GUIDE.md`, `docs/CODEGEN_ARCHITECTURE.md`, `docs/GETTING_STARTED.md`, `docs/INTEGRATION_GUIDE.md`, `docs/TESTING_STRATEGY.md` (8 files).

Also filed #165 for a pre-existing bug found while verifying the item-1 numbers (some codegen-robustness tests fail instead of skipping cleanly when `tools/templates/` is absent) — tracked separately per repo convention, not fixed in this docs-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)