### PR TITLE
fix: skip codegen robustness tests cleanly when tools/templates/ is absent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2255,8 +2255,17 @@ jobs:
           # missing xaloqi-tester install went unnoticed for months). The
           # bare `grep -q "failed"` this replaced had the same blind spot
           # and added nothing beyond what the floors below already cover.
-          # 332 is this job's real passed count on public CI today (no
+          # 292 is this job's real passed count on public CI today (no
           # commercial templates); a customer with the full ZIP sees 439/0.
+          # Was 332 until #165: 40 codegen-invoking tests in phases A/F/K
+          # were passing for the wrong reason (asserting on the commercial-
+          # license banner's exit code/text, not the validation behavior
+          # they were meant to exercise) rather than skipping cleanly when
+          # tools/templates/ is absent — the same false-pass shape the
+          # run-013 lesson above already names. Fixing that correctly moves
+          # those 40 from passed to skipped; total (439) and failed (0) are
+          # unchanged, so the invariant these floors protect still holds —
+          # only the passed/skipped split shifted, on purpose.
           failed=$(echo "$result" | grep -oE '[0-9]+ failed' | grep -oE '^[0-9]+' || echo 0)
           passed=$(echo "$result" | grep -oE '[0-9]+ passed' | grep -oE '^[0-9]+' || echo 0)
           skipped=$(echo "$result" | grep -oE '[0-9]+ skipped' | grep -oE '^[0-9]+' || echo 0)
@@ -2264,8 +2273,8 @@ jobs:
           echo "passed=$passed failed=$failed skipped=$skipped total=$total"
           [ "$failed" -eq 0 ] \
             || (echo "ERROR: $failed test(s) failed" && exit 1)
-          [ "$passed" -ge 332 ] \
-            || (echo "ERROR: only $passed passed (expected >= 332) — suite may be silently skipping" && exit 1)
+          [ "$passed" -ge 292 ] \
+            || (echo "ERROR: only $passed passed (expected >= 292) — suite may be silently skipping" && exit 1)
           [ "$total" -ge 439 ] \
             || (echo "ERROR: Expected passed+skipped >= 439, got $total — test count regression" && exit 1)
           echo "PASS: campaign integrity confirmed (439 tests accounted for, $passed genuinely executed)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,33 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   write-capable DID in that configuration) and needed no change. Companion
   fix in the EDS-toolchain codegen template that produces this file tracked
   separately so future `--test-gen` runs emit the corrected expression.
+- **`basic_ecu` robustness tests failed instead of skipping cleanly when
+  `tools/templates/` is absent.** (#165) `codegen.py` runs its license check
+  (import `_license`, commercial-only) before it ever loads or validates the
+  config YAML, so on a clean public checkout — no `tools/templates/`, no
+  `_license.py` — every subprocess invocation exits 1 with a "Commercial
+  License Required" banner regardless of input. 40 tests across
+  `test_robustness_A_codegen.py`, `test_robustness_F_codegen_limits.py`, and
+  `test_robustness_K_error_quality.py` asserted on specific exit codes and
+  stdout/stderr text for invalid-input cases (bad YAML, duplicate IDs, ASIL
+  violations, etc.) and failed on the banner instead of the validation
+  message they were exercising —
+  `test_robustness_L_codegen_output_fidelity.py` already skipped cleanly in
+  this situation via a `_TEMPLATES_OK` / `pytest.mark.skipif` guard, but A/F/K
+  either didn't apply it consistently or (K) didn't have it at all. Applied
+  the same guard to exactly the affected tests: A and F already had the
+  `_TEMPLATES_OK` check defined but not used on every codegen-invoking test
+  in `TestCodegenInvalidInputs` / `TestDuplicateAndReservedIDs`; K gained the
+  guard from scratch. Left alone the tests in the same classes/files that
+  only assert a bare non-zero exit code (or otherwise incidentally read
+  correctly against the license banner) and were already passing, per-test
+  rather than a blanket per-file skip, so genuinely template-independent
+  coverage keeps running. Verified: reproduced the 40 FAILED on the pre-fix
+  tree, confirmed all 40 now report SKIPPED with
+  "Jinja2 templates not present (commercial-only, not in public repo)", and
+  diffed the full list of passing tests before/after (`basic_ecu`'s
+  `generated/tests/` suite: 17 passed → 17 passed, identical set) to confirm
+  no previously-passing test was accidentally swept into the guard.
 - **Stack-buffer-overflow in `test_uds_security.c`.** (#168, found by #151's
   new ASan job on its first run) `test_uds_security_send_key__test_null_key`
   declared `uint8_t seed[4]` but passed it to `do_seed_request()`, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,6 +263,14 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   diffed the full list of passing tests before/after (`basic_ecu`'s
   `generated/tests/` suite: 17 passed → 17 passed, identical set) to confirm
   no previously-passing test was accidentally swept into the guard.
+  CI's "Robustness Campaign" job runs all 12 phases (A–L) together rather
+  than the single file checked above, and its own `passed >= 332` floor
+  (`.github/workflows/ci.yml`) is a *different* measurement — confirmed the
+  full campaign genuinely shifts from 332 passed / 107 skipped to 292
+  passed / 147 skipped (439 total, 0 failed, unchanged both ways) once this
+  fix is in the tree, run directly (not just inferred from the single-file
+  diff). Updated the floor to 292 with an explanatory comment rather than
+  leaving 40 tests' worth of headroom silently baked in.
 - **Stack-buffer-overflow in `test_uds_security.c`.** (#168, found by #151's
   new ASan job on its first run) `test_uds_security_send_key__test_null_key`
   declared `uint8_t seed[4]` but passed it to `do_seed_request()`, which

--- a/examples/basic_ecu/generated/tests/test_robustness_A_codegen.py
+++ b/examples/basic_ecu/generated/tests/test_robustness_A_codegen.py
@@ -115,6 +115,7 @@ def _run_codegen(yaml_content: str, extra_args=None, out_dir=None) -> tuple[int,
 class TestCodegenInvalidInputs:
     """Codegen must reject malformed or invalid YAML with non-zero exit codes."""
 
+    @_skip_no_tpl
     def test_missing_yaml_file_exits_2(self):
         cmd = [sys.executable, CODEGEN,
                "--config", "/nonexistent/path/config.yaml",
@@ -123,10 +124,12 @@ class TestCodegenInvalidInputs:
         r = subprocess.run(cmd, capture_output=True, text=True)
         assert r.returncode == 2, f"Expected exit 2 for missing file, got {r.returncode}"
 
+    @_skip_no_tpl
     def test_invalid_yaml_syntax_exits_2(self):
         rc, out, _ = _run_codegen("dids: [: broken yaml !@#$\n  - id")
         assert rc == 2, f"Expected exit 2 for bad YAML syntax, got {rc}"
 
+    @_skip_no_tpl
     def test_asil_write_did_no_security_exits_1(self):
         yaml = textwrap.dedent("""\
             schema_version: 1

--- a/examples/basic_ecu/generated/tests/test_robustness_F_codegen_limits.py
+++ b/examples/basic_ecu/generated/tests/test_robustness_F_codegen_limits.py
@@ -196,6 +196,7 @@ class TestDataLengthBoundaries:
 class TestDuplicateAndReservedIDs:
     """Codegen must detect duplicates and reserved IDs as hard errors."""
 
+    @_skip_no_tpl
     def test_duplicate_did_id_rejected(self):
         yaml = textwrap.dedent("""\
             schema_version: 1
@@ -293,12 +294,14 @@ class TestDuplicateAndReservedIDs:
         rc, out = _codegen(yaml)
         assert rc != 0, "Duplicate DTC code must be rejected"
 
+    @_skip_no_tpl
     def test_reserved_did_0x0000_rejected(self):
         yaml = _VALID_BASE.replace('"0xA001"', '"0x0000"')
         rc, out = _codegen(yaml)
         assert rc != 0, "Reserved DID 0x0000 must be rejected"
         assert "reserved" in out.lower() or "0x0000" in out.lower()
 
+    @_skip_no_tpl
     def test_reserved_did_0xFFFF_rejected(self):
         yaml = _VALID_BASE.replace('"0xA001"', '"0xFFFF"')
         rc, out = _codegen(yaml)

--- a/examples/basic_ecu/generated/tests/test_robustness_K_error_quality.py
+++ b/examples/basic_ecu/generated/tests/test_robustness_K_error_quality.py
@@ -25,6 +25,18 @@ import pytest
 EDS_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
 CODEGEN  = os.path.join(EDS_ROOT, "tools", "codegen.py")
 
+# Jinja2 templates (and the commercial _license.py module bundled with them)
+# live in EDS-toolchain (commercial-only). On the public CI runner neither is
+# present, so codegen.py exits early with a "Commercial License Required"
+# message before it ever reaches config load/validation — the code path these
+# tests are trying to exercise. Skip cleanly instead of asserting on the
+# wrong output. See test_robustness_L_codegen_output_fidelity.py.
+_TEMPLATES_OK = os.path.isdir(os.path.join(EDS_ROOT, "tools", "templates"))
+_skip_no_tpl  = pytest.mark.skipif(
+    not _TEMPLATES_OK,
+    reason="Jinja2 templates not present (commercial-only, not in public repo)"
+)
+
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 _VALID_BASE = textwrap.dedent("""\
@@ -94,6 +106,7 @@ def _assert_rejected(yaml_content: str, *keywords: str):
 
 # ── Sanity: good YAML exits 0 ─────────────────────────────────────────────────
 
+@_skip_no_tpl
 class TestSanity:
     def test_valid_yaml_exits_0(self):
         rc, out = _run_codegen(_VALID_BASE)
@@ -107,6 +120,7 @@ class TestSanity:
 
 # ── Class 1: Metadata errors ──────────────────────────────────────────────────
 
+@_skip_no_tpl
 class TestMetadataErrors:
     """Missing or malformed metadata fields."""
 
@@ -133,6 +147,7 @@ class TestMetadataErrors:
 
 # ── Class 2: DID errors ───────────────────────────────────────────────────────
 
+@_skip_no_tpl
 class TestDIDErrors:
     """Bad DID id format, missing fields, duplicate, invalid access, session, security."""
 
@@ -232,14 +247,17 @@ class TestDIDErrors:
 class TestDTCErrors:
     """Bad DTC code format, duplicate, missing fields."""
 
+    @_skip_no_tpl
     def test_dtc_code_wrong_hex_length(self):
         yaml = _VALID_BASE.replace('code:        "0xC00100"', 'code:        "0xC001"')
         _assert_rejected(yaml, "0xC001", "6-digit")
 
+    @_skip_no_tpl
     def test_dtc_code_missing_0x_prefix(self):
         yaml = _VALID_BASE.replace('code:        "0xC00100"', 'code:        "C00100"')
         _assert_rejected(yaml, "C00100")
 
+    @_skip_no_tpl
     def test_dtc_code_invalid_chars(self):
         yaml = _VALID_BASE.replace('code:        "0xC00100"', 'code:        "0xZZZZZZ"')
         _assert_rejected(yaml, "0xZZZZZZ")
@@ -251,6 +269,7 @@ class TestDTCErrors:
         )
         _assert_rejected(yaml, "code")
 
+    @_skip_no_tpl
     def test_duplicate_dtc_codes(self):
         extra = (
             "  - code:        \"0xC00100\"\n"
@@ -263,6 +282,7 @@ class TestDTCErrors:
 
 # ── Class 4: Timing errors ────────────────────────────────────────────────────
 
+@_skip_no_tpl
 class TestTimingErrors:
     """p2 > p2*, non-positive values."""
 
@@ -284,6 +304,7 @@ class TestTimingErrors:
 
 # ── Class 5: Routine errors ───────────────────────────────────────────────────
 
+@_skip_no_tpl
 class TestRoutineErrors:
     """Bad routine id format, duplicate."""
 
@@ -309,6 +330,7 @@ class TestRoutineErrors:
 
 # ── Class 6: YAML parse and structural errors ─────────────────────────────────
 
+@_skip_no_tpl
 class TestParseErrors:
     """Broken YAML syntax, empty file, non-mapping root."""
 


### PR DESCRIPTION
## Problem

On a clean public checkout (no `tools/templates/`, no `_license.py`), running
`examples/basic_ecu/generated/tests/` produced 40 FAILED instead of skipped, all in
`test_robustness_A_codegen.py`, `test_robustness_F_codegen_limits.py`, and
`test_robustness_K_error_quality.py`.

`tools/codegen.py` runs its commercial license check (`import _license`) before it
ever loads or validates the config YAML. On the public repo that import always fails,
so codegen exits 1 with a "Commercial License Required" banner regardless of input —
before reaching the validation/parsing code paths these tests exercise. The affected
tests assert specific exit codes and/or specific stdout/stderr text and fail on the
banner instead.

`test_robustness_L_codegen_output_fidelity.py` already handles this correctly, via a
`_TEMPLATES_OK = os.path.isdir(.../tools/templates)` check feeding a
`pytest.mark.skipif` guard (`tools/templates/` and `tools/_license.py` are bundled
together in the same commercial ZIP, so its presence/absence is a reliable proxy for
whether the license check will short-circuit).

## Fix

Applied the same `_TEMPLATES_OK` / `_skip_no_tpl` pattern to exactly the tests that
need it, not the whole file:

- **`test_robustness_A_codegen.py`** — already defined `_skip_no_tpl` and used it on
  two whole classes; added it to the 3 individual methods in
  `TestCodegenInvalidInputs` that assert exact exit codes / text derived from
  validation that never runs (`test_missing_yaml_file_exits_2`,
  `test_invalid_yaml_syntax_exits_2`, `test_asil_write_did_no_security_exits_1`).
- **`test_robustness_F_codegen_limits.py`** — already defined `_skip_no_tpl`; added it
  to the 3 methods in `TestDuplicateAndReservedIDs` that check output text
  (`test_duplicate_did_id_rejected`, `test_reserved_did_0x0000_rejected`,
  `test_reserved_did_0xFFFF_rejected`).
- **`test_robustness_K_error_quality.py`** — had no guard mechanism at all. Added the
  `_TEMPLATES_OK` / `_skip_no_tpl` block (mirroring L), applied at class level to
  `TestSanity`, `TestMetadataErrors`, `TestDIDErrors`, `TestTimingErrors`,
  `TestRoutineErrors`, `TestParseErrors` (every method in each of these classes was
  failing), and per-method within `TestDTCErrors` (4 of 5 methods were failing;
  `test_dtc_missing_code_field` was passing — its `"code"` keyword happens to appear
  in "Code generation requires…" — and is left unguarded).

Tests in the same files that only assert a bare non-zero/expected exit code (and
were already passing, whether for the "real" validation reason or coincidentally
against the license banner) are untouched, so genuinely template-independent
coverage keeps running.

## Verification

- Reproduced the bug: 40 FAILED, 17 passed, 54 skipped on the pre-fix tree
  (`pytest test_robustness_A_codegen.py test_robustness_F_codegen_limits.py
  test_robustness_K_error_quality.py -q`).
- After the fix: **0 failed, 17 passed, 94 skipped** (54 + 40 = 94) — all 40
  previously-FAILED tests now report SKIPPED with
  `"Jinja2 templates not present (commercial-only, not in public repo)"`.
- Diffed the full list of `PASSED` test IDs before vs. after the fix — **identical**,
  confirming no previously-passing test was accidentally swept into the guard.
- Full `examples/basic_ecu/generated/tests/` suite (all files): 426 passed, 206
  skipped, 0 failed.
- `bash build_tests.sh`: 44/44 modules, 894 cases, 0 failed (unrelated C suite,
  confirms no collateral breakage).

Fixes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)