### PR TITLE
build: compile the EDS stack once instead of 44 times; add mandatory ASan/UBSan CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,6 +478,100 @@ jobs:
       - name: Run CTest
         run: ctest --test-dir build --output-on-failure
 
+      # [#151 / run-013] ctest exits 0 on "all registered tests passed", which
+      # says nothing about how many were registered. If tests/CMakeLists.txt
+      # ever drifts from build_tests.sh's TESTS array again — the exact O-26
+      # failure this job exists to prevent — ctest would happily report 100%
+      # on a subset. Assert the real count instead, derived from the module
+      # sources so it cannot go stale, with a floor so a wiped directory
+      # cannot make the assertion vacuous.
+      - name: Assert CTest registered and ran every module
+        shell: bash
+        run: |
+          expected=$(find tests/unit_runnable -maxdepth 1 -name 'test_*.c' | wc -l)
+          echo "modules in tests/unit_runnable/: $expected"
+          [ "$expected" -ge 40 ] \
+            || (echo "FAIL: only $expected module source(s) found — expectation unusable" && exit 1)
+          registered=$(ctest --test-dir build -N | grep -cE '^ *Test +#[0-9]+:')
+          echo "tests registered with CTest: $registered"
+          [ "$registered" -eq "$expected" ] \
+            || (echo "FAIL: CTest registered $registered test(s), expected $expected —" \
+                     "tests/CMakeLists.txt has drifted from build_tests.sh (see O-26/#92)" \
+                && exit 1)
+          result=$(ctest --test-dir build 2>&1 | tail -5)
+          echo "$result"
+          echo "$result" | grep -q "100% tests passed, 0 tests failed out of $expected" \
+            || (echo "FAIL: expected '100% tests passed, 0 tests failed out of $expected'" && exit 1)
+          echo "PASS: CTest ran all $expected modules, 0 failed"
+
+  # ── Job 1c: ASan + UBSan on the host unit tests ────────────────────────────
+  #
+  # [#151] core/, transport/, config/ and platform/ are hand-managed C under a
+  # strict no-malloc/no-recursion policy. Until this job existed there was no
+  # sanitizer build anywhere in this repo's CI — `grep -rn "fsanitize"` over
+  # .github/workflows/ and build_tests.sh returned nothing — so memory-safety
+  # and undefined-behaviour defects had no automated detector at all. On its
+  # very first run this job found a real one that had been silently corrupting
+  # a test stack frame on every CI run: EDS#168.
+  #
+  # It is affordable only because of #151's other half: the shared stack
+  # archive means this second, fully instrumented build of the whole suite
+  # compiles ~150 translation units rather than ~1,900.
+  #
+  # The pass/fail decision lives in scripts/verify_sanitizer_gate.sh rather
+  # than in this YAML, so it can be run and tested locally, and so the
+  # reasoning behind each assertion has somewhere to live. Read that file's
+  # header for why an exit-code check would not have been enough.
+  sanitizers:
+    name: "Sanitizers — ASan + UBSan (host unit tests)"
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends gcc python3 python3-pip binutils
+
+      - name: Install Python dependencies
+        run: pip install pyyaml jinja2
+
+      - name: Verify pre-committed generated files are present
+        run: |
+          for f in examples/basic_ecu/generated/uds_init.c \
+                   examples/basic_ecu/generated/did_handlers.c \
+                   examples/basic_ecu/generated/safety_config.h \
+                   examples/basic_ecu/generated/generated_config.h; do
+            test -f "$f" && echo "OK: $f" || (echo "MISSING: $f" && exit 1)
+          done
+
+      # halt_on_error/abort_on_error harden from the runtime side what
+      # -fno-sanitize-recover=all does at compile time: a diagnostic must
+      # take the process down, never just print and continue.
+      # detect_leaks stays on deliberately — the host build substitutes a
+      # malloc-backed NVM store for the Zephyr flash driver, which is exactly
+      # the kind of test-only allocation that can leak unnoticed.
+      - name: Build and run all unit tests under ASan + UBSan
+        shell: bash
+        env:
+          ASAN_OPTIONS: "detect_leaks=1:detect_stack_use_after_return=1:strict_string_checks=1:abort_on_error=0"
+          UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1"
+        run: bash build_tests.sh --sanitize --keep-bin 2>&1 | tee sanitizer_run.log
+
+      # THE gate. Asserts positively that the suite really ran, on really
+      # instrumented binaries, with a live sanitizer that is still able to
+      # fail — see scripts/verify_sanitizer_gate.sh.
+      - name: Verify the sanitizer run (positive assertions, see run-013)
+        shell: bash
+        run: bash scripts/verify_sanitizer_gate.sh sanitizer_run.log build_test_host
+
+      - name: Upload sanitizer log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sanitizer-run-log
+          path: sanitizer_run.log
+
   # ── Job 5: Generated integration tests (simulator mode) ───────────────────
   #
   # Runs the auto-generated pytest suite produced by --test-gen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,77 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **Mandatory ASan + UBSan CI job on the host unit tests.** (#151) There was
+  no sanitizer build anywhere in this repo's CI — `grep -rn "fsanitize"`
+  over `.github/workflows/` and `build_tests.sh` returned nothing — even
+  though `core/`, `transport/`, `config/` and `platform/` are hand-managed C
+  under a no-malloc/no-recursion policy. New `sanitizers` job runs
+  `bash build_tests.sh --sanitize`, which builds and runs all 44 modules
+  with `-fsanitize=address,undefined -fno-sanitize-recover=all`
+  (`-fno-sanitize-recover` matters: UBSan's default is to print one line and
+  let the process exit 0). `--sanitize` is also available locally.
+  The gate is `scripts/verify_sanitizer_gate.sh`, written to the run-013
+  lesson — it asserts positive success rather than absence of failure:
+  - both a planted ASan violation and a planted UBSan violation are still
+    caught on this runner, using the flags recovered from `build_tests.sh`
+    itself, so the gate proves it can fail before it is allowed to pass;
+  - every test binary that ran carries `__asan*`/`__ubsan*` symbols, checked
+    in the ELF rather than taken on trust;
+  - the module count matches `tests/unit_runnable/`, and the suite executed
+    at least 800 assertions with zero failures.
+  Verified by deliberately injecting a stack-buffer-overflow and a signed
+  integer overflow into a test module (caught, with real reports), by
+  running the gate against an uninstrumented build, an empty log, a
+  short-count log and a short-module log (all rejected), and against clean
+  code (44 modules / 894 cases / 0 failures / 0 diagnostics).
+- **`cmake-ctest-build` now asserts CTest registered and ran every module.**
+  (#151) `ctest` exits 0 on "all registered tests passed", which says
+  nothing about how many were registered — a `tests/CMakeLists.txt` that
+  drifted from `build_tests.sh` again (the O-26/#92 failure) would report
+  100% on a subset. The count is derived from `tests/unit_runnable/` so it
+  cannot go stale, with a floor so a wiped directory cannot make it vacuous.
+
+### Changed
+
+- **The C unit test build compiles the EDS stack once instead of 44 times.**
+  (#151) `build_tests.sh` and `tests/CMakeLists.txt` both compiled all 47
+  shared sources independently for each of the 44 test modules — ~1,900
+  translation units for what is ~47 objects plus 44 small drivers. The stack
+  is now compiled once per compile-time configuration:
+  `build_tests.sh` produces `libeds_testable.a` and links it with
+  `--whole-archive`; `tests/CMakeLists.txt` uses an OBJECT library
+  (the portable equivalent on its CMake 3.16 baseline). Wall-clock:
+  `build_tests.sh` **58.1s → 12.5s**, CMake configure+build+ctest
+  **19.8s → 3.1s**. The source list and compile definitions stay mirrored
+  1:1 between the two paths, as O-26/#92 requires.
+  - `--whole-archive` / OBJECT library is not cosmetic: a plain static-archive
+    link extracts only the members needed to resolve an already-undefined
+    symbol. Measured on this codebase that silently drops 279 symbols,
+    including `g_uds_service_table` and the entire DID handler set — and the
+    affected module still reports PASS.
+  - Two modules need the *shared* sources built in a different configuration
+    (`test_trng_fail_closed` with `CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0`,
+    `test_uds_acl_permissive_opt_in` with
+    `UDS_ACL_ALLOW_UNLISTED_SERVICES=1`; both macros change code in
+    `core/uds_security_algo.c`, `core/uds_access_table.c` and
+    `core/uds_server.c`). They get their own library variant. Confirmed
+    load-bearing rather than decorative: linked against the default library
+    instead, each drops from 4/4 to 1/4 passing. The variant id is derived
+    from the flags themselves, so a third per-module `-D` automatically
+    gets a third library rather than silently reusing the default one.
+  - Verified content-identical, not merely "still green": every test
+    binary's full Unity output was captured before and after and diffed —
+    byte-for-byte identical, 44 modules / 894 cases / 0 failures, via
+    `build_tests.sh`, via the `--whole-archive`-less fallback path, and via
+    a real `cmake`/`ctest` run (100%, 44/44).
+- **`build_tests.sh` now reports and asserts the number of test *cases* that
+  ran**, not just how many modules exited 0. (#151, run-013) A module whose
+  `run_all_tests()` executes nothing still exits 0 and was reported as PASS;
+  the summary now carries a `Unit Test Cases: N run, M failed` line and the
+  script fails if any module executed zero cases.
+
 ### Security
 
 - **SecurityAccess stayed unlocked across an S3 inactivity timeout.** (#140)
@@ -27,6 +98,17 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   `test_s3_timeout_resets_security_unlock` in `test_uds_server.c`.
 
 ### Fixed
+
+- **Stack-buffer-overflow in `test_uds_security.c`.** (#168, found by #151's
+  new ASan job on its first run) `test_uds_security_send_key__test_null_key`
+  declared `uint8_t seed[4]` but passed it to `do_seed_request()`, which
+  declares the buffer to the stack as `UDS_SECURITY_SEED_LEN` (8) bytes — so
+  `core/uds_security.c:219`'s `memcpy` wrote 4 bytes past the end of a test
+  stack frame on every run, silently, with the module still reporting PASS.
+  The production stack is not at fault and is unchanged: it already rejects
+  an honestly-declared short buffer with `UDS_STATUS_ERR_BUFFER_OVERFLOW`.
+  The test buffer now uses the macro, as every other seed buffer in the
+  suite already did.
 
 - **CI's "Integration Tests (generated, simulator mode)" job has executed
   zero tests since the initial public release.** (#141, #142) `conftest.py`'s

--- a/build_tests.sh
+++ b/build_tests.sh
@@ -3,9 +3,35 @@
 # Xaloqi EDS
 # build_tests.sh  (project root)
 #
-# PURPOSE: Build and run all 43 host-side C unit tests.
-#          Each test module is compiled independently with the full
-#          diagnostics stack linked in, then executed immediately.
+# PURPOSE: Build and run every host-side C unit test module in
+#          tests/unit_runnable/. The full diagnostics stack is linked into
+#          every test binary, so each module exercises integration between
+#          modules and not just the unit under test.
+#
+# [#151] BUILD ONCE, LINK N TIMES
+#   This script used to compile all ~44 stack sources from scratch for every
+#   single test module (~44 x ~44 = ~1,900 translation units per run). The
+#   stack is now compiled once into a static archive, and each test module
+#   contributes only its own small driver .c file:
+#
+#       STACK_SRCS  --(compiled once per configuration)-->  libeds_testable.a
+#       test_foo.c  --(compiled per module)--------------->  test_foo
+#
+#   Two modules need the shared sources built in a DIFFERENT compile-time
+#   configuration and therefore get their own archive variant — see
+#   extra_flags_for_test() below for the full rationale. The variant id is
+#   derived from the flags themselves, so adding a third per-module -D
+#   automatically produces a third archive instead of silently reusing the
+#   default one and testing the wrong configuration.
+#
+#   The archive is pulled in with --whole-archive so that EVERY object is
+#   linked into every test binary, exactly as when the sources were listed
+#   on the command line. Without it, the linker would only extract archive
+#   members that resolve an already-undefined symbol, which would silently
+#   change link semantics (weak/strong interposition, e.g. test_main.c's
+#   weak setUp/tearDown, and objects reachable only through data tables).
+#   On a linker without --whole-archive the object files are listed
+#   directly instead, which has the same all-objects-linked semantics.
 #
 # CANONICAL TEST DIRECTORY: tests/unit_runnable/
 #   This script and tests/CMakeLists.txt both reference tests/unit_runnable/.
@@ -25,7 +51,7 @@
 #         --out examples/basic_ecu/generated/ --safety-wrappers --asil-level B --no-manifest
 #
 # USAGE:
-#   bash build_tests.sh              # Build + run all 43 tests
+#   bash build_tests.sh              # Build + run every test module
 #   bash build_tests.sh --verbose    # Show individual test output
 #   bash build_tests.sh --keep-bin   # Keep binaries in build_test_host/
 #   bash build_tests.sh --coverage   # Build with gcov + generate lcov HTML report
@@ -61,21 +87,35 @@ BUILD_DIR="${ROOT}/build_test_host"
 VERBOSE=0
 KEEP_BIN=0
 COVERAGE=0
+SANITIZE=0
 
 for arg in "$@"; do
     case "$arg" in
         --verbose)  VERBOSE=1  ;;
         --keep-bin) KEEP_BIN=1 ;;
         --coverage) COVERAGE=1 ; KEEP_BIN=1 ;;  # [P2-4] keep objects for gcov
+        --sanitize) SANITIZE=1 ;;               # [#151] ASan + UBSan
         --help)
-            echo "Usage: $0 [--verbose] [--keep-bin] [--coverage]"
+            echo "Usage: $0 [--verbose] [--keep-bin] [--coverage] [--sanitize]"
             echo "  --verbose   Print full output of each test binary."
             echo "  --keep-bin  Do not delete compiled test binaries after run."
             echo "  --coverage  Compile with gcov + generate HTML report."
+            echo "  --sanitize  Compile and run under AddressSanitizer +"
+            echo "              UndefinedBehaviorSanitizer (see the CI"
+            echo "              'sanitizers' job). Not combinable with --coverage."
             exit 0
             ;;
     esac
 done
+
+# gcov instrumentation and the sanitizer runtimes both rewrite the same code
+# paths; mixing them produces coverage data nobody reads and sanitizer reports
+# nobody can attribute. Refuse the combination rather than silently favouring
+# one of them.
+if [[ $COVERAGE -eq 1 && $SANITIZE -eq 1 ]]; then
+    echo "ERROR: --coverage and --sanitize cannot be combined."
+    exit 1
+fi
 
 # ---------------------------------------------------------------------------
 # Compiler flags
@@ -117,6 +157,30 @@ if [[ $COVERAGE -eq 1 ]]; then
     mkdir -p "${COVERAGE_DIR}"
 fi
 
+# ---------------------------------------------------------------------------
+# [#151] Sanitizer instrumentation.
+#
+# core/, transport/, config/ and platform/ are hand-managed C with a strict
+# no-malloc/no-recursion policy, which makes memory-safety and UB errors both
+# more likely to be silent and more expensive to find later. The shared stack
+# archive from #151 made a second full instrumented build cheap enough to run
+# on every PR, so CI now does (job 'sanitizers' in .github/workflows/ci.yml).
+#
+# -fno-sanitize-recover=all is what makes this a GATE rather than a log:
+# UBSan's default behaviour is to print a one-line "runtime error:" and CARRY
+# ON with exit status 0, so a job that only checked the exit code would go
+# green on a real undefined-behaviour finding. With this flag the process
+# aborts on the first violation. ASAN_OPTIONS/UBSAN_OPTIONS in the CI job
+# harden the same property from the runtime side.
+# ---------------------------------------------------------------------------
+if [[ $SANITIZE -eq 1 ]]; then
+    CFLAGS+=(
+        "-fsanitize=address,undefined"
+        "-fno-sanitize-recover=all"
+        "-fno-omit-frame-pointer"
+    )
+fi
+
 # Inject ztest_shim.h before every translation unit so that all
 # ztest_* macros resolve without the Zephyr headers present.
 SHIM_INCLUDE="-include ${ROOT}/tests/runner/ztest_shim.h"
@@ -132,6 +196,19 @@ SHIM_INCLUDE="-include ${ROOT}/tests/runner/ztest_shim.h"
 # CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY is defined as 0 (see the
 # ALGO_ENTROPY_FAIL_CLOSED gate in that file). Keyed on the test name ($t
 # in the build loop below).
+#
+# [#151] These flags change the compiled code of SHARED stack sources, not
+# just the test driver:
+#   CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY -> core/uds_security_algo.{c,h},
+#                                        examples/basic_ecu/generated/uds_init.c
+#   UDS_ACL_ALLOW_UNLISTED_SERVICES   -> core/uds_access_table.{c,h},
+#                                        core/uds_server.c
+# A module listed here therefore CANNOT link against the default
+# libeds_testable.a — it would silently test the default configuration under
+# a test name that claims to prove the other one. Each distinct flag set gets
+# its own archive variant instead (see build_stack_lib below). This function
+# is the single source of truth for both the driver's flags and its archive's
+# flags, so the two can never skew apart.
 # ---------------------------------------------------------------------------
 extra_flags_for_test() {
     case "$1" in
@@ -328,9 +405,168 @@ fi
 # ---------------------------------------------------------------------------
 mkdir -p "${BUILD_DIR}"
 
+# ===========================================================================
+# [#151] Shared stack archive(s) — compiled once, linked into every module.
+# ===========================================================================
+
+LIB_DIR="${BUILD_DIR}/lib"
+
+# --- Linker capability probe ------------------------------------------------
+# --whole-archive is a GNU ld / lld flag. Probe for it once rather than
+# assuming it: on a linker that lacks it (Apple ld, for instance) the object
+# files are listed on the link line directly, which has identical
+# all-objects-are-linked semantics, just without the archive indirection.
+# Set EDS_TEST_FORCE_NO_WHOLE_ARCHIVE=1 to exercise that fallback on a GNU
+# host — it is how the fallback path gets tested rather than assumed.
+WHOLE_ARCHIVE_OK=0
+if [[ "${EDS_TEST_FORCE_NO_WHOLE_ARCHIVE:-0}" != "1" ]]; then
+    if printf 'int main(void){return 0;}\n' \
+        | gcc -x c - -Wl,--whole-archive -Wl,--no-whole-archive -o /dev/null 2>/dev/null
+    then
+        WHOLE_ARCHIVE_OK=1
+    fi
+fi
+
+# Archive variant id for a test module, derived from its own extra flags so
+# that a new per-module -D cannot silently reuse the default archive.
+variant_id_for_test() {
+    local flags
+    flags="$(extra_flags_for_test "$1")"
+    if [[ -z "${flags//[[:space:]]/}" ]]; then
+        echo "default"
+    else
+        printf '%s' "${flags}" \
+            | tr -cs 'A-Za-z0-9' '_' \
+            | sed -e 's/^_*//' -e 's/_*$//' \
+            | tr 'A-Z' 'a-z'
+    fi
+}
+
+archive_path_for_variant() {
+    if [[ "$1" == "default" ]]; then
+        echo "${LIB_DIR}/libeds_testable.a"
+    else
+        echo "${LIB_DIR}/libeds_testable__$1.a"
+    fi
+}
+
+# variant id -> newline-separated link arguments that pull in the whole stack
+declare -A STACK_LINK_ARGS=()
+# variant id -> the extra compile flags that define it (empty for 'default')
+declare -A VARIANT_FLAGS=()
+# variant id -> space-separated list of the test modules that use it
+declare -A VARIANT_TESTS=()
+
+build_stack_lib() {
+    local variant="$1"
+    shift
+    local -a vflags=("$@")
+
+    local objdir="${LIB_DIR}/${variant}"
+    local archive
+    archive="$(archive_path_for_variant "${variant}")"
+
+    mkdir -p "${objdir}"
+    rm -f "${archive}"
+
+    local -a objs=()
+    local src rel obj out rc
+    for src in "${STACK_SRCS[@]}"; do
+        rel="${src#"${ROOT}/"}"
+        # Full relative path in the object name: two sources with the same
+        # basename in different directories must not collide.
+        obj="${objdir}/${rel//\//_}.o"
+        out=$(
+            gcc "${CFLAGS[@]}" "${vflags[@]}" ${SHIM_INCLUDE} "${INCLUDES[@]}" \
+                -c "${src}" -o "${obj}" 2>&1
+        ) && rc=0 || rc=$?
+        if [[ ${rc} -ne 0 ]]; then
+            echo "ERROR: failed to compile ${rel} into stack variant '${variant}'."
+            echo "${out}" | sed 's/^/    /'
+            return 1
+        fi
+        objs+=("${obj}")
+    done
+
+    out=$(ar rcs "${archive}" "${objs[@]}" 2>&1) && rc=0 || rc=$?
+    if [[ ${rc} -ne 0 ]]; then
+        echo "ERROR: ar failed for stack variant '${variant}'."
+        echo "${out}" | sed 's/^/    /'
+        return 1
+    fi
+
+    # [run-013] Positive assertion, not merely "nothing errored": the archive
+    # must exist AND contain exactly one member per stack source. An archive
+    # that silently came out short would otherwise link fine for most modules
+    # and only surface as a mystery undefined-reference much later.
+    local members
+    members=$(ar t "${archive}" | wc -l)
+    if [[ "${members}" -ne "${#STACK_SRCS[@]}" ]]; then
+        echo "ERROR: ${archive##*/} has ${members} member(s), expected ${#STACK_SRCS[@]}."
+        return 1
+    fi
+
+    if [[ ${WHOLE_ARCHIVE_OK} -eq 1 ]]; then
+        STACK_LINK_ARGS["${variant}"]=$(
+            printf '%s\n' "-Wl,--whole-archive" "${archive}" "-Wl,--no-whole-archive"
+        )
+    else
+        STACK_LINK_ARGS["${variant}"]=$(printf '%s\n' "${objs[@]}")
+    fi
+    return 0
+}
+
 PASS=0
 FAIL=0
 TOTAL=${#TESTS[@]}
+# [run-013] Aggregate assertion counters — see the positive success check
+# after the run loop.
+CASES_RUN=0
+CASES_FAILED=0
+ZERO_CASE_MODULES=()
+
+# Group the modules by the archive variant each one needs.
+for t in "${TESTS[@]}"; do
+    v="$(variant_id_for_test "${t}")"
+    VARIANT_FLAGS["${v}"]="$(extra_flags_for_test "${t}")"
+    VARIANT_TESTS["${v}"]="${VARIANT_TESTS[${v}]:-}${t} "
+done
+
+echo ""
+echo "================================================================"
+echo "  Shared stack archives  (${#STACK_SRCS[@]} sources x ${#VARIANT_FLAGS[@]} configuration(s))"
+echo "================================================================"
+echo ""
+if [[ ${WHOLE_ARCHIVE_OK} -eq 1 ]]; then
+    echo "  Link mode: --whole-archive (every archive member is linked)"
+else
+    echo "  Link mode: explicit object list (--whole-archive unavailable)"
+fi
+echo ""
+
+LIB_FAIL=0
+for v in "${!VARIANT_FLAGS[@]}"; do
+    read -r -a vflags <<< "${VARIANT_FLAGS[${v}]}"
+    if build_stack_lib "${v}" "${vflags[@]}"; then
+        n_modules=$(wc -w <<< "${VARIANT_TESTS[${v}]}")
+        if [[ "${v}" == "default" ]]; then
+            printf "  %-38s  OK  (%s module(s), default configuration)\n" \
+                "$(basename "$(archive_path_for_variant "${v}")")" "${n_modules}"
+        else
+            printf "  %-38s  OK  (%s module(s): %s)\n" \
+                "$(basename "$(archive_path_for_variant "${v}")")" \
+                "${n_modules}" "${VARIANT_FLAGS[${v}]}"
+        fi
+    else
+        LIB_FAIL=1
+    fi
+done
+echo ""
+
+if [[ ${LIB_FAIL} -ne 0 ]]; then
+    echo "FAIL: one or more shared stack archives failed to build."
+    exit 1
+fi
 
 echo ""
 echo "================================================================"
@@ -344,6 +580,9 @@ for t in "${TESTS[@]}"; do
 
     # [SEC-TRNG-FAILCLOSED-01] Per-test extra flags (empty for most tests).
     read -r -a extra_flags <<< "$(extra_flags_for_test "${t}")"
+    # [#151] ...and the stack archive built with those very same flags.
+    variant="$(variant_id_for_test "${t}")"
+    mapfile -t stack_link_args <<< "${STACK_LINK_ARGS[${variant}]}"
 
     # ── Build ──────────────────────────────────────────────────────────
     # [FIX-SETE] With set -euo pipefail active, `var=$(failing_cmd)` exits
@@ -353,7 +592,7 @@ for t in "${TESTS[@]}"; do
     build_out=$(
         gcc "${CFLAGS[@]}" "${extra_flags[@]}" ${SHIM_INCLUDE} "${INCLUDES[@]}" \
             "${test_src}" \
-            "${STACK_SRCS[@]}" \
+            "${stack_link_args[@]}" \
             -o "${bin}" 2>&1
     ) && build_rc=0 || build_rc=$?
 
@@ -371,20 +610,77 @@ for t in "${TESTS[@]}"; do
     # [FIX-SETE] Same set -e + $() trap applies to test binary execution.
     run_out=$(timeout 30 "${bin}" 2>&1) && run_rc=0 || run_rc=$?
 
+    # [run-013] Count the assertions each module actually executed, not just
+    # whether the process exited 0. A module whose run_all_tests() executed
+    # nothing at all still exits 0 and would otherwise be indistinguishable
+    # from one that ran its whole suite. The per-module floor is enforced
+    # after the loop.
+    module_cases=$(sed -n 's/^Tests run:[[:space:]]*\([0-9][0-9]*\).*/\1/p' <<< "${run_out}" | tail -1)
+    module_failed=$(sed -n 's/^Tests failed:[[:space:]]*\([0-9][0-9]*\).*/\1/p' <<< "${run_out}" | tail -1)
+    if [[ -z "${module_cases}" ]]; then
+        # No Unity summary at all — a crash, a sanitizer abort, or a binary
+        # that never reached UNITY_END(). Recorded as zero so the positive
+        # assertion below catches it.
+        module_cases=0
+        module_failed=0
+        ZERO_CASE_MODULES+=("${t}")
+    elif [[ "${module_cases}" -eq 0 ]]; then
+        ZERO_CASE_MODULES+=("${t}")
+    fi
+    CASES_RUN=$((CASES_RUN + module_cases))
+    CASES_FAILED=$((CASES_FAILED + module_failed))
+
     if [[ $run_rc -eq 0 ]]; then
-        printf "  %-45s  PASS\n" "${t}"
+        printf "  %-45s  PASS  (%s cases)\n" "${t}" "${module_cases}"
         PASS=$((PASS + 1))
     else
-        printf "  %-45s  FAIL\n" "${t}"
+        printf "  %-45s  FAIL  (%s cases)\n" "${t}" "${module_cases}"
         if [[ $VERBOSE -eq 1 ]]; then
             echo "    --- test output ---"
             echo "$run_out" | grep -E "FAIL|ERROR|assert" | sed 's/^/    /' || true
         else
             echo "$run_out" | grep -E "FAIL|ERROR" | head -3 | sed 's/^/    /' || true
         fi
+        # Sanitizer diagnostics are never truncated away: an ASan/UBSan report
+        # is the entire reason the --sanitize build exists.
+        if [[ $SANITIZE -eq 1 ]]; then
+            echo "    --- sanitizer output ---"
+            echo "$run_out" \
+                | grep -E "Sanitizer|runtime error|SUMMARY:|#[0-9]+ 0x" \
+                | head -40 | sed 's/^/    /' || true
+        fi
         FAIL=$((FAIL + 1))
     fi
 done
+
+# ---------------------------------------------------------------------------
+# [run-013] Positive success assertion.
+#
+# "0 failed" is not the same statement as "the suite ran". A module that
+# executed zero assertions exits 0 and is counted as PASS by the loop above;
+# so is a whole suite that somehow produced no test binaries at all. Assert
+# what actually happened — every module reported a Unity summary, and every
+# module ran at least one case — instead of only the absence of failures.
+# ---------------------------------------------------------------------------
+# Tracked separately from FAIL so that "N passed, M failed" keeps summing to
+# the module count — a module that aborts is already counted once in FAIL.
+ZERO_CASE_FAIL=0
+
+if [[ ${#ZERO_CASE_MODULES[@]} -gt 0 ]]; then
+    echo ""
+    echo "FAIL: ${#ZERO_CASE_MODULES[@]} module(s) executed zero test cases:"
+    printf '    %s\n' "${ZERO_CASE_MODULES[@]}"
+    echo "      A module that runs nothing still exits 0 and would otherwise"
+    echo "      be reported as PASS (see knowledge lessons/run-013)."
+    ZERO_CASE_FAIL=1
+fi
+
+if [[ ${CASES_RUN} -lt ${TOTAL} ]]; then
+    echo ""
+    echo "FAIL: only ${CASES_RUN} test case(s) ran across ${TOTAL} module(s)."
+    echo "      Every module must execute at least one assertion."
+    ZERO_CASE_FAIL=1
+fi
 
 # ---------------------------------------------------------------------------
 # [ISSUE-87] Anti-drift guard: every ZTEST(suite, name) case in
@@ -455,10 +751,14 @@ fi
 #
 # No separate regression-guard compile: the default dev-mode compile
 # (-DUNIT_TEST=1, no CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY) is already proven by
-# every one of the ~42 test modules built in the main loop above, all of
-# which link core/uds_security_algo.c under that exact configuration -- a
-# second compile here would only re-prove a fact the main loop already
-# established, on every single invocation of this script.
+# the default libeds_testable.a built above -- core/uds_security_algo.c is
+# compiled into it under exactly that configuration, and every module that
+# is not listed in extra_flags_for_test() links against it. A second compile
+# here would only re-prove a fact the archive build already established, on
+# every single invocation of this script.
+# [#151] Before the shared-archive restructure this same fact was re-proven
+# ~42 times per run (once per test module); it is now proven once. Nothing
+# about the configuration under test changed.
 # ---------------------------------------------------------------------------
 CRIT4_TMP_OBJ="$(mktemp -u /tmp/eds_crit4_negtest.XXXXXX.o)"
 # Reuses INCLUDES (defined above) rather than its own copy -- a second,
@@ -590,8 +890,15 @@ fi
 # ---------------------------------------------------------------------------
 echo ""
 echo "================================================================"
+if [[ $SANITIZE -eq 1 ]]; then
+    echo "  === Build: ASan + UBSan (-fsanitize=address,undefined) ==="
+fi
+# [run-013] The cases line states what actually ran; the summary line states
+# what passed. A reader (or a CI gate) needs both — "0 failed" alone cannot
+# distinguish a green suite from a suite that executed nothing.
+echo "  === Unit Test Cases: ${CASES_RUN} run, ${CASES_FAILED} failed ==="
 echo "  === Unit Test Summary: ${PASS} passed, ${FAIL} failed ==="
 echo "================================================================"
 echo ""
 
-[[ $FAIL -eq 0 ]]
+[[ $FAIL -eq 0 && $ZERO_CASE_FAIL -eq 0 ]]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -597,6 +597,7 @@ on a pull request:
 |---|---|
 | `unit-tests` | Unit Tests |
 | `cmake-ctest-build` | CMake/CTest Build (parity with build_tests.sh) |
+| `sanitizers` | Sanitizers — ASan + UBSan (host unit tests) |
 | `integration-tests` | Integration Tests (generated, simulator mode) |
 | `static-analysis` | Static Analysis + MISRA C:2012 (zero open violations) |
 | `zephyr-native` | Zephyr Build — native_sim |

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -406,6 +406,13 @@ push / PR
    ├── unit-tests          44 Unity modules via build_tests.sh
    │                       + ASIL-B assertion checks (self-test, key gate, write security)
    │
+   ├── cmake-ctest-build   The same modules via cmake -S tests + ctest
+   │                       + membership assertion vs tests/unit_runnable/
+   │
+   ├── sanitizers          The same modules via build_tests.sh --sanitize,
+   │                       built and run under ASan + UBSan
+   │                       + scripts/verify_sanitizer_gate.sh positive gate
+   │
    ├── integration-tests   Generated pytest suite, simulator mode
    │                       + zero dynamic allocation grep gate
    │
@@ -424,7 +431,10 @@ push / PR
                            + 10 pytest end-to-end tests (skipped when TestLab absent)
 ```
 
-All 8 jobs must pass before a PR can be merged.
+Every job must pass before a PR can be merged. The tree above names the
+test-bearing jobs; the `jobs:` block in `.github/workflows/ci.yml` is the
+authoritative list, because a hand-maintained job count here has already
+drifted twice (#91, #119) — this line claimed 8.
 
 ### FreeRTOS CI job (`freertos-qemu`)
 

--- a/scripts/verify_sanitizer_gate.sh
+++ b/scripts/verify_sanitizer_gate.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Xaloqi EDS
+# scripts/verify_sanitizer_gate.sh
+#
+# PURPOSE: The pass/fail gate for CI's 'sanitizers' job (issue #151).
+#
+#          `bash build_tests.sh --sanitize` builds and runs every host unit
+#          test module under AddressSanitizer + UndefinedBehaviorSanitizer.
+#          This script decides whether that run may be called green.
+#
+# WHY THIS IS NOT `if build_tests.sh; then echo ok; fi`
+#
+#          Knowledge lessons/run-013: a CI gate must assert POSITIVE success,
+#          not merely the absence of failure. EDS shipped a green
+#          "Integration Tests" job that executed zero tests from the initial
+#          public release onward, because its gate was
+#          `grep -q "failed" && exit 1 || true` and "136 skipped" contains no
+#          "failed". Every one of these would pass an exit-code-only gate on
+#          a run with no sanitizer coverage whatsoever:
+#
+#            - the --sanitize flag silently stops being applied (arg-parsing
+#              regression, renamed flag, a `case` arm that stopped matching);
+#            - the compiler on the runner has no sanitizer runtime, so the
+#              instrumentation is a no-op;
+#            - UBSan finds a real violation but, being recoverable by
+#              default, prints one line and lets the process exit 0;
+#            - the test loop builds nothing, or builds binaries that execute
+#              zero assertions and still exit 0.
+#
+#          So this script asserts, positively and in order:
+#            1. The project's sanitizer flags can be recovered from
+#               build_tests.sh at all (if not, everything below is vacuous).
+#            2. Those exact flags really do catch a planted ASan violation
+#               AND a planted UBSan violation on this runner, right now.
+#               The gate proves it can fail before it is allowed to pass.
+#            3. The test binaries that were actually run carry ASan and UBSan
+#               instrumentation (checked in the ELF, not taken on trust).
+#            4. Every test module was built and run, none aborted, and the
+#               suite executed a real minimum number of assertions with zero
+#               failures.
+#            5. No sanitizer diagnostic appears anywhere in the run log.
+#
+# USAGE:
+#   bash build_tests.sh --sanitize --keep-bin 2>&1 | tee sanitizer_run.log
+#   bash scripts/verify_sanitizer_gate.sh sanitizer_run.log [build_test_host]
+#
+# EXIT CODES:
+#   0  The sanitizer run genuinely happened and was genuinely clean.
+#   1  Any assertion above failed.
+#
+# SAFETY CONTEXT : CI infrastructure — not safety-assessed.
+# SPDX-License-Identifier: GPL-2.0-only
+# =============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+LOG="${1:-}"
+BIN_DIR="${2:-${ROOT}/build_test_host}"
+
+if [[ -z "${LOG}" || ! -f "${LOG}" ]]; then
+    echo "usage: bash scripts/verify_sanitizer_gate.sh <run-log> [bin-dir]"
+    exit 1
+fi
+
+# A module that ran zero assertions is the exact failure run-013 describes,
+# so the floor is deliberately close to the real number (894 at the time of
+# writing) rather than a token "> 0". It is a floor, not an equality, so
+# adding test cases never breaks the gate; removing most of them does.
+MIN_CASES=800
+# Guards against the module list itself being wiped: the expected module
+# count is derived from the repo (so it never goes stale), but a derived
+# expectation of 0 or 3 must not be allowed to satisfy the gate.
+MIN_MODULES=40
+
+FAILURES=0
+note_fail() {
+    echo "  FAIL: $*"
+    FAILURES=$((FAILURES + 1))
+}
+
+echo "================================================================"
+echo "  [#151] Sanitizer gate — positive verification"
+echo "================================================================"
+echo ""
+
+# ---------------------------------------------------------------------------
+# 1. Recover the project's sanitizer flags from build_tests.sh.
+#
+# Derived rather than duplicated: a second hand-maintained copy of the flag
+# list is precisely the "two copies of the same fact drift apart" failure
+# this repo keeps paying for. If the derivation itself breaks, that is a hard
+# failure — silently falling back to "no flags" would make step 2 vacuous.
+# ---------------------------------------------------------------------------
+mapfile -t SAN_FLAGS < <(
+    sed -n '/^if \[\[ \$SANITIZE -eq 1 \]\]; then/,/^fi$/p' "${ROOT}/build_tests.sh" \
+        | grep -oE '"-f[^"]+"' | tr -d '"'
+)
+
+echo "--- 1. sanitizer flags recovered from build_tests.sh ---"
+if [[ ${#SAN_FLAGS[@]} -eq 0 ]]; then
+    note_fail "could not recover any -f flags from build_tests.sh's --sanitize block."
+    echo "        Everything below would be vacuous; refusing to continue."
+    exit 1
+fi
+printf '  %s\n' "${SAN_FLAGS[@]}"
+
+if ! printf '%s\n' "${SAN_FLAGS[@]}" | grep -q -- '-fsanitize=address,undefined'; then
+    note_fail "-fsanitize=address,undefined is not among the recovered flags."
+fi
+if ! printf '%s\n' "${SAN_FLAGS[@]}" | grep -q -- '-fno-sanitize-recover=all'; then
+    note_fail "-fno-sanitize-recover=all is not among the recovered flags — UBSan" \
+              "would print a diagnostic and let the process exit 0."
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# 2. Canaries: prove the gate can fail, on this runner, with these flags.
+#
+# Two deliberately-broken programs, one per sanitizer, compiled with the
+# flags recovered above. Each must be caught. If a canary is NOT caught, the
+# sanitizer coverage on this runner is not real and the clean run below
+# proves nothing.
+#
+# The canaries live here, generated into a temp dir, rather than as committed
+# .c files: a file containing a deliberate buffer overrun must never be
+# reachable by any other build in this repo.
+# ---------------------------------------------------------------------------
+CANARY_DIR="$(mktemp -d)"
+trap 'rm -rf "${CANARY_DIR}"' EXIT
+
+cat > "${CANARY_DIR}/asan_canary.c" <<'CANARY_EOF'
+/* Deliberate heap-buffer-overflow. Must be caught by AddressSanitizer. */
+#include <stdlib.h>
+#include <string.h>
+int main(void)
+{
+    volatile size_t n = 5U;          /* volatile: not foldable at compile time */
+    char *p = (char *)malloc(4U);
+    if (p == NULL) { return 2; }
+    memset(p, 'x', n);               /* one byte past the end of a 4-byte block */
+    free(p);
+    return 0;
+}
+CANARY_EOF
+
+cat > "${CANARY_DIR}/ubsan_canary.c" <<'CANARY_EOF'
+/* Deliberate signed integer overflow. Must be caught by UBSan. */
+#include <limits.h>
+int main(void)
+{
+    volatile int a = INT_MAX;
+    volatile int b = 1;
+    return (int)(a + b);             /* signed overflow: undefined behaviour */
+}
+CANARY_EOF
+
+check_canary() {
+    local name="$1" expect="$2"
+    local src="${CANARY_DIR}/${name}_canary.c"
+    local bin="${CANARY_DIR}/${name}_canary"
+    local out rc
+
+    if ! gcc -std=c11 -g -O0 "${SAN_FLAGS[@]}" "${src}" -o "${bin}" 2>"${CANARY_DIR}/${name}.build"; then
+        note_fail "${name} canary failed to COMPILE with the project's sanitizer flags:"
+        sed 's/^/        /' "${CANARY_DIR}/${name}.build"
+        return
+    fi
+
+    out=$("${bin}" 2>&1) && rc=0 || rc=$?
+
+    if [[ ${rc} -eq 0 ]]; then
+        note_fail "${name} canary exited 0 — a deliberate violation was NOT caught." \
+                  "Sanitizer coverage on this runner is not real."
+        return
+    fi
+    if ! grep -qE "${expect}" <<< "${out}"; then
+        note_fail "${name} canary failed, but not with the expected diagnostic" \
+                  "(/${expect}/). Got:"
+        sed 's/^/        /' <<< "${out}" | head -5
+        return
+    fi
+    echo "  OK: ${name} canary was caught — $(grep -oE "${expect}" <<< "${out}" | head -1)"
+}
+
+echo "--- 2. canaries (the gate must be able to fail before it may pass) ---"
+check_canary asan  'AddressSanitizer: heap-buffer-overflow'
+check_canary ubsan 'runtime error: signed integer overflow'
+echo ""
+
+# ---------------------------------------------------------------------------
+# 3. The binaries that actually ran must carry the instrumentation.
+#
+# The canaries prove the toolchain works; this proves the flags reached the
+# test binaries themselves. Without it, --sanitize could quietly stop being
+# applied to the suite while the canaries kept passing.
+# ---------------------------------------------------------------------------
+echo "--- 3. instrumentation present in the test binaries ---"
+EXPECTED_MODULES=$(find "${ROOT}/tests/unit_runnable" -maxdepth 1 -name 'test_*.c' | wc -l)
+if [[ "${EXPECTED_MODULES}" -lt "${MIN_MODULES}" ]]; then
+    note_fail "only ${EXPECTED_MODULES} module source(s) found in tests/unit_runnable/" \
+              "(expected at least ${MIN_MODULES}) — the expectation itself is unusable."
+fi
+
+if [[ ! -d "${BIN_DIR}" ]]; then
+    note_fail "binary directory ${BIN_DIR} does not exist — was --keep-bin passed?"
+else
+    mapfile -t BINARIES < <(find "${BIN_DIR}" -maxdepth 1 -type f -executable -name 'test_*' | LC_ALL=C sort)
+    echo "  test binaries found: ${#BINARIES[@]} (expected ${EXPECTED_MODULES})"
+    if [[ ${#BINARIES[@]} -ne ${EXPECTED_MODULES} ]]; then
+        note_fail "expected ${EXPECTED_MODULES} test binaries, found ${#BINARIES[@]}."
+    fi
+
+    uninstrumented=0
+    for b in "${BINARIES[@]}"; do
+        syms=$(nm -D "${b}" 2>/dev/null || true)
+        if ! grep -q '__asan' <<< "${syms}" || ! grep -q '__ubsan' <<< "${syms}"; then
+            echo "        not instrumented: $(basename "${b}")"
+            uninstrumented=$((uninstrumented + 1))
+        fi
+    done
+    if [[ ${uninstrumented} -ne 0 ]]; then
+        note_fail "${uninstrumented} test binary/binaries carry no ASan+UBSan symbols."
+    elif [[ ${#BINARIES[@]} -gt 0 ]]; then
+        echo "  OK: all ${#BINARIES[@]} test binaries carry both __asan* and __ubsan* symbols"
+    fi
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# 4. The run itself: assert what happened, not that nothing went wrong.
+# ---------------------------------------------------------------------------
+echo "--- 4. the run executed the whole suite ---"
+
+if ! grep -q '=== Build: ASan + UBSan' "${LOG}"; then
+    note_fail "the log does not state that this was a sanitizer build —" \
+              "build_tests.sh did not take its --sanitize branch."
+fi
+
+num_from() {  # num_from <regex-with-one-group>
+    sed -nE "s/.*$1.*/\1/p" "${LOG}" | tail -1
+}
+passed=$(num_from 'Unit Test Summary: ([0-9]+) passed')
+failed=$(num_from 'Unit Test Summary: [0-9]+ passed, ([0-9]+) failed')
+cases_run=$(num_from 'Unit Test Cases: ([0-9]+) run')
+cases_failed=$(num_from 'Unit Test Cases: [0-9]+ run, ([0-9]+) failed')
+
+if [[ -z "${passed}" || -z "${failed}" || -z "${cases_run}" || -z "${cases_failed}" ]]; then
+    note_fail "could not parse the summary lines out of ${LOG}." \
+              "The run did not reach its own summary."
+else
+    echo "  modules: ${passed} passed, ${failed} failed (expected ${EXPECTED_MODULES} passed, 0 failed)"
+    echo "  cases:   ${cases_run} run, ${cases_failed} failed (floor ${MIN_CASES} run, 0 failed)"
+
+    [[ "${failed}" -eq 0 ]]        || note_fail "${failed} module(s) failed."
+    [[ "${cases_failed}" -eq 0 ]]  || note_fail "${cases_failed} test case(s) failed."
+    [[ "${passed}" -eq "${EXPECTED_MODULES}" ]] \
+        || note_fail "${passed} module(s) passed but tests/unit_runnable/ holds ${EXPECTED_MODULES}."
+    [[ "${cases_run}" -ge "${MIN_CASES}" ]] \
+        || note_fail "only ${cases_run} test case(s) executed (floor ${MIN_CASES}) —" \
+                     "the suite ran, but barely; something is being skipped."
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# 5. No sanitizer diagnostic anywhere in the log.
+#
+# Secondary to the assertions above, deliberately: on its own this is exactly
+# the "absence of a bad string" check run-013 warns about, and an empty log
+# would satisfy it. It is here to catch a diagnostic that somehow did not
+# take the process down.
+# ---------------------------------------------------------------------------
+echo "--- 5. no sanitizer diagnostics in the run log ---"
+diag=$(grep -cE 'AddressSanitizer|LeakSanitizer|UndefinedBehaviorSanitizer|runtime error:|SUMMARY: .*Sanitizer' "${LOG}" || true)
+if [[ "${diag}" -ne 0 ]]; then
+    note_fail "${diag} sanitizer diagnostic line(s) in ${LOG}:"
+    grep -nE 'AddressSanitizer|LeakSanitizer|UndefinedBehaviorSanitizer|runtime error:|SUMMARY: .*Sanitizer' \
+        "${LOG}" | head -20 | sed 's/^/        /'
+else
+    echo "  OK: none"
+fi
+echo ""
+
+echo "================================================================"
+if [[ ${FAILURES} -ne 0 ]]; then
+    echo "  FAIL: sanitizer gate — ${FAILURES} assertion(s) failed."
+    echo "================================================================"
+    exit 1
+fi
+echo "  PASS: ${EXPECTED_MODULES} modules / ${cases_run} cases ran under"
+echo "        ASan + UBSan with 0 failures and 0 sanitizer diagnostics,"
+echo "        on binaries verified to be instrumented, with both canaries"
+echo "        confirming the gate can still fail."
+echo "================================================================"
+exit 0

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,25 +2,49 @@
 # Xaloqi EDS
 # FILE: tests/CMakeLists.txt
 #
-# PURPOSE: Host-native CMake build for all 43 unit test modules.
-#          Compiles each test_*.c file together with the FULL diagnostics
-#          stack (mirroring build_tests.sh's STACK_SRCS) and the Unity
-#          framework into a standalone executable. CTest then runs each
-#          executable and reports pass/fail based on exit code.
+# PURPOSE: Host-native CMake build for every unit test module in
+#          tests/unit_runnable/. The FULL diagnostics stack (mirroring
+#          build_tests.sh's STACK_SRCS) is linked into every test executable
+#          alongside the Unity framework. CTest then runs each executable and
+#          reports pass/fail based on exit code.
 #
 #          Architecture:
 #            tests/CMakeLists.txt (this file)
 #              -> tests/runner/test_main.c         (Unity main + lifecycle)
 #              -> tests/runner/ztest_shim.h        (ZTEST-to-Unity macro map)
 #              -> project/unity/unity.c            (Unity assertion engine)
-#              -> tests/unit_runnable/test_<module>.c  (canonical test cases — 43 modules)
+#              -> tests/unit_runnable/test_<module>.c  (canonical test cases)
 #              -> <production sources>             (the entire diagnostics stack)
 #              -> examples/basic_ecu/generated/ did_handlers.c etc. (generated stubs)
 #
-#          This design allows all 43 modules to be tested on a CI runner
+#          This design allows every module to be tested on a CI runner
 #          without a Zephyr SDK or hardware target, using only GCC/Clang
-#          and CMake. Each test module compiles independently to avoid
-#          link-time symbol conflicts between test modules.
+#          and CMake.
+#
+#          [#151] BUILD ONCE, LINK N TIMES
+#          The stack used to be listed in every single add_diag_test() call,
+#          so CMake compiled all ~44 stack sources once per test target
+#          (~1,900 translation units). It is now compiled once into an
+#          OBJECT library whose objects are linked into every test
+#          executable; only each module's own driver .c is compiled
+#          per-target. This mirrors build_tests.sh's libeds_testable.a.
+#
+#          Why an OBJECT library and not a STATIC one: every object must end
+#          up in every test binary, exactly as when the sources were listed
+#          per-target. A plain static-archive link would extract only the
+#          members needed to resolve an already-undefined symbol and would
+#          silently drop the rest (measured on this codebase: 279 symbols,
+#          including g_uds_service_table and the whole DID handler set, with
+#          the affected module still reporting PASS). build_tests.sh gets
+#          that guarantee from GNU ld's --whole-archive; the portable CMake
+#          equivalent, on the 3.16 baseline this file targets, is an OBJECT
+#          library. Same semantics, expressed in each build system's idiom —
+#          what O-26 requires the two paths to keep in lockstep is the source
+#          list and the compile definitions, and those remain mirrored 1:1.
+#
+#          Two modules need the SHARED sources compiled in a different
+#          configuration and therefore get their own OBJECT library variant;
+#          see eds_stack_objects() and build_tests.sh's extra_flags_for_test().
 #
 #          [EDS#88 FIX] This file previously (a) pointed generated sources at
 #          <repo-root>/generated/, which does not exist — the real location
@@ -54,14 +78,15 @@
 #
 # SAFETY CONTEXT : Test infrastructure — not safety-assessed.
 # CODING STANDARD: MISRA C:2012 alignment intended (advisory for test code).
-# VERSION        : 1.8.0 (43 modules wired — parity with build_tests.sh; see EDS#88)
+# VERSION        : 1.9.0 (shared stack OBJECT library — see #151; module list
+#                  stays at parity with build_tests.sh's TESTS array, see EDS#88)
 # SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 
 cmake_minimum_required(VERSION 3.16)
 
 project(diag_unit_tests
-    VERSION     1.8.0
+    VERSION     1.9.0
     LANGUAGES   C
     DESCRIPTION "Host-native Unity unit tests — Xaloqi EDS"
 )
@@ -105,7 +130,7 @@ set(DIAG_PLATFORM_ZEPHYR "${DIAG_ROOT}/platform/zephyr")
 # This matches build_tests.sh's STACK_SRCS / INCLUDES exactly.
 set(DIAG_GENERATED     "${DIAG_ROOT}/examples/basic_ecu/generated")
 set(DIAG_UNITY         "${DIAG_ROOT}/project/unity")
-# [M2] Canonical test directory is unit_runnable/ (43 modules).
+# [M2] Canonical test directory is unit_runnable/.
 # tests/legacy_unit/ has been removed — unit_runnable/ is the single source of truth.
 # build_tests.sh and this CMakeLists.txt both reference unit_runnable/.
 set(TEST_UNIT_DIR      "${CMAKE_CURRENT_SOURCE_DIR}/unit_runnable")
@@ -197,26 +222,79 @@ set(DIAG_TEST_COMPILE_OPTIONS
 )
 
 # ---------------------------------------------------------------------------
+# [#151] eds_stack_objects(OUT_VAR [<defines>...])
+#
+# Returns (in OUT_VAR) the name of the OBJECT library holding the whole
+# diagnostics stack compiled with the given extra compile definitions,
+# creating it on first use. One library per distinct definition set:
+#
+#   no defines                            -> eds_stack_default
+#   CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0   -> eds_stack_config_diag_placeholder_keys_only_0
+#   UDS_ACL_ALLOW_UNLISTED_SERVICES=1     -> eds_stack_uds_acl_allow_unlisted_services_1
+#
+# The library name is DERIVED FROM THE DEFINES, exactly as build_tests.sh
+# derives its archive variant id from extra_flags_for_test()'s output. That
+# is the point: a module that needs a third compile-time configuration of the
+# shared sources automatically gets a third library, instead of silently
+# linking the default one and "proving" a configuration it never compiled.
+#
+# test_main.c is part of the stack here (it is identical for every module and
+# carries the weak setUp/tearDown defaults each test_*.c overrides), matching
+# build_tests.sh's STACK_SRCS. unity.c is NOT: it is provided by the 'unity'
+# static library below, which is compiled once and shared by every target.
+# ---------------------------------------------------------------------------
+function(eds_stack_objects OUT_VAR)
+    set(_defs ${ARGN})
+
+    if(NOT _defs)
+        set(_objlib "eds_stack_default")
+    else()
+        string(REPLACE ";" "_" _slug "${_defs}")
+        string(REGEX REPLACE "[^A-Za-z0-9]+" "_" _slug "${_slug}")
+        string(REGEX REPLACE "^_+|_+$" "" _slug "${_slug}")
+        string(TOLOWER "${_slug}" _slug)
+        set(_objlib "eds_stack_${_slug}")
+    endif()
+
+    if(NOT TARGET ${_objlib})
+        add_library(${_objlib} OBJECT
+            "${TEST_RUNNER_DIR}/test_main.c"
+            ${DIAG_STACK_SRCS}
+        )
+        target_include_directories(${_objlib} PRIVATE ${DIAG_INCLUDE_DIRS})
+        target_compile_options(${_objlib} PRIVATE ${DIAG_TEST_COMPILE_OPTIONS})
+        if(_defs)
+            target_compile_definitions(${_objlib} PRIVATE ${_defs})
+        endif()
+    endif()
+
+    set(${OUT_VAR} ${_objlib} PARENT_SCOPE)
+endfunction()
+
+# ---------------------------------------------------------------------------
 # Helper function: add_diag_test(name SOURCES sources... [DEFINES ...])
 #
 # Creates a test executable named 'name' that:
-#   - Compiles the listed source files, plus tests/runner/test_main.c
+#   - Compiles the listed source files (just the module's own driver .c)
+#   - Links in every object of the shared stack OBJECT library built with
+#     this target's DEFINES  [#151]
 #   - Links against Unity
 #   - Includes all DIAG_INCLUDE_DIRS
 #   - Applies DIAG_TEST_COMPILE_OPTIONS
 #   - Registers with CTest via add_test()
 #
-# NOTE: test_main.c is added here unconditionally — do not also list it in
-# a call's SOURCES (CMake errors on a source file listed twice in one
-# add_executable). Likewise unity.c is provided via the 'unity' link
-# library, not as a direct source, to avoid linking its symbols twice.
+# NOTE: neither test_main.c nor unity.c may be listed in a call's SOURCES.
+# test_main.c comes from the stack OBJECT library and unity.c from the
+# 'unity' link library; listing either again would duplicate its symbols.
 # ---------------------------------------------------------------------------
 function(add_diag_test TEST_NAME)
     cmake_parse_arguments(ARG "" "" "SOURCES;DEFINES" ${ARGN})
 
+    eds_stack_objects(_stack_objlib ${ARG_DEFINES})
+
     add_executable(${TEST_NAME}
-        "${TEST_RUNNER_DIR}/test_main.c"
         ${ARG_SOURCES}
+        $<TARGET_OBJECTS:${_stack_objlib}>
     )
 
     target_include_directories(${TEST_NAME} PRIVATE
@@ -254,14 +332,17 @@ endfunction()
 # per-target hand-maintained SOURCES lists (previously the pattern in this
 # file) unnecessary and prone to drift: one dependency graph, one list.
 #
+# [#151] This list is now compiled ONCE per configuration, into the OBJECT
+# library that eds_stack_objects() creates, rather than once per test target.
+#
 # Two files from STACK_SRCS's bash array are deliberately NOT repeated here:
 #   - project/unity/unity.c   — provided via the 'unity' static library
 #                                (target_link_libraries), not as a direct
 #                                source; listing it again would double-link
 #                                its symbols.
-#   - tests/runner/test_main.c — added unconditionally inside add_diag_test()
-#                                 above; listing it again is a duplicate
-#                                 source file, which CMake rejects.
+#   - tests/runner/test_main.c — added inside eds_stack_objects() above, so
+#                                 it is compiled once with the stack rather
+#                                 than once per test target.
 # ===========================================================================
 set(DIAG_STACK_SRCS
     # UDS core
@@ -324,230 +405,195 @@ set(DIAG_STACK_SRCS
 )
 
 # ===========================================================================
-# Test targets — one per module under test (43 total, matching
-# build_tests.sh's TESTS array 1:1 — see EDS#88)
+# Test targets — one per module under test, matching build_tests.sh's
+# TESTS array 1:1 (see EDS#88). The count is deliberately not written down
+# here: ci.yml's "Verify test count" step and scripts/verify_doc_counts.py
+# are what keep it honest, and a number in a comment has drifted twice.
 # ===========================================================================
 
 add_diag_test(test_uds_session
     SOURCES
         "${TEST_UNIT_DIR}/test_uds_session.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_uds_security
     SOURCES
         "${TEST_UNIT_DIR}/test_uds_security.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_uds_safety
     SOURCES
         "${TEST_UNIT_DIR}/test_uds_safety.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_uds_server
     SOURCES
         "${TEST_UNIT_DIR}/test_uds_server.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_did_database
     SOURCES
         "${TEST_UNIT_DIR}/test_did_database.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_dtc_database
     SOURCES
         "${TEST_UNIT_DIR}/test_dtc_database.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_dtc_mirror
     SOURCES
         "${TEST_UNIT_DIR}/test_dtc_mirror.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_routine_database
     SOURCES
         "${TEST_UNIT_DIR}/test_routine_database.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_did_handlers
     SOURCES
         "${TEST_UNIT_DIR}/test_did_handlers.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_did_safety_wrappers
     SOURCES
         "${TEST_UNIT_DIR}/test_did_safety_wrappers.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_can_transport
     SOURCES
         "${TEST_UNIT_DIR}/test_can_transport.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_isotp
     SOURCES
         "${TEST_UNIT_DIR}/test_isotp.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_isotp_concurrent
     SOURCES
         "${TEST_UNIT_DIR}/test_isotp_concurrent.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_service_0x10
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x10.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_service_0x11
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x11.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_service_0x14
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x14.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_service_0x19
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x19.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_service_0x22
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x22.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_service_0x27
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x27.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_service_0x28
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x28.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_uds_periodic
     SOURCES
         "${TEST_UNIT_DIR}/test_uds_periodic.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_service_0x2A
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x2A.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_service_0x2F
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x2F.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_service_0x31
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x31.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_service_0x23_0x3D
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x23_0x3D.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_service_0x34
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x34.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_service_0x35
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x35.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_service_0x36
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x36.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_service_0x37
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x37.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_service_0x3E
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x3E.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_service_0x85
     SOURCES
         "${TEST_UNIT_DIR}/test_service_0x85.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_phase2_suppress_bit
     SOURCES
         "${TEST_UNIT_DIR}/test_phase2_suppress_bit.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_phase2_session_matrix
     SOURCES
         "${TEST_UNIT_DIR}/test_phase2_session_matrix.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_phase2_isotp_stmin
     SOURCES
         "${TEST_UNIT_DIR}/test_phase2_isotp_stmin.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_phase3_nvm_security
     SOURCES
         "${TEST_UNIT_DIR}/test_phase3_nvm_security.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_phase3_nvm_dtc
     SOURCES
         "${TEST_UNIT_DIR}/test_phase3_nvm_dtc.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_phase3_nvm_integration
     SOURCES
         "${TEST_UNIT_DIR}/test_phase3_nvm_integration.c"
-        ${DIAG_STACK_SRCS}
 )
 
 # ---------------------------------------------------------------------------
@@ -562,31 +608,26 @@ add_diag_test(test_phase3_nvm_integration
 add_diag_test(test_phase5_security_algo
     SOURCES
         "${TEST_UNIT_DIR}/test_phase5_security_algo.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_phase5_access_table
     SOURCES
         "${TEST_UNIT_DIR}/test_phase5_access_table.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_phase5_server_access
     SOURCES
         "${TEST_UNIT_DIR}/test_phase5_server_access.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_phase5_replay_protection
     SOURCES
         "${TEST_UNIT_DIR}/test_phase5_replay_protection.c"
-        ${DIAG_STACK_SRCS}
 )
 
 add_diag_test(test_doip_server
     SOURCES
         "${TEST_UNIT_DIR}/test_doip_server.c"
-        ${DIAG_STACK_SRCS}
 )
 
 # ---------------------------------------------------------------------------
@@ -601,7 +642,6 @@ add_diag_test(test_doip_server
 add_diag_test(test_trng_fail_closed
     SOURCES
         "${TEST_UNIT_DIR}/test_trng_fail_closed.c"
-        ${DIAG_STACK_SRCS}
     DEFINES
         CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0
 )
@@ -617,7 +657,6 @@ add_diag_test(test_trng_fail_closed
 add_diag_test(test_uds_acl_permissive_opt_in
     SOURCES
         "${TEST_UNIT_DIR}/test_uds_acl_permissive_opt_in.c"
-        ${DIAG_STACK_SRCS}
     DEFINES
         UDS_ACL_ALLOW_UNLISTED_SERVICES=1
 )

--- a/tests/unit_runnable/test_uds_security.c
+++ b/tests/unit_runnable/test_uds_security.c
@@ -367,7 +367,17 @@ ZTEST(test_uds_security_send_key, test_null_key)
 {
     uds_security_ctx_t ctx;
     zassert_equal(default_sec_init(&ctx), UDS_STATUS_OK, "init failed");
-    uint8_t seed[4]; uint8_t seed_len;
+    /*
+     * [#151] Must be UDS_SECURITY_SEED_LEN, not 4: do_seed_request() declares
+     * the buffer to uds_security_request_seed() as UDS_SECURITY_SEED_LEN
+     * bytes, so a 4-byte array here has the stack memcpy 8 bytes into it.
+     * Found by the new ASan/UBSan CI job as a stack-buffer-overflow at
+     * core/uds_security.c:219 — it had been silently corrupting this frame on
+     * every run. The stack itself is correct: it rejects an honestly-declared
+     * short buffer with UDS_STATUS_ERR_BUFFER_OVERFLOW. Every other seed
+     * buffer in this suite already uses the macro.
+     */
+    uint8_t seed[UDS_SECURITY_SEED_LEN]; uint8_t seed_len;
     do_seed_request(&ctx, seed, &seed_len);
     zassert_equal(uds_security_send_key(&ctx, UDS_SEC_LEVEL_1_KEY, NULL, 4U),
                   UDS_STATUS_ERR_NULL_PTR, "NULL key must fail");


### PR DESCRIPTION
Fixes #151
Fixes #168

## Part 1 — build once, link 44 times

`build_tests.sh` and `tests/CMakeLists.txt` each compiled all **47 shared sources independently for every one of the 44 test modules** — ~1,900 translation units for what is ~47 objects plus 44 small drivers. The stack is now compiled **once per compile-time configuration**:

| Path | Mechanism |
|---|---|
| `build_tests.sh` | `libeds_testable.a`, linked with `-Wl,--whole-archive` |
| `tests/CMakeLists.txt` | OBJECT library (`eds_stack_default`) |

Both paths keep the same source list and the same compile definitions, which is what O-26/#92 requires them to hold in lockstep. They use different mechanisms because CMake 3.16 (this file's baseline; ubuntu-22.04 ships 3.22) has no portable whole-archive genex — `$<LINK_LIBRARY:WHOLE_ARCHIVE,…>` needs 3.24. The rationale is written into both files' headers.

### Measured

| | before | after |
|---|---|---|
| `bash build_tests.sh` | **58.1 s** | **12.5 s** (−78%) |
| `cmake -S tests -B build && cmake --build -j4 && ctest` | **19.8 s** | **3.1 s** (−84%) |

### `--whole-archive` is load-bearing, not defensive

A plain static-archive link only extracts members that resolve an already-undefined symbol. Measured on this codebase by diffing `nm --defined-only` between the three link styles for `test_uds_server`:

- all-sources-on-the-command-line (the old way) vs archive + `--whole-archive` → **identical, 407 symbols**
- archive + `--whole-archive` vs plain archive link → **279 symbols silently dropped**, including `g_uds_service_table`, the whole DID handler set, DoIP and the DTC database — **and the module still reported PASS (37/37)**.

That is exactly the silent-coverage-loss trap a naive consolidation would have walked into.

### Two modules genuinely need a different configuration of the *shared* sources

The audit found exactly two, and both files already agreed on them:

| module | define | shared sources it changes |
|---|---|---|
| `test_trng_fail_closed` | `CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0` | `core/uds_security_algo.{c,h}`, `generated/uds_init.c` |
| `test_uds_acl_permissive_opt_in` | `UDS_ACL_ALLOW_UNLISTED_SERVICES=1` | `core/uds_access_table.{c,h}`, `core/uds_server.c` |

They get their own library variant. **Proven load-bearing rather than assumed** — linked against the *default* library instead:

```
test_trng_fail_closed          + default lib -> 4 run, 1 passed, 3 FAILED
test_uds_acl_permissive_opt_in + default lib -> 4 run, 1 passed, 3 FAILED
   (each + its own variant lib -> 4/4 PASSED)
```

The variant id is **derived from the flags themselves**, in both files, so a third per-module `-D` automatically gets a third library rather than silently reusing the default one and "proving" a configuration it never compiled.

### Verified content-identical, not merely "still green"

Every test binary's **full Unity output** (per-case names + counts) was captured before touching anything and diffed against each post-change run:

| run | result |
|---|---|
| pre-change baseline | 44 modules / **894 cases** / 0 failed |
| `bash build_tests.sh` after | **byte-for-byte identical** |
| `--whole-archive`-less fallback path (`EDS_TEST_FORCE_NO_WHOLE_ARCHIVE=1`) | **byte-for-byte identical** |
| real `cmake` + `ctest` after | **byte-for-byte identical**, ctest 100% (44/44) |

`--coverage` also still works; `.gcno`/`.gcda` pairs are produced for all 185 instrumented objects and `gcov` reads real merged counters.

## Part 2 — mandatory ASan/UBSan job

Confirmed absent before this PR: `grep -rn "fsanitize" .github/workflows/*.yml build_tests.sh` returned nothing.

New `sanitizers` job runs `bash build_tests.sh --sanitize`, which builds and runs **all 44 modules** with `-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer`, LeakSanitizer on. `-fno-sanitize-recover` is the part that makes it a gate: UBSan's default is to print one line and let the process exit 0. It runs in **16 s** — affordable only because of Part 1 (~150 TUs instead of ~1,900).

### The gate asserts positive success (lessons/run-013)

The pass/fail decision lives in `scripts/verify_sanitizer_gate.sh`, not in YAML, so it can be run and tested locally. In order:

1. **Recover the sanitizer flags from `build_tests.sh`** (derived, not a second copy that drifts). If recovery fails, hard error — everything below would be vacuous.
2. **Canaries.** A planted heap-buffer-overflow and a planted signed-integer-overflow, compiled with *those recovered flags*, must both still be caught on this runner. **The gate proves it can fail before it is allowed to pass.**
3. **Instrumentation in the ELF.** All 44 test binaries must carry `__asan*` *and* `__ubsan*` symbols — checked with `nm`, not taken on trust, so `--sanitize` silently ceasing to apply cannot go green.
4. **The run happened.** Module count matches `tests/unit_runnable/` (derived, with a floor of 40 so a wiped directory can't make it vacuous), 0 modules failed, ≥800 assertions executed, 0 cases failed.
5. **No sanitizer diagnostic in the log** — last and explicitly labelled as the weakest check, since on its own it is exactly the "absence of a bad string" pattern run-013 warns about.

### The gate was verified against real failures

| scenario | gate |
|---|---|
| **1-byte stack-buffer-overflow injected into a test module** | **FAILS** — real ASan `stack-buffer-overflow` report at the injected line |
| **signed integer overflow injected into a test module** | **FAILS** — real UBSan `runtime error: signed integer overflow` |
| `--sanitize` not applied (uninstrumented build) | **FAILS** — "44 binaries carry no ASan+UBSan symbols" |
| log with no tests at all | **FAILS** — "the run did not reach its own summary" |
| green log but only 12 cases ran | **FAILS** — "only 12 test case(s) executed (floor 800)" |
| green log but 41 of 44 modules | **FAILS** — "41 passed but tests/unit_runnable/ holds 44" |
| **clean code** | **PASSES** — 44 modules / 894 cases / 0 failed / 0 diagnostics |

The injections were made in the working tree only and reverted (`git diff` clean); nothing deliberately broken is committed.

### #168 — a real bug, found on the job's first run

The job immediately caught a **stack-buffer-overflow that had been silently corrupting a test stack frame on every CI run**:

```
ERROR: AddressSanitizer: stack-buffer-overflow
    #1 uds_security_request_seed core/uds_security.c:219
    #2 do_seed_request           tests/unit_runnable/test_uds_security.c:129
    #3 test_uds_security_send_key__test_null_key  ...:371
```

`test_uds_security.c` declared `uint8_t seed[4]` but `do_seed_request()` declares that buffer to the stack as `UDS_SECURITY_SEED_LEN` (**8**), so `memcpy` wrote 4 bytes past the end. The module reported `PASS` every time.

**The production stack is not at fault and is unchanged** — `uds_security_request_seed()` already rejects an honestly-declared short buffer with `UDS_STATUS_ERR_BUFFER_OVERFLOW`; the test lied about its buffer size. Fixed here (rather than deferred) because a *mandatory* gate cannot land with a known violation outstanding. Filed separately as #168 for the record.

## Two smaller hardenings in the same area

- **`cmake-ctest-build` now asserts CTest registered and ran every module.** `ctest` exits 0 on "all *registered* tests passed", which says nothing about how many were registered — a `tests/CMakeLists.txt` that drifted from `build_tests.sh` again (the O-26/#92 failure this job exists to prevent) would report a cheerful 100% on a subset. Count derived from `tests/unit_runnable/`, with a floor.
- **`build_tests.sh` now reports and asserts test *case* counts**, not just module exit codes. A module whose `run_all_tests()` executes nothing still exits 0 and was previously reported as PASS. New `=== Unit Test Cases: 894 run, 0 failed ===` line; the script fails if any module ran zero cases. The existing `grep -q "44 passed, 0 failed"` CI step still matches (verified against the real `tail -3`).

## Local verification summary

```
bash build_tests.sh                    44 passed, 0 failed / 894 cases   12.5s
cmake -S tests + ctest                 100% tests passed, 44/44           3.1s
bash build_tests.sh --sanitize         44 passed, 0 failed / 894 cases   16.3s
scripts/verify_sanitizer_gate.sh       PASS (canaries caught, 44 binaries instrumented)
scripts/verify_doc_counts.py           PASS (44)
misra_analysis.py                      0 open violations (no production C touched)
```

`bash build_harness.sh --run` is not applicable — `harness/` is a commercial ZIP deliverable and is absent from the public repo (the script says so and exits 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
