### PR TITLE
docs: document the SecurityAccess failed-attempt lockout policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+- **Documented the SecurityAccess failed-attempt lockout policy** (#183).
+  The mechanism was already implemented in `core/uds_security.c`
+  (`max_attempts` default 3, `lockout_ms` default 10s, NVM-persistable
+  counter) but `docs/SECURITY_NOTICE.md` never described the semantics
+  an integrator needs: the lockout duration is flat, not progressive
+  (no built-in exponential backoff); the counter resets only on a
+  successful unlock, not on lockout expiry; and NVM persistence across
+  power cycles is optional — off by default — not automatic. Docs-only,
+  pulled directly from the actual config struct and reset logic, not
+  invented defaults.
+
 - **`docs/ARCHITECTURE.md`, `docs/AI_CONTEXT.md`, and `docs/TESTING_STRATEGY.md`'s own `**Version:**` headers still said v1.12.0 after v1.13.0 was tagged.** Found by `check_release_docs.py` immediately after tagging — the new `bump_release_version.py` (xaloqi-knowledge) only touched `README.md`/`INSTALL.md` at the repo root, not `docs/*.md`, the exact drift class this repo's own release runbook already names ("docs/ went unswept for three releases"). Fixed here; the bump script itself was extended (same day, xaloqi-knowledge) to sweep `docs/*.md` for this header pattern automatically going forward, rather than shipped as a hardcoded per-file list.
 
 ## [1.13.0] — 2026-09-01

--- a/docs/SECURITY_NOTICE.md
+++ b/docs/SECURITY_NOTICE.md
@@ -194,6 +194,42 @@ void eds_entropy_sanity_check(void)
 
 ---
 
+## Failed Attempt Lockout Policy
+
+SecurityAccess (0x27) implements a failed-attempt counter and lockout, per
+ISO 14229-1's `requiredTimeDelay` mechanism. This section documents the
+actual implemented semantics (`core/uds_security.c`, `core/uds_security.h`)
+so you can decide whether the defaults fit your product before shipping.
+
+| Parameter | Default | Configurable via |
+|---|---|---|
+| Max consecutive failed attempts before lockout | 3 | `uds_security_cfg_t.max_attempts` (`UDS_SECURITY_MAX_ATTEMPTS` if left at 0) |
+| Lockout duration | 10,000 ms (10 s) | `uds_security_cfg_t.lockout_ms` (`UDS_SECURITY_LOCKOUT_MS` if left at 0) |
+
+**The lockout duration is flat, not progressive.** Every time the counter
+reaches `max_attempts`, the *same* configured duration applies — there is no
+built-in exponential backoff (1s, 2s, 4s, 8s...). If your product needs
+escalating delays, you must implement that yourself around the seed/key
+exchange calls; EDS applies one fixed duration per lockout event.
+
+**Counter reset:** the failed-attempt counter resets to 0 only on a
+*successful* key validation. It does **not** reset when a lockout period
+naturally expires — the counter stays at `max_attempts`, so the very next
+failed attempt re-triggers lockout immediately with no partial credit. Only
+a correct key clears it.
+
+**Persistence is optional, not automatic.** By default (`nvm_load_cb` /
+`nvm_save_cb` left `NULL` in `uds_security_cfg_t`) the counter and any
+in-progress lockout live in RAM only and reset to zero on any reboot —
+power-cycling the ECU is a full bypass. Wiring both callbacks makes the
+counter and lockout residual survive a power cycle (loaded back in by
+`uds_security_init()` on the next boot); this is the only way to close
+the power-cycle bypass. If your product's threat model includes an
+attacker with physical access to power, wire NVM persistence — the stack
+does not require it, but it does not protect you without it either.
+
+---
+
 ## Questions
 
 Contact **contact@xaloqi.com** for questions about entropy source validation,


### PR DESCRIPTION
Closes #183.

The mechanism (`max_attempts`, `lockout_ms`, NVM-persistable counter) was already implemented in `core/uds_security.c` — this only documents it, with the exact semantics pulled from the actual code, not invented defaults:

- `max_attempts` default 3 (`UDS_SECURITY_MAX_ATTEMPTS`)
- `lockout_ms` default 10000ms/10s (`UDS_SECURITY_LOCKOUT_MS`), **flat, not progressive** — no built-in exponential backoff
- counter resets to 0 **only on successful unlock**, not on lockout expiry (verified: `uds_security_key_validate`'s success path vs `uds_security_is_unlocked`'s tick-to-zero path)
- NVM persistence is **optional** (`nvm_load_cb`/`nvm_save_cb` default `NULL`) — without it, power-cycling the ECU is a full bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)