### PR TITLE
codegen: wire dtc_config.h.j2 into RENDER_PLAN (fixes #175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`tools/templates/dtc_config.h.j2` (Professional-tier, in EDS-toolchain)
+  is now wired into `codegen.py`'s `RENDER_PLAN`.** (#175, companion to
+  #158) The template — a per-example DTC X-macro list `harness_ecu.c`
+  consumes so it can register each example's own DTCs instead of two
+  hardcoded `basic_ecu` literals — existed since #158/[EDS-toolchain#76](https://github.com/Xaloqi/EDS-toolchain/pull/76),
+  but `RENDER_PLAN` lives in this (public) repo, so a real `codegen.py`
+  run couldn't produce `dtc_config.h` yet; EDS-toolchain kept 8 examples'
+  copies in sync by hand as a stopgap. Added `build_dtc_config_context()`
+  (reuses the same `_build_dtc_list()` enrichment `uds_init.c.j2`'s Step 5
+  registration loop already relies on, so the two stay in lockstep by
+  construction) and added the template to `RENDER_PLAN` unconditionally —
+  `render_and_write()` already skips a missing template with a warning
+  rather than failing, so this is a no-op on a public checkout without the
+  commercial `tools/templates/`. Verified against the real EDS-toolchain
+  templates (`--template-dir`): regenerating `ardep_ecu` and `sensor_ecu`
+  matches their committed `dtc_config.h` on the timestamp line only.
 - **`build_safety_config_context()` now threads `tools/codegen.py`'s own
   `__version__` into the safety_config.h.j2 template context as
   `stack_version`.** (#163, follow-up to #149/#156 and

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -947,6 +947,25 @@ def build_did_handlers_context(cfg: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def build_dtc_config_context(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Build the template context for dtc_config.h (Professional-tier template,
+    tools/templates/dtc_config.h.j2 — this example's DTCs exposed as an
+    X-macro list so harness/harness_ecu.c can register them generically
+    instead of the two hardcoded basic_ecu literals it used before #158).
+    Reuses the same _build_dtc_list() enrichment uds_init.c.j2's Step 5
+    registration loop already relies on, so the two stay in lockstep by
+    construction rather than by convention.
+    """
+    meta = cfg["metadata"]
+    return {
+        "ecu_name":  meta["ecu_name"],
+        "version":   meta["version"],
+        "generated": _now_utc(),
+        "dtcs":      _build_dtc_list(cfg),
+    }
+
+
 def build_uds_init_context(cfg: Dict[str, Any]) -> Dict[str, Any]:
     """Build the template context for uds_init.h and uds_init.c."""
     timing = cfg["timing"]
@@ -1209,6 +1228,10 @@ RENDER_PLAN: List[Tuple[str, Any, str]] = [
     ("did_handlers.c.j2",     build_did_handlers_context,     "did_handlers.c"),
     ("uds_init.h.j2",         build_uds_init_context,         "uds_init.h"),
     ("uds_init.c.j2",         build_uds_init_context,         "uds_init.c"),
+    # Professional-tier only (harness/ consumer) — render_and_write() already
+    # skips a missing template with a warning rather than failing, so this is
+    # a no-op on a public checkout without tools/templates/dtc_config.h.j2.
+    ("dtc_config.h.j2",       build_dtc_config_context,       "dtc_config.h"),
 ]
 
 


### PR DESCRIPTION
Companion follow-up to #158. Bundled with EDS-toolchain#72 (also fixed today, same pass — see that PR).

## What this closes

`tools/templates/dtc_config.h.j2` (Professional-tier, EDS-toolchain) has existed since [EDS-toolchain#76](https://github.com/Xaloqi/EDS-toolchain/pull/76) — a per-example DTC X-macro list `harness_ecu.c` consumes so it can register each example's own DTCs instead of two hardcoded `basic_ecu` literals. But `codegen.py`'s `RENDER_PLAN` lives in this repo, so a real `codegen.py` run couldn't produce `dtc_config.h` — EDS-toolchain kept 8 examples' copies in sync by hand as a stopgap.

## Fix

- Added `build_dtc_config_context()` — reuses `_build_dtc_list()`, the same enrichment `uds_init.c.j2`'s Step 5 registration loop already relies on, so the two stay in lockstep by construction rather than by convention.
- Added `("dtc_config.h.j2", build_dtc_config_context, "dtc_config.h")` to `RENDER_PLAN`, unconditionally (matches the other 5 always-rendered templates). `render_and_write()` already skips a missing template with a warning rather than failing — confirmed this is a no-op on a public checkout without the commercial `tools/templates/` directory (same pre-existing behavior as the other RENDER_PLAN entries when the whole templates dir is absent).

## Verification

- `python3 -m py_compile tools/codegen.py` clean.
- Regenerated `ardep_ecu` and `sensor_ecu` against the real EDS-toolchain templates (`--template-dir`): output matches their already-committed `dtc_config.h` on the timestamp line only, both cases.
- `bash build_tests.sh` → 44/44 (codegen-only change, C stack unaffected as expected).

Fixes #175