### PR TITLE
docs: dual-transport concurrency + DID-callback execution context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+- **Documented the dual-transport concurrency contract and the DID-callback
+  execution context** (#181). `uds_server_ctx_t` is a single shared struct
+  and `core/uds_server.c` does not lock around `uds_server_process_request()`
+  internally — `docs/threading_guide.md` already had an `s_session_lock` /
+  `s_security_lock` pair for `diag_task`, but never mentioned that DoIP runs
+  in its own thread (`doip_thread`) with its own unguarded call path into
+  the same shared context, or what an integrator combining both transports
+  (as `basic_ecu_doip`'s own `main.c` comment invites) is responsible for
+  locking. Added a "Dual-Transport Concurrency" and a "Callback Execution
+  Context" section to `docs/threading_guide.md`, cross-referenced from
+  `docs/ARCHITECTURE.md` and `docs/INTEGRATION_GUIDE.md`. Docs-only — no
+  code defect found; the shipped single-transport examples are correctly
+  unaffected either way.
+
 - **`docs/ARCHITECTURE.md`, `docs/AI_CONTEXT.md`, and `docs/TESTING_STRATEGY.md`'s own `**Version:**` headers still said v1.12.0 after v1.13.0 was tagged.** Found by `check_release_docs.py` immediately after tagging — the new `bump_release_version.py` (xaloqi-knowledge) only touched `README.md`/`INSTALL.md` at the repo root, not `docs/*.md`, the exact drift class this repo's own release runbook already names ("docs/ went unswept for three releases"). Fixed here; the bump script itself was extended (same day, xaloqi-knowledge) to sweep `docs/*.md` for this header pattern automatically going forward, rather than shipped as a hardcoded per-file list.
 
 ## [1.13.0] — 2026-09-01

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,7 +14,10 @@ ECUs. It implements a complete UDS (ISO 14229) server over two transports:
 - **DoIP (ISO 13400-2)** over Ethernet/TCP — added in v1.6.0, Zephyr and FreeRTOS+LwIP bindings
 
 Both transports use the same UDS server core, ASIL-B safety wrappers, and YAML-driven code
-generation. Transport selection is a one-line change in `diagnostics_config.yaml`.
+generation. Transport selection is a one-line change in `diagnostics_config.yaml`. Both can be
+active in the same build, but nothing inside the UDS server core serializes concurrent access
+to it if you do — see [`docs/threading_guide.md`](threading_guide.md)'s "Dual-Transport
+Concurrency" section before combining CAN and DoIP in one ECU.
 
 The system is structured to support:
 

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -461,7 +461,7 @@ while (true) {
 }
 ```
 
-**Implement your DID handlers** — open `generated/did_handlers.c` and replace each stub body with a real sensor read:
+**Implement your DID handlers** — open `generated/did_handlers.c` and replace each stub body with a real sensor read. These run synchronously from task context (`diag_task` for CAN, `doip_thread` for DoIP), never from an ISR, and EDS holds no lock while calling them — synchronizing access to any shared application state inside your handler is your responsibility. See [`docs/threading_guide.md`](threading_guide.md)'s "Callback Execution Context" section for the full contract:
 
 ```c
 /* Generated stub — replace with real sensor read: */

--- a/docs/threading_guide.md
+++ b/docs/threading_guide.md
@@ -79,6 +79,47 @@ access to guarantee atomic read-modify-write on all architectures.
 calls `k_msgq_put()` from ISR context; `diag_task` calls `k_msgq_get(K_NO_WAIT)` from thread
 context. No additional locking is required.
 
+### Dual-Transport Concurrency (CAN + DoIP)
+
+`uds_server_ctx_t` (holding session and security state) is a single struct — every generated
+`uds_init.c` declares exactly one static instance (`s_server_ctx`), regardless of which
+transport(s) are compiled in. **`core/uds_server.c` itself does not lock around
+`uds_server_process_request()`** — any locking around a call into it is application-level, not
+something EDS does for you internally.
+
+The `s_session_lock` / `s_security_lock` pair described above is example-level integration code
+(`examples/*/src/main.c`), written once per example around `diag_task`'s call site. **DoIP runs
+in its own dedicated thread** (`doip_thread`, `K_THREAD_DEFINE` in `platform/zephyr/zephyr_lwip.c`,
+running `eds_doip_server_run()`) with its own call path into `uds_server_process_request()`.
+
+The shipped examples never combine both: `basic_ecu` runs CAN-only (`diag_task`, with the mutex
+pair); `basic_ecu_doip` / `basic_ecu_doip_freertos` run DoIP-only (`doip_thread`, no mutex —
+correctly, since there's only one caller thread in that build) — its `main.c` explicitly notes
+*"The CAN diagnostic task (diag_task) is NOT started here... for a production 'both' transport
+ECU, add the CAN thread from basic_ecu alongside the DoIP init."*
+
+**If you do that** — wire both `diag_task` and `doip_thread` into the same build against the
+same `s_server_ctx` — both threads now call `uds_server_process_request()` concurrently, and
+nothing inside EDS serializes them. You are responsible for extending the *same* `s_session_lock`
+/ `s_security_lock` (or an equivalent single lock) around **every** call site that touches
+`uds_server_ctx_t`, CAN's and DoIP's alike — not just `diag_task`'s, as the single-transport
+examples show it. Skipping this is a real, unguarded data race on session/security state, not a
+theoretical one.
+
+### Callback Execution Context
+
+Generated DID/routine handlers (`did_handlers.c`, `routine_handlers.c`) are called synchronously,
+inline, from within `uds_server_process_request()` — never from an ISR. The calling thread is
+whichever thread invoked `uds_server_process_request()` in your build: `diag_task` for CAN,
+`doip_thread` for DoIP, or both (see above) if you've wired a dual-transport build.
+
+EDS holds no lock while invoking your callback and expects none — synchronizing your callback's
+access to shared application state (a sensor reading, a calibration value, anything not owned
+exclusively by the calling thread) is entirely your responsibility, using the same primitives
+(`diag_mutex_t`, atomics, message queues) you'd use between any two threads touching shared state.
+A DID handler reading `app_global_vin` without synchronization races exactly like any other
+unsynchronized cross-thread read — nothing UDS-specific makes it safer.
+
 ---
 
 ## Timing Constraints


### PR DESCRIPTION
Closes #181.

`uds_server_ctx_t` is a single shared struct per generated init, and `core/uds_server.c` does not lock around `uds_server_process_request()` internally. `docs/threading_guide.md` already documented an `s_session_lock` / `s_security_lock` pair, but that pair is example-level integration code (`examples/*/src/main.c`) written around `diag_task`'s call site only — it never mentioned that DoIP runs in its own dedicated thread (`doip_thread`, `K_THREAD_DEFINE` in `zephyr_lwip.c`) with its own unguarded call path into the same shared context.

Verified against code before writing anything: the shipped examples never combine both transports (`basic_ecu` is CAN-only with the mutex pair; `basic_ecu_doip`/`basic_ecu_doip_freertos` are DoIP-only with no mutex, correctly, since there's only one caller thread) — but `basic_ecu_doip`'s own `main.c` comment explicitly invites combining them ("for a production 'both' transport ECU, add the CAN thread from `basic_ecu` alongside the DoIP init"). Anyone who does that gets a real, unguarded data race on session/security state unless they extend the same lock pair to DoIP's call site too.

- New "Dual-Transport Concurrency" and "Callback Execution Context" sections in `docs/threading_guide.md`
- Cross-referenced from `docs/ARCHITECTURE.md` (the ambiguous "both transports use the same UDS server core" line) and `docs/INTEGRATION_GUIDE.md` (the DID handler implementation walkthrough)

Docs-only — no code defect found; the shipped single-transport examples are correctly unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)