### PR TITLE
release: v1.13.0 version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+## [1.13.0] — 2026-09-01
+
 ### Added
 
 - **`tools/templates/dtc_config.h.j2` (Professional-tier, in EDS-toolchain)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@
 #
 # SAFETY CONTEXT : Contains ASIL-B candidate modules (ISO 26262 Part 6).
 # CODING STANDARD: MISRA C:2012 alignment intended.
-# VERSION        : 1.12.0
+# VERSION        : 1.13.0
 # SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 
@@ -74,7 +74,7 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(zephyr_diagnostics_suite
-    VERSION     1.12.0
+    VERSION     1.13.0
     LANGUAGES   C
     DESCRIPTION "Production-grade UDS/ISO-TP diagnostics stack for Zephyr RTOS"
 )

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 > repo. Community users cloning the public repo can ignore this file.
 
 **Product:** Xaloqi EDS (Xaloqi Embedded Diagnostic Suite)  
-**Version:** v1.12.0  
+**Version:** v1.13.0  
 **Support:** contact@xaloqi.com
 
 ---
@@ -50,7 +50,7 @@ cd EDS
 Verify you are on the correct version:
 
 ```bash
-git checkout v1.12.0
+git checkout v1.13.0
 ```
 
 ---
@@ -59,10 +59,10 @@ git checkout v1.12.0
 
 ```bash
 # From the EDS repo root:
-unzip -o /path/to/xaloqi-eds-developer-v1.12.0.zip
+unzip -o /path/to/xaloqi-eds-developer-v1.13.0.zip
 
 # Or for Professional:
-unzip -o /path/to/xaloqi-eds-professional-v1.12.0.zip
+unzip -o /path/to/xaloqi-eds-professional-v1.13.0.zip
 ```
 
 The `-o` flag overwrites existing files without prompting — required when updating an existing installation.
@@ -75,7 +75,7 @@ The `-o` flag overwrites existing files without prompting — required when upda
 >
 > ```bash
 > rm -f tools/templates tools/testgen.py tools/_license.py harness
-> unzip -o /path/to/xaloqi-eds-developer-v1.12.0.zip
+> unzip -o /path/to/xaloqi-eds-developer-v1.13.0.zip
 > ```
 
 This extracts the toolchain files directly into the repo tree. No separate directory. After extraction you will have:
@@ -185,7 +185,7 @@ Expected output:
 
 ```
 ========================================================================
-  Xaloqi EDS — Code Generator v1.12.0
+  Xaloqi EDS — Code Generator v1.13.0
 ========================================================================
   Config   : examples/bms_ecu/diagnostics_config.yaml
   ...

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Xaloqi Embedded Diagnostics Suite
 
 [![CI](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml/badge.svg)](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-v1.12.0-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.12.0)
+[![Version](https://img.shields.io/badge/version-v1.13.0-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.13.0)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](LICENSE)
 [![Zephyr](https://img.shields.io/badge/Zephyr-v3.7%2B-brightgreen)](https://zephyrproject.org)
 
@@ -126,7 +126,7 @@ The generator produces: DID handler stubs, ASIL-B safety wrappers, DTC registrat
 | **ASIL-B safety chain** | 5-step DID validation enforced at codegen time — cannot be bypassed at runtime |
 | **Security** | AES-128-CMAC seed / 4-byte key response ([threat model](SECURITY.md#security-architecture-notes)) · TRNG-backed · configurable per-session levels · lockout with NVM persistence |
 | **DTC persistence** | NVM mirror survives power cycles · 0x14 ClearDTC · 0x19 ReadDTCInformation |
-| **Code generation** | YAML → 17 Jinja2 templates · CLI · reproducible deterministic output |
+| **Code generation** | YAML → 18 Jinja2 templates · CLI · reproducible deterministic output |
 | **Test generation** | YAML → pytest suite per DID and DTC · simulator mode (no hardware) · firmware harness mode |
 | **CANoe CAPL** | YAML → `.can` scripts for CANoe import · per-DID, per-DTC, core services |
 | **SOVD CDA** | `--sovd` flag: YAML → OpenSOVD 1.0 `sovd_cda.json` — DIDs, DTCs, routines, transport, all 19 services · DoIP ECUs include `logicalAddress` and `port` · Eclipse SDV / OEM SOVD clients |
@@ -319,7 +319,7 @@ Step 5  Data length correct?     → NRC 0x13 incorrectMessageLengthOrInvalidFor
 | `transport/` | ISO-TP state machine, CAN driver binding · `transport/doip/` — DoIP server (ISO 13400-2), Zephyr and FreeRTOS+LwIP platform bindings |
 | `config/` | DID database, DTC database, NVM mirror |
 | `platform/` | Platform abstraction layer — `platform/zephyr/` (Zephyr HAL) · `platform/freertos/` (FreeRTOS HAL) · `platform_api.h` (shared interface) |
-| `tools/` | `codegen.py`, `testgen.py`, 17 Jinja2 templates |
+| `tools/` | `codegen.py`, `testgen.py`, 18 Jinja2 templates |
 | `ide/vscode-extension/` | YAML validation, hover docs, Run Codegen command *(Developer/Professional tier)* |
 | `examples/` | basic\_ecu · basic\_ecu\_doip · basic\_ecu\_freertos · basic\_ecu\_doip\_freertos · sensor\_ecu · sensor\_ecu\_freertos · safeboot\_ecu · safeboot\_freertos\_ecu · robot\_joint\_controller\_ecu · bms\_ecu · motor\_controller\_ecu · ardep\_ecu · each with its own `generated/` subfolder |
 | `gui/` | React/TypeScript configurator + live dashboard *(Developer/Professional tier)* |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@
 
 | Version | Security fixes |
 |---|---|
-| 1.12.x (current) | ✅ Yes |
+| 1.13.x (current) | ✅ Yes |
 | 1.11.x | ✅ Yes (critical only) |
-| < 1.11 | ❌ No — please upgrade |
+| < 1.12 | ❌ No — please upgrade |
 
 Only the current release branch receives routine security fixes. Pre-release and
 modified versions are not supported. Update to the latest tagged release before

--- a/core/uds_types.h
+++ b/core/uds_types.h
@@ -35,11 +35,11 @@ extern "C" {
  * Bumped to 1.12.0 for the v1.12.0 release.
  * -------------------------------------------------------------------------- */
 #define UDS_SUITE_VERSION_MAJOR  (1U)
-#define UDS_SUITE_VERSION_MINOR  (12U)
+#define UDS_SUITE_VERSION_MINOR  (13U)
 #define UDS_SUITE_VERSION_PATCH  (0U)
 
 /** Compile-time version string — matches UDS_STACK_VERSION in safety_config.h. */
-#define UDS_SUITE_VERSION_STRING "1.12.0"
+#define UDS_SUITE_VERSION_STRING "1.13.0"
 
 /* --------------------------------------------------------------------------
  * Buffer and protocol sizing constants

--- a/docs/CODEGEN_ARCHITECTURE.md
+++ b/docs/CODEGEN_ARCHITECTURE.md
@@ -142,7 +142,7 @@ Produces the pytest test suite when `--test-gen` is active. One test file per DI
 
 ### Template System (`tools/templates/`)
 
-17 Jinja2 templates produce all generated output. Templates have access to the full enriched configuration object and use Jinja2 filters, loops, and conditionals to produce well-structured, commented C and Python output.
+18 Jinja2 templates produce all generated output. Templates have access to the full enriched configuration object and use Jinja2 filters, loops, and conditionals to produce well-structured, commented C and Python output.
 
 ---
 
@@ -232,7 +232,7 @@ routines:
 
 ## 6. Template Catalogue
 
-All 17 templates in `tools/templates/`:
+All 18 templates in `tools/templates/`:
 
 Note: the SOVD CDA output (`--sovd`) is generated directly by `build_sovd_cda()` in
 `codegen.py` — it uses no Jinja2 template. `json.dumps(indent=2)` is used instead to

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -62,7 +62,7 @@ The test suite verifies:
 - Correct ISO-TP transport: SF/FF/CF/FC framing, timing, multi-frame reassembly
 - Correct DoIP transport: header encode/decode, routing activation, diagnostic message dispatch, negative acknowledgement generation, alive check (v1.6.0)
 - Enforcement of the ASIL-B 5-step DID access safety chain
-- Correct diagnostics code generation from YAML (all 17 templates)
+- Correct diagnostics code generation from YAML (all 18 templates)
 - Correct test generation from YAML (`testgen.py`) — verified for all examples
 - NVM DTC mirror persistence across simulated resets
 - Zero dynamic memory allocation anywhere in the stack

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -207,7 +207,7 @@ platform/
   platform_api.h    Common HAL interface (Zephyr + FreeRTOS)
   zephyr/           Zephyr RTOS port (threads, CAN, NVM, flash, watchdog, DoIP shim)
   freertos/         FreeRTOS port (task, CAN shim, NVM abstraction, DoIP shim)
-tools/              codegen.py, testgen.py, mcp_server.py, 17 Jinja2 templates
+tools/              codegen.py, testgen.py, mcp_server.py, 18 Jinja2 templates
 examples/           12 ECU examples — each with diagnostics_config.yaml + generated/
 gui/                React/TypeScript configurator and live dashboard
 tests/              44 Unity unit tests, Python integration tests, harness (68 tests)

--- a/examples/ardep_ecu/generated/safety_config.h
+++ b/examples/ardep_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.12.0"
+#define UDS_STACK_VERSION "1.13.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu/generated/safety_config.h
+++ b/examples/basic_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.12.0"
+#define UDS_STACK_VERSION "1.13.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu_doip/generated/safety_config.h
+++ b/examples/basic_ecu_doip/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.12.0"
+#define UDS_STACK_VERSION "1.13.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu_doip_freertos/generated/safety_config.h
+++ b/examples/basic_ecu_doip_freertos/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.12.0"
+#define UDS_STACK_VERSION "1.13.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu_freertos/generated/safety_config.h
+++ b/examples/basic_ecu_freertos/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.12.0"
+#define UDS_STACK_VERSION "1.13.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/bms_ecu/generated/safety_config.h
+++ b/examples/bms_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.12.0"
+#define UDS_STACK_VERSION "1.13.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/motor_controller_ecu/generated/safety_config.h
+++ b/examples/motor_controller_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.12.0"
+#define UDS_STACK_VERSION "1.13.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/robot_joint_controller_ecu/generated/safety_config.h
+++ b/examples/robot_joint_controller_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.12.0"
+#define UDS_STACK_VERSION "1.13.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/safeboot_ecu/generated/safety_config.h
+++ b/examples/safeboot_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.12.0"
+#define UDS_STACK_VERSION "1.13.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/safeboot_freertos_ecu/generated/safety_config.h
+++ b/examples/safeboot_freertos_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.12.0"
+#define UDS_STACK_VERSION "1.13.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/sensor_ecu/generated/safety_config.h
+++ b/examples/sensor_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.12.0"
+#define UDS_STACK_VERSION "1.13.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/sensor_ecu_freertos/generated/safety_config.h
+++ b/examples/sensor_ecu_freertos/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.12.0"
+#define UDS_STACK_VERSION "1.13.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -100,7 +100,7 @@ except ImportError:
     print("ERROR: Jinja2 is required.  pip install jinja2", file=sys.stderr)
     sys.exit(2)
 
-__version__ = "1.12.0"
+__version__ = "1.13.0"
 
 # =============================================================================
 # Constants


### PR DESCRIPTION
Version bump for the v1.13.0 release — release-runbook.md steps 1-2 (CHANGELOG roll + version bumps), now via a new automation script rather than hand-editing files one at a time.

## New: `scripts/bump_release_version.py` (xaloqi-knowledge repo)

Built in direct response to this campaign's own version-identity bugs (O-50/O-51 and their tail through O-67) — every version-bearing literal that drifted independently this campaign (`core/uds_types.h`, `CMakeLists.txt`, `SECURITY.md`, 12 generated `safety_config.h` files, the EDS-toolchain template, `INSTALL.md`, README badges...) is now bumped from one command, so there's no window where different files disagree about what "the version" is. Companion commit lands in EDS-toolchain.

## This PR

- `CHANGELOG.md`: rolled `[Unreleased]` → `[1.13.0] — 2026-09-01`.
- `tools/codegen.py` `__version__`, `core/uds_types.h`'s 4 `UDS_SUITE_VERSION_*` macros, `CMakeLists.txt`, `SECURITY.md`'s supported-versions table (shifted: 1.13.x current / 1.12.x critical-only / <1.12 unsupported), `README.md` badge, `INSTALL.md` (6 occurrences).
- All 12 committed `examples/*/generated/safety_config.h`'s `UDS_STACK_VERSION` line.
- Found running the release-time docs sweep (`check_release_docs.py`) and fixed: 5 stale "17 Jinja2 templates" mentions the #158/#76 count-fix pass missed (`README.md` x2, `docs/llms.txt`, `docs/CODEGEN_ARCHITECTURE.md` x2, `docs/TESTING_STRATEGY.md`).

## Verification

- `bash build_tests.sh` → 44/44.
- Spot-checked `ardep_ecu`'s `safety_config.h` against a real `codegen.py` + EDS-toolchain-templates regen — timestamp-only diff, confirming the targeted line edit matches what real codegen produces.
- `python3 scripts/check_versions.py` — clean except `products/eds.md`/`KNOWLEDGE_INDEX.md` (release-runbook step 10, "close the loop," done after tagging).
- `python3 scripts/check_release_docs.py` — 0 hard failures once this + the EDS-toolchain companion land and the tag is cut (the script's "current version" is `git describe --tags`, so it reads the *old* tag until v1.13.0 is actually pushed — expected).

Next after merge: tag `v1.13.0`, verify the automated GitHub Release, build + gate the EDS-toolchain ZIPs.