### PR TITLE
docs: consolidated documentation-accuracy pass (fixes #170, #164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,47 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+- **Consolidated documentation-accuracy pass across `docs/ARCHITECTURE.md`,
+  `docs/TESTING_STRATEGY.md`, and `docs/GETTING_STARTED.md`, plus a widened
+  `scripts/verify_doc_counts.py` guard.** (#170, #164) `docs/ARCHITECTURE.md`'s
+  repo-tree diagram claimed 36 unit-test modules (actual 44 — the line right
+  below it in the same block already said 44), showed `build_tests.sh` /
+  `build_harness.sh` nested under a `scripts/` directory that has never
+  existed (both live at the repo root), and its `tests/` node named
+  `integration/` and `harness/` subdirectories that don't exist while
+  omitting the real `tests/runner/`; also fixed the `examples/` node (listed
+  4 of 12 examples under two names — `motor_controller/`, `ardep/` — that
+  don't match the real `motor_controller_ecu/`, `ardep_ecu/` directories).
+  `docs/TESTING_STRATEGY.md` had two sections (§7 Integration Tests, §10
+  System Tests) describing a `tests/integration/` suite and a `pytest
+  --system` flag that were never built — replaced with the real generated
+  per-example suite layout and an explicit note on §10 that it describes
+  target coverage, not an implemented one; its §11 CI pipeline tree named 10
+  of the 22 real `ci.yml` jobs with no indication the list was partial —
+  added the 3 more substantive test layers it was missing
+  (`robustness-tests`, `harness-tests`, `sovd-codegen`) and an explicit
+  callout naming what's deliberately omitted (7 repetitive per-example
+  smoke-build jobs, one extra board variant) rather than trying to keep it
+  exhaustively hand-synced a third time. `docs/GETTING_STARTED.md`'s Step 8
+  walkthrough pointed at a `tests/integration/test_uds_read_did.py` that
+  never existed, with test names (`test_read_vin`, `test_read_odometer`)
+  that don't exist anywhere in the repo — replaced with a real, verified-passing
+  example (`test_did_f190.py`, the generated VIN-read suite) and corrected
+  the surrounding narrative, which had implied the request would be sent to
+  Step 7's `native_sim` process even though `--can-interface=simulator` is a
+  separate, self-contained virtual bus that doesn't talk to it.
+  `scripts/verify_doc_counts.py`'s two existing checks (#119) were both blind
+  to ASCII tree diagrams — the dead `scripts/build_tests.sh` path was split
+  across a `scripts/` tree node and a `build_tests.sh` leaf line, never on
+  one line so the substring check never fired, and `(36 modules)` matched
+  none of the prose count patterns. Widened both, and fixed a real bug found
+  while doing so: the doc sweep wasn't excluding the gitignored
+  `.claude/worktrees/` scratch directory, so a stray agent worktree with
+  stale doc copies could fail the guard for a reason having nothing to do
+  with the tracked repo. Verified per lessons/run-014: reverted just
+  `docs/ARCHITECTURE.md` to confirm the widened guard still catches the
+  original 3 problems it was built for, then restored the fix and confirmed
+  clean.
 - **`can_transport_transmit()`'s CONFIRMED-vs-queued contract was
   undocumented, even though ISO-TP's N_As/N_Ar timers depend entirely on
   it.** (#152) `transport/can_transport.h` said only that a successful

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -207,22 +207,31 @@ embedded-diagnostics-suite/
 │   │   └── useConfiguratorStore.ts # YAML config state + export/import
 │   └── server/bridge.py           # WebSocket bridge: ECU ↔ GUI + codegen runner
 │
-├── examples/
+├── examples/                    # 12 example ECUs total
 │   ├── basic_ecu/              # Minimal reference ECU (start here)
 │   ├── bms_ecu/                # Battery Management System
-│   ├── motor_controller/       # Motor controller with speed/torque DIDs
-│   └── ardep/                  # ARDEP reference platform with DFU
+│   ├── motor_controller_ecu/   # Motor controller with speed/torque DIDs
+│   ├── ardep_ecu/              # ARDEP reference platform with DFU
+│   └── ...                     # + 8 more (DoIP, FreeRTOS, SafeBoot, sensor, robot variants)
 │
 ├── tests/
-│   ├── unit_runnable/          # Canonical Unity unit tests (36 modules)
-│   ├── integration/            # Python ISO-TP/UDS simulation tests
-│   ├── harness/                # Build harness tests (68 tests)
-│   └── mocks/                  # Zephyr port mock + NVM mock for host builds
+│   ├── unit_runnable/          # Canonical Unity unit tests (44 modules)
+│   ├── runner/                 # Shared Unity test-main scaffolding — build_tests.sh
+│   │                           # and tests/CMakeLists.txt each link one module's
+│   │                           # object against libeds_testable.a (built once) + this
+│   ├── mocks/                  # Zephyr port mock + NVM mock for host builds
+│   └── CMakeLists.txt          # CTest path — mirrors build_tests.sh's source list
 │
-└── scripts/
-    ├── build_tests.sh          # Runs all 44 unit test modules
-    └── build_harness.sh        # Runs all 68 harness tests
+├── build_tests.sh              # Runs all 44 unit test modules (repo root, not scripts/)
+├── build_harness.sh            # Runs all 68 harness tests (repo root, not scripts/;
+│                                # Professional tier — harness/ sources are gitignored)
+└── run_python_tests.sh         # Canonical entrypoint for the whole Python suite —
+                                 # repo tests/ + every example, each correctly scoped
 ```
+
+The Python generated/robustness suites (`examples/*/generated/tests/`) are not
+shown above — see [TESTING_STRATEGY.md](TESTING_STRATEGY.md) for the full
+Python test layout and how to run them.
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -211,21 +211,24 @@ Press **Ctrl+C** to stop.
 
 ## Step 8 — Send a UDS Request (2 min)
 
-With the simulator running, open a second terminal and run the Python integration test
-to send a real UDS `ReadDataByIdentifier` (0x22) request:
+You can stop the Step 7 process now — the generated pytest suite below runs
+against its own self-contained virtual CAN bus (`--can-interface=simulator`),
+a separate mechanism from `native_sim`'s CAN loopback, so it doesn't need
+Step 7 left running. In a new terminal, run it to send a real UDS
+`ReadDataByIdentifier` (0x22) request for the VIN (DID 0xF190):
 
 ```bash
-# In a second terminal, from the eds repo root
-pytest tests/integration/test_uds_read_did.py -v
+# From the eds repo root
+cd examples/basic_ecu/generated/tests && pytest test_did_f190.py -v --can-interface=simulator
 ```
 
 Expected output:
 
 ```
-tests/integration/test_uds_read_did.py::test_read_vin PASSED
-tests/integration/test_uds_read_did.py::test_read_odometer PASSED
-tests/integration/test_uds_read_did.py::test_read_invalid_did_returns_nrc_31 PASSED
-tests/integration/test_uds_read_did.py::test_read_did_wrong_session_returns_nrc_7f PASSED
+test_did_f190.py::TestReadVehicleidentificationnumber::test_happy_path_returns_correct_length PASSED
+test_did_f190.py::TestReadVehicleidentificationnumber::test_response_data_not_all_zero PASSED
+test_did_f190.py::TestReadVehicleidentificationnumber::test_request_with_one_did_byte_rejected PASSED
+test_did_f190.py::TestReadVehicleidentificationnumber::test_request_with_only_sid_rejected PASSED
 ```
 
 You just sent ISO-TP framed UDS requests to a running Zephyr ECU and validated the responses.
@@ -526,7 +529,7 @@ Run the integration tests in a second terminal to send traffic while it's runnin
 | `west build -b mr_canhubk3 examples/basic_ecu -- -DEXTRA_CONF_FILE=boards/mr_canhubk3/mr_canhubk3.conf -DDTC_OVERLAY_FILE=boards/mr_canhubk3/mr_canhubk3.overlay` | Cross-compile for NXP MR-CANHUBK3 (S32K344) |
 | `west flash` | Flash to connected hardware |
 | `bash build_tests.sh` | Run 44 unit tests |
-| `pytest tests/integration/ -v` | Run Python integration tests |
+| `bash run_python_tests.sh` | Run the whole Python suite (repo `tests/` + every example, each correctly scoped) |
 | `cd gui && npm ci && npm start` | Start GUI configurator |
 | `python3 tools/testgen.py --config CONFIG --out OUT` | Generate pytest test suite |
 | `python3 tools/testgen.py --capl --config CONFIG --out OUT` | Generate pytest + CANoe CAPL |

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -275,20 +275,25 @@ handler call chain.
 Python tests using `pytest` that simulate a real diagnostic tester sending ISO-TP framed
 UDS requests to a running `native_sim` ECU process.
 
+> **No `tests/integration/` directory exists** — the tree below is the real
+> layout. Each example's generated suite is a self-contained pytest project;
+> there is no single hand-written `tests/integration/` tree to point at.
+
 ```
-tests/integration/
-├── test_isotp_transport_flow.py
-├── test_uds_read_did_flow.py
-├── test_uds_write_did_flow.py
-├── test_security_access_flow.py
-├── test_diagnostic_session_flow.py
-├── test_dtc_report_flow.py
-└── test_codegen_output.py
+examples/<name>/generated/tests/
+├── test_services.py          # Per-service protocol tests
+├── test_did_<xxxx>.py        # Per-DID read/write tests (one file per DID)
+├── test_firmware_services.py # Same assertions, against the real compiled
+│                              # harness instead of the simulator (--firmware)
+└── test_robustness_*.py      # 12-phase robustness campaign (A–L)
 ```
 
 ```bash
-# Requires native_sim ECU running in another terminal
-pytest tests/integration/ -v
+# One example, simulator mode (no hardware/harness needed)
+cd examples/basic_ecu/generated/tests && pytest test_services.py test_did_*.py -v --can-interface=simulator
+
+# Whole repo — this dir's own tests/ + every example, each correctly scoped
+bash run_python_tests.sh
 ```
 
 ### Example flow — SecurityAccess denial
@@ -400,14 +405,21 @@ Output in `examples/basic_ecu/generated/tests/capl/`:
 End-to-end tests running the complete Zephyr firmware on `native_sim`. These validate the
 full stack from Zephyr thread scheduling through ISO-TP framing down to DID handler response.
 
+> This describes target end-to-end coverage; there is no `--system` pytest
+> flag or `tests/integration/` suite implementing it today. The closest real
+> equivalent is `test_firmware_services.py --firmware` (§7 above) — the same
+> service/DID assertions run against a real compiled harness binary instead
+> of the simulator, though that's a host GCC build, not a `native_sim` Zephyr
+> process.
+
 ```bash
 # Build and run native_sim in background
 west build -b native_sim examples/basic_ecu \
     -- -DDTC_OVERLAY_FILE=boards/native_sim.overlay
 west build -t run &
 
-# Run system test suite against the running process
-pytest tests/integration/ -v --system
+# Target: a system-test suite exercising the running native_sim process
+# (not yet implemented — see note above)
 ```
 
 System test scenarios:
@@ -425,6 +437,15 @@ System test scenarios:
 
 All test layers run automatically in GitHub Actions on every push and pull request.
 
+> **This tree is a representative walkthrough, not an exhaustive list** —
+> `.github/workflows/ci.yml`'s `jobs:` block is the sole authoritative list
+> (22 jobs as of this writing), because a hand-maintained count here has
+> already drifted twice (#91, #119). Omitted below on purpose: 7 per-example
+> build-verification smoke jobs (`example-ardep`, `example-bms`,
+> `example-motor`, `example-sensor`, `example-sensor-frtos`, `example-robot`,
+> `example-safeboot` — one per specialist ECU, same shape each time) and
+> `zephyr-nxp-s32k` (a second NXP board variant of `zephyr-nxp` below).
+
 ```
 push / PR
    │
@@ -441,11 +462,20 @@ push / PR
    ├── integration-tests   Generated pytest suite, simulator mode
    │                       + zero dynamic allocation grep gate
    │
+   ├── robustness-tests    Robustness Campaign — 439 tests, 12 phases (A–L)
+   │
+   ├── harness-tests       68 C harness integration tests, MISRA-clean build
+   │                       (skips cleanly — Professional tier, sources gitignored)
+   │
+   ├── sovd-codegen        OpenSOVD CDA generation smoke check (no templates needed)
+   │
    ├── static-analysis     GCC -fanalyzer
    │
    ├── zephyr-native       Full Zephyr build, native_sim (basic_ecu)
    │
    ├── zephyr-stm32        Cross-compile for STM32 Nucleo-H743ZI2
+   │
+   ├── zephyr-nxp          Cross-compile for NXP FRDM-MCXN947
    │
    ├── freertos-qemu       FreeRTOS build — QEMU ARM Cortex-M4 (basic_ecu_freertos)
    │

--- a/scripts/verify_doc_counts.py
+++ b/scripts/verify_doc_counts.py
@@ -8,10 +8,19 @@ number where it appears in prose — docs drifted to 42 and 35 against an actual
 43, and pointed at a `scripts/build_tests.sh` that has never existed (the
 script lives at the repo root).
 
+Widened by #170: both checks were blind to ASCII tree diagrams, which is
+exactly where a path/count claim is most likely to be copied and left to rot.
+`docs/ARCHITECTURE.md` had `└── scripts/` on one line and `build_tests.sh` as
+its own leaf line below — the same dead path as `scripts/build_tests.sh`, but
+never on one line, so the substring check never fired. It also had
+`Canonical Unity unit tests (36 modules)`, a phrasing the original
+COUNT_PATTERNS list didn't cover.
+
 This script is the prose-side counterpart of that CI step:
 
   1. No tracked doc may reference `scripts/build_tests.sh` /
-     `scripts/build_harness.sh`.
+     `scripts/build_harness.sh` — inline, or split across a tree diagram's
+     `scripts/` node and a `build_tests.sh`/`build_harness.sh` leaf line.
   2. Any unit-test module count stated in prose must equal the real count,
      derived from `tests/unit_runnable/test_*.c`.
 
@@ -40,7 +49,16 @@ COUNT_PATTERNS = (
     r"Coverage\s+—\s+(\d+)\s+unit",
     r"unit\s+tests?\s+must\s+pass\s+\(currently\s+(\d+)\)",
     r"unit\s+test\s+to\s+fail\s+\(currently\s+(\d+)\s",
+    # Tree-diagram annotation style, e.g. "unit tests (36 modules)" (#170).
+    r"unit\s+tests?\s*\((\d+)\s+modules?\)",
 )
+
+# A tree-diagram leaf naming one of these under a `scripts/` node is the same
+# dead path as DEAD_PATHS below, just split across two lines (#170). Matched
+# as a bare leaf (optional tree-drawing prefix, nothing else on the line)
+# so real prose sentences that merely mention the filename aren't flagged.
+TREE_LEAF_RE = re.compile(r"^[\s│├└─]*(build_tests\.sh|build_harness\.sh)\b")
+TREE_SCRIPTS_NODE_RE = re.compile(r"^[\s│├└─]*scripts/\s*$")
 
 
 def real_module_count() -> int:
@@ -53,7 +71,12 @@ def real_module_count() -> int:
 def docs():
     for p in sorted(ROOT.rglob("*.md")):
         rel = p.relative_to(ROOT)
-        if rel.name in EXEMPT or ".git" in rel.parts or "node_modules" in rel.parts:
+        if (
+            rel.name in EXEMPT
+            or ".git" in rel.parts
+            or "node_modules" in rel.parts
+            or ".claude" in rel.parts  # gitignored local agent-worktree scratch space
+        ):
             continue
         yield rel, p.read_text(encoding="utf-8")
 
@@ -63,13 +86,35 @@ def main() -> int:
     problems = []
 
     for rel, text in docs():
+        in_fence = False
+        saw_scripts_node_at = None  # lineno of the most recent `scripts/` tree node, or None
         for lineno, line in enumerate(text.splitlines(), 1):
+            if line.strip().startswith("```"):
+                in_fence = not in_fence
+                if not in_fence:
+                    saw_scripts_node_at = None
+                continue
+
             for dead in DEAD_PATHS:
                 if dead in line:
                     problems.append(
                         f"{rel}:{lineno}: references `{dead}`, which does not exist "
                         f"— the script lives at the repo root"
                     )
+
+            if in_fence:
+                if TREE_SCRIPTS_NODE_RE.match(line):
+                    saw_scripts_node_at = lineno
+                elif saw_scripts_node_at is not None:
+                    m = TREE_LEAF_RE.match(line)
+                    if m:
+                        problems.append(
+                            f"{rel}:{lineno}: tree diagram shows `{m.group(1)}` "
+                            f"under the `scripts/` node opened at line "
+                            f"{saw_scripts_node_at}, which does not exist "
+                            f"— the script lives at the repo root"
+                        )
+
             # Several patterns can match the same phrase; report each
             # (file, line, stated count) once, with the longest match as
             # the most descriptive quote.


### PR DESCRIPTION
Consolidates all currently-open documentation-related issues into one pass, per repo convention (one issue for documentation changes covering everything at once).

## Scope

**#170** — `docs/ARCHITECTURE.md`'s repo-tree diagram: stale module count (36 vs. actual 44 — the line directly below it in the same block already said 44), a `scripts/build_tests.sh`/`scripts/build_harness.sh` dead path (both live at the repo root), and while fixing the tree I found it also named `tests/integration/`/`tests/harness/` subdirectories that don't exist and was missing the real `tests/runner/`; also fixed the `examples/` node's wrong directory names (`motor_controller/`→`motor_controller_ecu/`, `ardep/`→`ardep_ecu/`) and stale count (listed 4, real total is 12).

**#164** — `docs/TESTING_STRATEGY.md`'s `tests/integration/` references don't exist. Turned out to be part of two larger fictional sections (§7 Integration Tests, §10 System Tests) describing a test suite/pytest flag (`--system`) that was never built — replaced with the real generated per-example suite layout, and made §10 explicit that it describes target coverage rather than something implemented today, pointing at the closest real equivalent (`--firmware`-backed tests).

**Found during the pass, same defect class, folded in:**
- `docs/GETTING_STARTED.md`'s Step 8 walkthrough pointed at a `tests/integration/test_uds_read_did.py` with test names (`test_read_vin`, etc.) that don't exist anywhere in the repo — replaced with a real example (`test_did_f190.py`, the generated VIN-read suite), verified passing before writing it into the doc. Also fixed a narrative-continuity bug the swap surfaced: the original text implied the request goes to Step 7's `native_sim` process, but `--can-interface=simulator` is a separate, self-contained virtual bus — corrected the connecting prose rather than just swapping the command.
- §11's CI pipeline tree named 10 of the 22 real `ci.yml` jobs with no indication it was a partial list. Rather than trying to hand-sync all 22 (the exact anti-pattern that caused this doc to drift twice already — #91, #119), added an explicit "representative, not exhaustive" callout naming what's deliberately omitted (7 repetitive per-example smoke-build jobs, one extra board variant), and added the 3 missing jobs that are genuinely distinct test layers (`robustness-tests`, `harness-tests`, `sovd-codegen`).

**`scripts/verify_doc_counts.py`** — both of #119's existing checks were blind to ASCII tree diagrams, which is exactly where ARCHITECTURE.md's stale facts lived: the dead `scripts/build_tests.sh` path was split across a `scripts/` tree node and a `build_tests.sh` leaf line on separate lines, so the substring check never fired; `(36 modules)` matched none of the prose count patterns. Widened both. Also fixed a real bug found while verifying: the sweep wasn't excluding the gitignored `.claude/worktrees/` scratch directory, so a stray leftover agent worktree with stale doc copies could fail the guard for a reason unrelated to the tracked repo.

## Verification

- Per lessons/run-014: reverted just `docs/ARCHITECTURE.md` to the pre-fix content, confirmed the widened guard fails with exactly the 3 original problems, restored the fix, confirmed clean.
- `docs/GETTING_STARTED.md`'s replacement example actually run: `test_did_f190.py -v --can-interface=simulator` → 4 passed.
- `bash build_tests.sh` → 44/44 (doc-only + guard-script change, unaffected as expected).
- `python3 scripts/verify_doc_counts.py` → PASS.

## Out of scope, tracked separately

**#165** was labeled `documentation` but is actually a test-code fix (3 robustness test files need a skip guard for `tools/templates/`-absent, matching the pattern `test_robustness_L_codegen_output_fidelity.py` already uses) — relabeled `bug` and left for its own PR rather than folded in here.

Fixes #170, Fixes #164