### PR TITLE
codegen: thread __version__ into safety_config.h context as stack_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`build_safety_config_context()` now threads `tools/codegen.py`'s own
+  `__version__` into the safety_config.h.j2 template context as
+  `stack_version`.** (#163, follow-up to #149/#156 and
+  Xaloqi/EDS-toolchain#70) `render_safety_wrappers()`'s Jinja2 environment
+  uses `StrictUndefined`, so any template variable not present in the
+  context dict is a hard `SystemExit(3)` on every codegen run — meaning
+  EDS-toolchain's `safety_config.h.j2` had no way to reference a
+  stack-version variable, and `UDS_STACK_VERSION` in generated
+  `safety_config.h` could only be fixed by hand-editing already-generated
+  output, or by hand-bumping the template's own literal on every release.
+  The new `stack_version` key is distinct from the existing `version` key
+  (the ECU config's own `metadata.version`) and does not collide with it.
+  Unblocks the EDS-toolchain-side follow-up to switch
+  `#define UDS_STACK_VERSION "1.12.0"` to
+  `#define UDS_STACK_VERSION "{{ stack_version }}"`, closing the loop
+  `__version__` was picked as #149's single source of truth for.
 - **Mandatory ASan + UBSan CI job on the host unit tests.** (#151) There was
   no sanitizer build anywhere in this repo's CI — `grep -rn "fsanitize"`
   over `.github/workflows/` and `build_tests.sh` returned nothing — even

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -1114,6 +1114,12 @@ def build_safety_config_context(
       - GEN_SAFETY_MAX_DID_DATA_LEN  DID buffer bound from YAML validation
       - GEN_SAFETY_DTC_SUPPORT_MASK  DTC status availability mask
 
+    The context also carries ``stack_version`` (the codegen tool's own
+    ``__version__``, distinct from ``version``, which is the ECU config's
+    own ``metadata.version``) so templates such as safety_config.h.j2 can
+    derive e.g. UDS_STACK_VERSION from a single source of truth instead of
+    a hand-maintained literal (see issue #163).
+
     Args:
         cfg:        Validated configuration dictionary.
         asil_level: ASIL target level string.
@@ -1140,6 +1146,7 @@ def build_safety_config_context(
     return {
         "ecu_name":                   meta["ecu_name"],
         "version":                    meta["version"],
+        "stack_version":              __version__,
         "generated":                  _now_utc(),
         "asil_level":                 asil_level.upper(),
         "asil_level_numeric":         asil_numeric,


### PR DESCRIPTION
## Summary

`build_safety_config_context()` in `tools/codegen.py` did not return a version key, so the EDS-toolchain-owned `safety_config.h.j2` template had no way to reference a stack-version variable. `render_safety_wrappers()`'s Jinja2 environment uses `StrictUndefined`, so any template variable not present in the context dict is a hard `SystemExit(3)` on every codegen run — there is no environment-level global and no `--extra-context` CLI flag to inject one from outside.

This adds a `stack_version` key, sourced from the module-level `__version__` constant (`tools/codegen.py:103`) that is already used for the SOVD `generatedBy` field and the CLI banner.

```python
return {
    ...
    "stack_version": __version__,
    ...
}
```

- Key name follows the snake_case convention already used by every other key in this function's return dict (`ecu_name`, `asil_level_numeric`, `enable_session_checks`, etc.) — matching the issue's suggestion of `stack_version` rather than reusing `version`, which already exists in this same dict and means something different (the ECU config's own `metadata.version`, e.g. `1.6.0` in `examples/basic_ecu_doip`, vs. the stack's `1.12.0`). Confirmed no collision.

Fixes #163

## Verification

- `XALOQI_LICENSE_SKIP=1 pytest tests/ -q` → 12 skipped, 0 failed (all skips are pre-existing environment gaps in a bare public checkout — commercial `tools/_license.py` and Zephyr/native_sim not present — unrelated to this change; unchanged before/after).
- No unit test in this public checkout calls `build_safety_config_context()` directly — searched `tests/`, `pytest.ini` (`testpaths = tests`), and the whole repo for `build_safety_config_context` call sites: the only references are the function's own definition and its entry in `SAFETY_RENDER_PLAN`. `tools/testgen.py`, which would generate such coverage, is a commercial gitignored deliverable not present here (`CLAUDE.md`/#67). Verified manually instead:
  ```python
  import codegen, yaml
  cfg = yaml.safe_load(open("examples/basic_ecu_doip/diagnostics_config.yaml"))
  ctx = codegen.build_safety_config_context(cfg, asil_level="B")
  # ctx["stack_version"] == codegen.__version__ == "1.12.0"
  # ctx["version"] == "1.6.0"  (ECU config version, unchanged, no collision)
  ```
  Confirms the function still returns valid output for a real example config, and the new key is present with the correct value alongside every pre-existing key, unmodified.
- `tools/templates/` (EDS-toolchain-owned, gitignored) is not present in this public checkout, so a full end-to-end codegen → rendered `safety_config.h` pass isn't possible here — this PR only makes the key available in the context; the toolchain-side template change is tracked as a separate follow-up (see below).
- `python3 -m py_compile tools/codegen.py` — clean.

## Follow-up

Filed Xaloqi/EDS-toolchain follow-up issue to switch `safety_config.h.j2`'s `UDS_STACK_VERSION` from its manually-bumped literal to `{{ stack_version }}`, now that this context key exists — that work was deliberately deferred in EDS-toolchain#70/#71 pending this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)