### PR TITLE
fix: derive WriteDID too-short byte count from DID data_length (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,43 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`test_step5_data_length_nrc_13_firmware`'s "too-short WriteDID" firmware
+  test hardcoded the short byte count instead of deriving it from the DID's
+  own `data_length`.** (#160, found while verifying #144) Every generated
+  `test_firmware_services.py` computed `short_data` as
+  `bytes([0xAA] * max(1, 1 - 1))` — a byte count that never referenced the
+  actual DID at all. For `sensor_ecu` / `sensor_ecu_freertos`,
+  `DID_CATALOGUE[5]` is DID 0xD010 with `data_length: 1`: the hardcoded
+  expression always produces 1 byte, which is the DID's *full* length, not a
+  short one, so the firmware accepted the write and returned a positive
+  response (0x6E) where the test asserted a negative one — confirmed via
+  `--firmware` against a locally built harness (`assert 110 == 127`). The
+  other 10 examples' `DID_CATALOGUE` index used by this test happens to have
+  `data_length >= 2` (e.g. `basic_ecu`'s DID 0xF187 is 11 bytes), so the same
+  wrong expression coincidentally still produced a genuinely-short write —
+  masking the bug everywhere except the two 1-byte-DID examples.
+  Fixed to `bytes([0xAA] * max(0, DID_CATALOGUE[N]["data_length"] - 1))`,
+  reading the DID's real length instead of a baked-in literal. Note the floor
+  had to change from 1 to 0, not just the literal: the issue's own suggested
+  `max(1, data_length - 1)` still evaluates to 1 for a `data_length=1` DID
+  (`max(1, 1 - 1) == max(1, 0) == 1`), which is exactly the bug being fixed —
+  writing "one byte short" of a 1-byte DID is a 0-byte write, and `max(0, …)`
+  is needed to let it through as 0 while still flooring longer DIDs at a
+  minimum of 0 bytes removed (never negative). Worked examples:
+  `data_length=1` → `max(0, 1 - 1) = 0` bytes (was 1, wrongly matching the
+  full length); `data_length=11` → `max(0, 11 - 1) = 10` bytes (was already
+  10 via the old hardcoded literal for that example, so no behavior change
+  there). Verified for both `sensor_ecu` and `sensor_ecu_freertos` against a
+  freshly built local harness (Professional-tier `harness/` extracted for
+  verification only, never committed — `harness/` stays gitignored per #67):
+  `test_step5_data_length_nrc_13_firmware` reproducibly fails on the
+  pre-fix code (`assert 110 == 127`) and passes after the fix; `basic_ecu`
+  (`data_length=11`) still passes unchanged. All 10 affected
+  `examples/*/generated/tests/test_firmware_services.py` files fixed here;
+  `safeboot_ecu`'s copy of this test already `pytest.skip()`s (no
+  write-capable DID in that configuration) and needed no change. Companion
+  fix in the EDS-toolchain codegen template that produces this file tracked
+  separately so future `--test-gen` runs emit the corrected expression.
 - **Stack-buffer-overflow in `test_uds_security.c`.** (#168, found by #151's
   new ASan job on its first run) `test_uds_security_send_key__test_null_key`
   declared `uint8_t seed[4]` but passed it to `do_seed_request()`, which

--- a/examples/ardep_ecu/generated/tests/test_firmware_services.py
+++ b/examples/ardep_ecu/generated/tests/test_firmware_services.py
@@ -2323,7 +2323,7 @@ class TestFirmwareSafetyWrappers:
     ) -> None:
         """Step 5 (write path): Length mismatch → NRC 0x13 from safety wrapper."""
         _setup_for_did(firmware_bus, DID_CATALOGUE[2], for_write=True)
-        short_data = bytes([0xAA] * max(1, 11 - 1))
+        short_data = bytes([0xAA] * max(0, DID_CATALOGUE[2]["data_length"] - 1))
         pdu = firmware_bus.request(
             bytes([SID_WRITE_DATA_BY_ID, 241, 135]) + short_data
         )

--- a/examples/basic_ecu/generated/tests/test_firmware_services.py
+++ b/examples/basic_ecu/generated/tests/test_firmware_services.py
@@ -787,7 +787,7 @@ class TestFirmwareSafetyWrappers:
     ) -> None:
         """Step 5 (write path): Length mismatch → NRC 0x13 from safety wrapper."""
         _setup_for_did(firmware_bus, DID_CATALOGUE[2], for_write=True)
-        short_data = bytes([0xAA] * max(1, 11 - 1))
+        short_data = bytes([0xAA] * max(0, DID_CATALOGUE[2]["data_length"] - 1))
         pdu = firmware_bus.request(
             bytes([SID_WRITE_DATA_BY_ID, 241, 135]) + short_data
         )

--- a/examples/basic_ecu_doip/generated/tests/test_firmware_services.py
+++ b/examples/basic_ecu_doip/generated/tests/test_firmware_services.py
@@ -787,7 +787,7 @@ class TestFirmwareSafetyWrappers:
     ) -> None:
         """Step 5 (write path): Length mismatch → NRC 0x13 from safety wrapper."""
         _setup_for_did(firmware_bus, DID_CATALOGUE[2], for_write=True)
-        short_data = bytes([0xAA] * max(1, 11 - 1))
+        short_data = bytes([0xAA] * max(0, DID_CATALOGUE[2]["data_length"] - 1))
         pdu = firmware_bus.request(
             bytes([SID_WRITE_DATA_BY_ID, 241, 135]) + short_data
         )

--- a/examples/basic_ecu_doip_freertos/generated/tests/test_firmware_services.py
+++ b/examples/basic_ecu_doip_freertos/generated/tests/test_firmware_services.py
@@ -787,7 +787,7 @@ class TestFirmwareSafetyWrappers:
     ) -> None:
         """Step 5 (write path): Length mismatch → NRC 0x13 from safety wrapper."""
         _setup_for_did(firmware_bus, DID_CATALOGUE[2], for_write=True)
-        short_data = bytes([0xAA] * max(1, 11 - 1))
+        short_data = bytes([0xAA] * max(0, DID_CATALOGUE[2]["data_length"] - 1))
         pdu = firmware_bus.request(
             bytes([SID_WRITE_DATA_BY_ID, 241, 135]) + short_data
         )

--- a/examples/basic_ecu_freertos/generated/tests/test_firmware_services.py
+++ b/examples/basic_ecu_freertos/generated/tests/test_firmware_services.py
@@ -787,7 +787,7 @@ class TestFirmwareSafetyWrappers:
     ) -> None:
         """Step 5 (write path): Length mismatch → NRC 0x13 from safety wrapper."""
         _setup_for_did(firmware_bus, DID_CATALOGUE[2], for_write=True)
-        short_data = bytes([0xAA] * max(1, 11 - 1))
+        short_data = bytes([0xAA] * max(0, DID_CATALOGUE[2]["data_length"] - 1))
         pdu = firmware_bus.request(
             bytes([SID_WRITE_DATA_BY_ID, 241, 135]) + short_data
         )

--- a/examples/bms_ecu/generated/tests/test_firmware_services.py
+++ b/examples/bms_ecu/generated/tests/test_firmware_services.py
@@ -1725,7 +1725,7 @@ class TestFirmwareSafetyWrappers:
     ) -> None:
         """Step 5 (write path): Length mismatch → NRC 0x13 from safety wrapper."""
         _setup_for_did(firmware_bus, DID_CATALOGUE[2], for_write=True)
-        short_data = bytes([0xAA] * max(1, 11 - 1))
+        short_data = bytes([0xAA] * max(0, DID_CATALOGUE[2]["data_length"] - 1))
         pdu = firmware_bus.request(
             bytes([SID_WRITE_DATA_BY_ID, 241, 135]) + short_data
         )

--- a/examples/motor_controller_ecu/generated/tests/test_firmware_services.py
+++ b/examples/motor_controller_ecu/generated/tests/test_firmware_services.py
@@ -1931,7 +1931,7 @@ class TestFirmwareSafetyWrappers:
     ) -> None:
         """Step 5 (write path): Length mismatch → NRC 0x13 from safety wrapper."""
         _setup_for_did(firmware_bus, DID_CATALOGUE[2], for_write=True)
-        short_data = bytes([0xAA] * max(1, 11 - 1))
+        short_data = bytes([0xAA] * max(0, DID_CATALOGUE[2]["data_length"] - 1))
         pdu = firmware_bus.request(
             bytes([SID_WRITE_DATA_BY_ID, 241, 135]) + short_data
         )

--- a/examples/robot_joint_controller_ecu/generated/tests/test_firmware_services.py
+++ b/examples/robot_joint_controller_ecu/generated/tests/test_firmware_services.py
@@ -1125,7 +1125,7 @@ class TestFirmwareSafetyWrappers:
     ) -> None:
         """Step 5 (write path): Length mismatch → NRC 0x13 from safety wrapper."""
         _setup_for_did(firmware_bus, DID_CATALOGUE[7], for_write=True)
-        short_data = bytes([0xAA] * max(1, 4 - 1))
+        short_data = bytes([0xAA] * max(0, DID_CATALOGUE[7]["data_length"] - 1))
         pdu = firmware_bus.request(
             bytes([SID_WRITE_DATA_BY_ID, 160, 16]) + short_data
         )

--- a/examples/sensor_ecu/generated/tests/test_firmware_services.py
+++ b/examples/sensor_ecu/generated/tests/test_firmware_services.py
@@ -938,7 +938,7 @@ class TestFirmwareSafetyWrappers:
     ) -> None:
         """Step 5 (write path): Length mismatch → NRC 0x13 from safety wrapper."""
         _setup_for_did(firmware_bus, DID_CATALOGUE[5], for_write=True)
-        short_data = bytes([0xAA] * max(1, 1 - 1))
+        short_data = bytes([0xAA] * max(0, DID_CATALOGUE[5]["data_length"] - 1))
         pdu = firmware_bus.request(
             bytes([SID_WRITE_DATA_BY_ID, 208, 16]) + short_data
         )

--- a/examples/sensor_ecu_freertos/generated/tests/test_firmware_services.py
+++ b/examples/sensor_ecu_freertos/generated/tests/test_firmware_services.py
@@ -938,7 +938,7 @@ class TestFirmwareSafetyWrappers:
     ) -> None:
         """Step 5 (write path): Length mismatch → NRC 0x13 from safety wrapper."""
         _setup_for_did(firmware_bus, DID_CATALOGUE[5], for_write=True)
-        short_data = bytes([0xAA] * max(1, 1 - 1))
+        short_data = bytes([0xAA] * max(0, DID_CATALOGUE[5]["data_length"] - 1))
         pdu = firmware_bus.request(
             bytes([SID_WRITE_DATA_BY_ID, 208, 16]) + short_data
         )


### PR DESCRIPTION
## Summary

Fixes #160. Every generated `examples/*/generated/tests/test_firmware_services.py`'s `test_step5_data_length_nrc_13_firmware` hardcoded the "one byte short" WriteDID payload as:

```python
short_data = bytes([0xAA] * max(1, 1 - 1))   # always 1 byte
```

instead of deriving it from the referenced DID's actual `data_length`. For `sensor_ecu` / `sensor_ecu_freertos`, `DID_CATALOGUE[5]` is DID `0xD010` with `data_length: 1` — so the hardcoded expression produced 1 byte, which is the DID's *full* length, not a short one. The firmware correctly accepted the write and returned a positive response (`0x6E`), but the test asserted a negative one, failing with `assert 110 == 127`. The other 10 examples' referenced `DID_CATALOGUE` entry happens to have `data_length >= 2` (e.g. `basic_ecu`'s DID `0xF187` is 11 bytes), so the same wrong expression coincidentally still produced a genuinely-short write, masking the bug everywhere else.

## Fix

```python
short_data = bytes([0xAA] * max(0, DID_CATALOGUE[N]["data_length"] - 1))
```

reading the DID's real `data_length` (`N` matches the index already used by that test's `_setup_for_did(firmware_bus, DID_CATALOGUE[N], for_write=True)` call).

**The floor also had to change, not just the literal.** The issue's own suggested fix, `max(1, data_length - 1)`, still evaluates to `1` for a `data_length=1` DID (`max(1, 1 - 1) == max(1, 0) == 1`) — that's exactly the bug being fixed. Writing "one byte short" of a 1-byte DID is a genuinely **0-byte** write, so the floor needs to be `0`, not `1`.

### Worked examples

| DID `data_length` | old (`max(1, N-1)`) | new (`max(0, N-1)`) | correct? |
|---|---|---|---|
| 1 (`sensor_ecu` 0xD010) | `max(1, 0) = 1` byte — equals full length, **not short** | `max(0, 0) = 0` bytes — genuinely short | new is correct |
| 11 (`basic_ecu` 0xF187) | `max(1, 10) = 10` bytes | `max(0, 10) = 10` bytes | unchanged, both correct |

So the new floor is a strict improvement for 1-byte DIDs and a no-op for every DID with `data_length >= 2` (since `data_length - 1 >= 1 > 0` there, the two floors agree).

## Verification

Static: derived and checked the arithmetic above for both the failing case (1-byte DID) and a passing case (11-byte DID).

Dynamic (firmware-backed, `--firmware`): extracted `harness/` from the local Professional-tier ZIP (`EDS-toolchain/dist/xaloqi-eds-professional-v1.12.0.zip`) for local verification only — never committed; `harness/` stays gitignored per #67. Built per-example via `build_harness.sh --example <name>` (#144's per-example fix) and confirmed:

- **Pre-fix** (`git stash` back to the hardcoded expression): `sensor_ecu`'s `test_step5_data_length_nrc_13_firmware` reproducibly **fails** with `assert 110 == 127`, matching the issue exactly.
- **Post-fix**: the same test **passes** for both `sensor_ecu` and `sensor_ecu_freertos`.
- `basic_ecu` (`data_length=11`, already-passing case): still **passes** unchanged after the fix — no regression.
- Full `sensor_ecu` firmware suite (`pytest test_firmware_services.py --firmware`): 56 passed, 1 skipped, 4 failed — the 4 failures are pre-existing DTC-hardcoding failures tracked separately as #158, unrelated to this change and unaffected by it.
- Public gate `bash build_tests.sh`: 44/44 modules, 894/894 cases pass.

## Scope

All 10 `examples/*/generated/tests/test_firmware_services.py` files containing this pattern are fixed (enumerated via `grep -rn "max(1, 1 - 1)"` broadened to the actual per-file literals, since each file bakes in its own DID's `data_length` as a literal, e.g. `max(1, 11 - 1)`, `max(1, 4 - 1)`, `max(1, 1 - 1)`): `ardep_ecu`, `basic_ecu`, `basic_ecu_doip`, `basic_ecu_doip_freertos`, `basic_ecu_freertos`, `bms_ecu`, `motor_controller_ecu`, `robot_joint_controller_ecu`, `sensor_ecu`, `sensor_ecu_freertos`. `safeboot_ecu`'s copy of this test already `pytest.skip()`s ("No write-capable DID in this configuration") and needed no change; `safeboot_freertos_ecu` has no generated `test_firmware_services.py` at all.

A companion agent is fixing the EDS-toolchain codegen template that produces this file so future `--test-gen` regenerations emit the corrected expression; this PR only fixes the already-committed generated output in this repo.

CHANGELOG.md updated under `[Unreleased] / Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)