### PR TITLE
docs: fix 8 more stale v1.12.0 references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+- **8 more stale v1.12.0 references, none of them the `**Version:**` header
+  pattern #178 already fixed.** (#180) Found by the Tier-1 architect's
+  round-2 re-review plus a broader manual sweep once the pattern was
+  known: `README.md`'s and `docs/GETTING_STARTED.md`'s `west init --mr
+  v1.12.0` quickstart commands (would clone the wrong tag), `README.md`'s
+  and `docs/INTEGRATION_GUIDE.md`'s example `revision: v1.12.0` west
+  manifest snippets, `docs/TESTING_STRATEGY.md`'s test-count header and
+  inline count claim, `docs/AI_CONTEXT.md`'s pricing footer, `docs/
+  INTEGRATION_GUIDE.md`'s title header, and `docs/COMMERCIAL_ONBOARDING.md`'s
+  two example ZIP filenames. Left untouched, deliberately: `docs/
+  ARCHITECTURE.md`'s DoIP feature matrix ("current as of v1.12.0" / "out
+  of scope as of v1.12.0") — a dated snapshot marker whose claim remains
+  literally true, not a current-version claim; and `docs/
+  INTEGRATION_GUIDE.md`'s SOVD CDA JSON worked example, whose
+  `generatedBy` version is paired with a fixed illustrative `generatedAt`
+  timestamp — bumping one without the other would make the example more
+  wrong, not less. `check_release_docs.py` (xaloqi-knowledge) extended
+  the same day to recognize the new phrasings so this class can't recur
+  silently.
+
 - **`docs/ARCHITECTURE.md`, `docs/AI_CONTEXT.md`, and `docs/TESTING_STRATEGY.md`'s own `**Version:**` headers still said v1.12.0 after v1.13.0 was tagged.** Found by `check_release_docs.py` immediately after tagging — the new `bump_release_version.py` (xaloqi-knowledge) only touched `README.md`/`INSTALL.md` at the repo root, not `docs/*.md`, the exact drift class this repo's own release runbook already names ("docs/ went unswept for three releases"). Fixed here; the bump script itself was extended (same day, xaloqi-knowledge) to sweep `docs/*.md` for this header pattern automatically going forward, rather than shipped as a hardcoded per-file list.
 
 ## [1.13.0] — 2026-09-01

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ manifest:
   projects:
     - name: EDS
       remote: xaloqi
-      revision: v1.12.0
+      revision: v1.13.0
       path: modules/eds
 ```
 
@@ -181,7 +181,7 @@ The `ZEPHYR_EDS_MODULE_DIR` variable is set automatically by west when the modul
 
 ```bash
 pip install west
-west init -m https://github.com/Xaloqi/EDS --mr v1.12.0 eds-workspace
+west init -m https://github.com/Xaloqi/EDS --mr v1.13.0 eds-workspace
 cd eds-workspace && west update
 pip install -r tools/requirements.txt
 ```

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -1033,5 +1033,5 @@ tooling and lives in EDS-toolchain — it is not part of this repo's public CI.)
 
 ---
 
-*EDS v1.12.0 — Developer €690/yr · Professional €1,990/yr — xaloqi.com*
+*EDS v1.13.0 — Developer €690/yr · Professional €1,990/yr — xaloqi.com*
 *Runtime: GPL v2 · Examples: Apache 2.0 · Tools + IDE + GUI: Commercial*

--- a/docs/COMMERCIAL_ONBOARDING.md
+++ b/docs/COMMERCIAL_ONBOARDING.md
@@ -15,7 +15,7 @@ After purchase you will have received a download link containing a ZIP file.
 ### Developer license ZIP contents
 
 ```
-xaloqi-eds-developer-v1.12.0.zip
+xaloqi-eds-developer-v1.13.0.zip
 ├── tools/
 │   ├── _license.py          ← License validation module (required for codegen)
 │   └── templates/           ← Jinja2 templates for all generated C/H files
@@ -37,7 +37,7 @@ xaloqi-eds-developer-v1.12.0.zip
 Everything in Developer, plus:
 
 ```
-xaloqi-eds-professional-v1.12.0.zip
+xaloqi-eds-professional-v1.13.0.zip
 ├── tools/
 │   ├── _license.py
 │   └── templates/           ← Same Jinja2 templates

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -61,7 +61,7 @@ west --version   # must print 1.2 or newer
 mkdir eds-workspace && cd eds-workspace
 
 # Initialise the workspace from the EDS repository
-west init -m https://github.com/Xaloqi/EDS --mr v1.12.0 .
+west init -m https://github.com/Xaloqi/EDS --mr v1.13.0 .
 
 # Pull Zephyr and all dependencies (this downloads ~500 MB, takes 2-4 min)
 west update

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -1,6 +1,6 @@
 # Integration Guide
 
-## Xaloqi EDS — Zephyr RTOS, FreeRTOS, DoIP, and SOVD (v1.12.0)
+## Xaloqi EDS — Zephyr RTOS, FreeRTOS, DoIP, and SOVD (v1.13.0)
 
 | Field | Value |
 |---|---|
@@ -185,7 +185,7 @@ manifest:
 
     - name: embedded-diagnostics-suite
       url: https://github.com/your-org/embedded-diagnostics-suite
-      revision: v1.12.0            # pin to a release tag
+      revision: v1.13.0            # pin to a release tag
       path: eds
 ```
 

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -10,7 +10,7 @@
 EDS uses a four-layer testing strategy: unit tests, harness tests, integration tests, and system
 tests. All four layers run automatically in CI on every push and pull request.
 
-**Current test counts (v1.12.0):**
+**Current test counts (v1.13.0):**
 
 | Layer | Count | Framework | Status |
 |---|---|---|---|
@@ -30,7 +30,7 @@ tests. All four layers run automatically in CI on every push and pull request.
 ### What "the generated pytest suite" (row above) actually runs on a clean checkout
 
 `cd examples/basic_ecu/generated/tests && pytest --collect-only -q` reports **632 tests
-collected** for `basic_ecu` (v1.12.0). That is a *collection* count, not a claim that
+collected** for `basic_ecu` (v1.13.0). That is a *collection* count, not a claim that
 632 tests execute — and pass — right after `pip install -r tools/requirements.txt`. A
 meaningful share need TestLab (the commercial `xaloqi-tester` package), the
 (not-publicly-included) `firmware_bus` harness, or the commercial `tools/templates/`


### PR DESCRIPTION
Closes #180.

None of these are the `**Version:**` header pattern #178 already fixed:

- `README.md`, `docs/GETTING_STARTED.md`: `west init --mr v1.12.0` quickstart (clones the wrong tag)
- `README.md`, `docs/INTEGRATION_GUIDE.md`: example `revision: v1.12.0` west manifest snippets
- `docs/TESTING_STRATEGY.md`: test-count header + inline count claim
- `docs/AI_CONTEXT.md`: pricing footer
- `docs/INTEGRATION_GUIDE.md`: title header
- `docs/COMMERCIAL_ONBOARDING.md`: two example ZIP filenames

Deliberately left alone (checked, not stale):
- `docs/ARCHITECTURE.md`'s DoIP feature matrix ("current as of v1.12.0" / "out of scope as of v1.12.0") — a dated snapshot marker whose claim remains literally true, not a current-version claim.
- `docs/INTEGRATION_GUIDE.md`'s SOVD CDA JSON worked example — its `generatedBy` version is paired with a fixed illustrative `generatedAt` timestamp; bumping one without the other makes the example more wrong, not less.

Companion fix in `xaloqi-knowledge`'s `check_release_docs.py` (extending its pattern coverage so this class can't recur silently) landing alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)