### PR TITLE
fix: sbom.json stale since inception, 6 releases behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **`sbom.json` was hand-maintained and stale since inception — six
+  releases behind** (#179): `version`/`bom-ref` said `1.7.4`, `timestamp`
+  said 2026-06-21, while the repo has been at v1.13.0 since 2026-09-01. No
+  tooling in either repo touched this file. One-time corrective fix here;
+  `scripts/bump_release_version.py` (xaloqi-knowledge) is now extended to
+  update `metadata.component.version`/`bom-ref`/`timestamp` on every future
+  release, so this can't silently drift again. Deliberately does not touch
+  `components[]` (zephyr@3.7.0 and dependency entries) — those are real
+  third-party versions, not EDS's own, and must not shift with an EDS
+  release.
+
 ### Documentation
 
 - **8 more stale v1.12.0 references, none of them the `**Version:**` header

--- a/sbom.json
+++ b/sbom.json
@@ -4,7 +4,7 @@
   "serialNumber": "urn:uuid:7b3c9a5d-1f2e-4c8b-a6d0-8e4f2b1c5a3d",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-06-21T00:00:00Z",
+    "timestamp": "2026-09-01T00:00:00Z",
     "tools": [
       {
         "vendor": "Xaloqi",
@@ -14,9 +14,9 @@
     ],
     "component": {
       "type": "firmware",
-      "bom-ref": "xaloqi-eds@1.7.4",
+      "bom-ref": "xaloqi-eds@1.13.0",
       "name": "Xaloqi EDS",
-      "version": "1.7.4",
+      "version": "1.13.0",
       "description": "Production-grade UDS/ISO-TP/DoIP diagnostics stack for automotive ECUs (ASIL-B candidate, ISO 14229 / ISO 15765-2 / ISO 13400-2)",
       "licenses": [
         {


### PR DESCRIPTION
Closes #179.

`version`/`bom-ref` said `1.7.4`, `timestamp` said 2026-06-21, while the repo has been at v1.13.0 since 2026-09-01. No tooling in either repo touched this file — entirely hand-maintained since it was first added.

One-time corrective fix: `metadata.component.version` → `"1.13.0"`, `metadata.component.bom-ref` → `"xaloqi-eds@1.13.0"`, `metadata.timestamp` → `"2026-09-01T00:00:00Z"`. Applied via the same `bump_sbom()` logic now wired into `bump_release_version.py` (xaloqi-knowledge, companion change), verified byte-identical round-trip except for exactly these 3 fields before applying for real.

Deliberately does **not** touch `components[]` (`zephyr@3.7.0` and other dependency entries) — those are real third-party versions, not EDS's own, and must not shift with an EDS release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)