### PR TITLE
DoIP transport hardening: tick timers, disconnect reset, sync, deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,71 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **DoIP transport hardening — 3 bundled fixes** (#191, #192, #193; Tier-1
+  round-3 due diligence). All three live in `transport/doip/` + the two
+  DoIP example `main.c` files, bundled into one PR per that campaign's
+  CI-cost-consolidation guidance rather than three separate ones.
+
+  - **DoIP-only examples never ticked UDS timers** (#191a): neither
+    `examples/basic_ecu_doip/src/main.c` (Zephyr) nor
+    `examples/basic_ecu_doip_freertos/src/main.c` (FreeRTOS) called
+    `uds_server_tick_1ms()`/`uds_periodic_tick_1ms()` anywhere — with no
+    CAN `diag_task` in a DoIP-only build, the S3 session timeout and
+    SecurityAccess lockout countdown never progressed at all. Added a
+    dedicated 1ms tick task/thread to both examples (not a reuse of
+    FreeRTOS's `eds_freertos_start()` poll task, which is CAN/ISO-TP-
+    specific and would call `can_transport_receive()`/`isotp_tick_1ms()`
+    against the NULL transport a DoIP-only build has no context for).
+
+  - **DoIP disconnect didn't reset UDS session/security state** (#191b):
+    `doip_server.c`'s `connection_closed` path only reset DoIP-layer
+    `routing_active`/`tester_address`, never the UDS session or security
+    context — a new connection inherited whatever session/security state
+    the previous one left behind. Same lesson as `[SEC-S3-RESET-01]`
+    (`core/uds_server.c`) recurring in a different code path: a forced
+    return to a fresh state must reset SecurityAccess too. Added
+    `uds_session_transition(..., UDS_SESSION_DEFAULT)` +
+    `uds_security_reset(...)` to `connection_closed`, mirroring
+    SEC-S3-RESET-01's own pairing exactly. New regression test
+    `test_doip_disconnect_resets_security_and_session`
+    (`tests/test_doip_integration.py`) — unlocks on connection 1, proves
+    it with a write, reconnects without re-unlocking, confirms the same
+    write now correctly fails NRC 0x33.
+
+  - **DoIP Zephyr thread startup used a fixed 500ms delay** (#192):
+    `K_THREAD_DEFINE(doip_thread, ..., delay_ms = 500)` assumed
+    application init always completes within 500ms — a timing budget, not
+    a guarantee. Replaced with a semaphore (`s_doip_ready_sem`) that
+    `zephyr_doip_platform_init()` gives once `s_uds_ctx` is set and
+    platform ops are registered; `doip_thread` blocks on it instead of
+    sleeping a fixed duration. (FreeRTOS's analogous
+    `vTaskDelay(pdMS_TO_TICKS(500U))` in `freertos_lwip.c` is justified
+    differently — network-interface bring-up time, not a `s_uds_ctx` race,
+    since FreeRTOS's task is created dynamically *after* `s_uds_ctx` is
+    already set — left alone, out of scope here.)
+
+  - **DoIP had no absolute frame-assembly deadline** (#193): each
+    `tcp_recv()` call in the header/payload read loops had its own
+    150ms-silence timeout, but a client sending 1 byte per window never
+    triggered it, holding the single connection slot indefinitely.
+    `doip_server.c` cannot call an RTOS clock directly (platform
+    interaction is ops-only), so added a read-*attempt* bound instead of
+    a true wall-clock deadline — `DOIP_MAX_FRAME_READ_ATTEMPTS` (256,
+    tuneable) — generous enough for any legitimate fragmentation pattern
+    while still bounding the worst case.
+
+  Verified: `bash build_tests.sh` — 44 passed, 894 cases, 0 failed
+  (including `test_doip_server`, 30/30). The new Python integration test
+  targets a real compiled `basic_ecu_doip` binary (Zephyr SDK + native_sim
+  + `xaloqi-tester`), not available in this environment — logic verified
+  by tracing `service_0x10.c`'s security-reset condition (only fires on
+  transition *to* `UDS_SESSION_DEFAULT`, confirming the test's premise
+  that an Extended-session reconnect without the fix would NOT have reset
+  security on its own) rather than a local run; CI's DoIP Integration job
+  will execute it for real.
+
 ## [1.13.1] — 2026-09-01
 
 ### Added

--- a/examples/basic_ecu_doip/src/main.c
+++ b/examples/basic_ecu_doip/src/main.c
@@ -18,8 +18,14 @@
  *          add the CAN thread from basic_ecu alongside the DoIP init.
  *
  * THREAD MODEL:
- *   main()        — init → uds_generated_init → eds_doip_platform_start → return
- *   doip_thread   — K_THREAD_DEFINE in zephyr_lwip.c; runs eds_doip_server_run()
+ *   main()        — init → uds_generated_init → start tick + DoIP → return
+ *   uds_tick_task — 1 ms poll loop: uds_server_tick_1ms() + uds_periodic_tick_1ms().
+ *                   [EDS#191] A DoIP-only build has no CAN diag_task, so
+ *                   without this thread the S3 session timeout and the
+ *                   SecurityAccess lockout countdown never progress — a
+ *                   session/unlock, once entered, never expires on its own.
+ *   doip_thread   — started via a semaphore (zephyr_lwip.c), not a fixed
+ *                   delay [EDS#192]; runs eds_doip_server_run()
  *
  * TARGET: native_sim (CI — loopback networking) and any Ethernet-capable
  *         Zephyr board (e.g. FRDM-K64F, STM32H7 with ETH).
@@ -89,6 +95,28 @@ LOG_MODULE_REGISTER(basic_ecu_doip, LOG_LEVEL_INF);
  * ============================================================================= */
 
 #define DOIP_ECU_LOGICAL_ADDR   (0xE400U)
+
+/* =============================================================================
+ * UDS tick task configuration [EDS#191]
+ *
+ * Drives uds_server_tick_1ms() and uds_periodic_tick_1ms() every 1 ms —
+ * the only thing progressing the S3 session timeout and SecurityAccess
+ * lockout countdown in a DoIP-only build (no isotp_tick_1ms(): there is
+ * no ISO-TP/CAN transport here). Priority matches basic_ecu's diag_task
+ * (5) — higher priority than doip_thread's default (7,
+ * zephyr_lwip.c) so UDS timer progression is never starved by DoIP
+ * request handling, same rationale as the CAN example's own priority split.
+ * ============================================================================= */
+
+#ifndef CONFIG_DIAG_TICK_TASK_STACK_SIZE
+#define CONFIG_DIAG_TICK_TASK_STACK_SIZE   (1024U)
+#endif
+#ifndef CONFIG_DIAG_TICK_TASK_PRIORITY
+#define CONFIG_DIAG_TICK_TASK_PRIORITY     (5)
+#endif
+
+K_THREAD_STACK_DEFINE(s_tick_stack, CONFIG_DIAG_TICK_TASK_STACK_SIZE);
+static struct k_thread s_tick_thread;
 
 /* =============================================================================
  * Application state — same stub DIDs as basic_ecu
@@ -174,6 +202,25 @@ static void s_on_session_change(uds_session_type_t old_sess,
 }
 
 /* =============================================================================
+ * UDS tick task [EDS#191]
+ * ============================================================================= */
+
+static void uds_tick_task_entry(void *p1, void *p2, void *p3)
+{
+    uds_server_ctx_t *srv = (uds_server_ctx_t *)p1;
+    (void)p2;
+    (void)p3;
+
+    LOG_INF("UDS tick task started");
+
+    while (true) {
+        k_msleep(1);
+        (void)uds_server_tick_1ms(srv);
+        (void)uds_periodic_tick_1ms();
+    }
+}
+
+/* =============================================================================
  * main()
  * ============================================================================= */
 
@@ -223,11 +270,24 @@ int main(void)
             (unsigned)GEN_DID_COUNT, (unsigned)GEN_DTC_COUNT);
 
     /*
+     * [EDS#191] Start the 1 ms UDS tick task before the DoIP server so
+     * S3/lockout timing is live from the moment a connection can arrive.
+     */
+    (void)k_thread_create(
+        &s_tick_thread, s_tick_stack,
+        K_THREAD_STACK_SIZEOF(s_tick_stack),
+        uds_tick_task_entry,
+        (void *)srv, NULL, NULL,
+        CONFIG_DIAG_TICK_TASK_PRIORITY, 0U, K_NO_WAIT
+    );
+    k_thread_name_set(&s_tick_thread, "uds_tick_task");
+
+    /*
      * Start DoIP server.
      * This registers the Zephyr BSD-socket platform ops with doip_server.c
-     * and activates the pre-defined doip_thread (K_THREAD_DEFINE in
-     * zephyr_lwip.c). The thread starts accepting TCP connections on
-     * DOIP_ECU_LOGICAL_ADDR / DOIP_PORT after a 500 ms startup delay.
+     * and signals doip_thread (zephyr_lwip.c) to start — a semaphore, not
+     * a fixed delay [EDS#192]. The thread then accepts TCP connections on
+     * DOIP_ECU_LOGICAL_ADDR / DOIP_PORT.
      */
     status = eds_doip_platform_start(DOIP_ECU_LOGICAL_ADDR, DOIP_PORT, srv);
     if (status != UDS_STATUS_OK) {

--- a/examples/basic_ecu_doip_freertos/src/main.c
+++ b/examples/basic_ecu_doip_freertos/src/main.c
@@ -12,11 +12,16 @@
  *          The UDS stack, DoIP server logic, and platform abstraction layer
  *          are identical. Only the OS primitives and IP stack differ.
  *
- *          INTEGRATION SEQUENCE (4 steps):
+ *          INTEGRATION SEQUENCE (5 steps):
  *
  *            1. eds_platform_init()                     — CAN transport + NVM
  *            2. uds_generated_init(NULL, 0, 0)          — UDS stack (DoIP-only,
  *                                                         no CAN transport)
+ *            2.5. uds_tick_task (xTaskCreate)            — [EDS#191] 1ms
+ *                                                         uds_server_tick_1ms()
+ *                                                         + uds_periodic_tick_1ms();
+ *                                                         without this, S3/lockout
+ *                                                         timing never progresses
  *            3. eds_doip_platform_start_freertos(...)   — DoIP server task
  *            4. vTaskStartScheduler()
  *
@@ -63,6 +68,19 @@
 #define DOIP_ECU_LOGICAL_ADDR   (0xE400U)  /**< Standard xaloqi-tester ECU addr */
 #define DOIP_TASK_STACK_BYTES   (4096U)
 #define DOIP_TASK_PRIORITY      (6U)
+
+/*
+ * [EDS#191] UDS tick task — drives uds_server_tick_1ms() and
+ * uds_periodic_tick_1ms() every 1ms. This example never calls
+ * eds_freertos_start() (its poll task is CAN/ISO-TP-specific — it would
+ * call can_transport_receive()/isotp_tick_1ms() against the NULL
+ * transport this DoIP-only build passes to uds_generated_init(), which
+ * this build has no CAN context for), so without a dedicated tick task
+ * here, S3 session timeout and SecurityAccess lockout countdown never
+ * progress at all.
+ */
+#define UDS_TICK_TASK_STACK_WORDS  (256U)
+#define UDS_TICK_TASK_PRIORITY     (5U)
 
 /* =============================================================================
  * Application state — same stub DIDs as basic_ecu_doip
@@ -148,6 +166,21 @@ static void s_on_session_change(uds_session_type_t old_sess,
 }
 
 /* =============================================================================
+ * UDS tick task [EDS#191]
+ * ============================================================================= */
+
+static void uds_tick_task(void *pvParameters)
+{
+    uds_server_ctx_t *srv = (uds_server_ctx_t *)pvParameters;
+
+    for (;;) {
+        vTaskDelay((TickType_t)1U);
+        (void)uds_server_tick_1ms(srv);
+        (void)uds_periodic_tick_1ms();
+    }
+}
+
+/* =============================================================================
  * main() — four-step integration
  * ============================================================================= */
 
@@ -197,6 +230,22 @@ int main(void)
     (void)uds_periodic_init();
     (void)uds_session_register_change_cb(srv->cfg.session_ctx,
                                           s_on_session_change);
+
+    /*
+     * Step 2.5: Start the 1 ms UDS tick task [EDS#191] — before the DoIP
+     * server task so S3/lockout timing is live from the moment a
+     * connection can arrive. xTaskCreate (not xTaskCreateStatic) is fine
+     * here: this task's own footprint is tiny and one-time at boot,
+     * unlike the CAN poll task's stack-budget concerns noted above.
+     */
+    (void)xTaskCreate(
+        uds_tick_task,
+        "uds_tick",
+        (configSTACK_DEPTH_TYPE)UDS_TICK_TASK_STACK_WORDS,
+        (void *)srv,
+        (UBaseType_t)UDS_TICK_TASK_PRIORITY,
+        NULL
+    );
 
     /*
      * Step 3: Start DoIP server task.

--- a/tests/test_doip_integration.py
+++ b/tests/test_doip_integration.py
@@ -309,6 +309,55 @@ async def test_doip_disconnect_reconnect(doip_ecu: subprocess.Popen) -> None:
 
 
 # ===========================================================================
+# Test 10b — Disconnect resets UDS session/security, not just DoIP routing
+#            state [EDS#191]
+# ===========================================================================
+
+@pytest.mark.asyncio
+async def test_doip_disconnect_resets_security_and_session(
+    doip_ecu: subprocess.Popen,
+) -> None:
+    """A SecurityAccess unlock must NOT survive a TCP disconnect.
+
+    Before EDS#191: doip_server.c's connection_closed path only reset
+    DoIP-layer routing_active/tester_address, never the UDS session or
+    security context. A new connection (a different tester, or the same
+    one reconnecting) inherited whatever session/security state the
+    previous connection left behind until S3 eventually timed it out.
+
+    This reproduces exactly that: unlock security on connection 1, prove
+    the unlock worked (a write succeeds), disconnect, reconnect fresh,
+    and confirm the SAME write now requires a new unlock (NRC 0x33) —
+    not the state.
+    """
+    from xaloqi.tester.exceptions import NegativeResponseError
+
+    # Connection 1: unlock and prove it by writing without error.
+    async with UdsTester(_bus(), rx_id=0xE400, tx_id=0x0E00) as ecu1:
+        await ecu1.change_session(Session.EXTENDED)
+        await ecu1.security_access(level=1)
+        await ecu1.write_did(0xF187, b"EDS-DIP-001")  # unlocked — must succeed
+
+    # Brief pause to let the server accept the next connection.
+    await asyncio.sleep(0.2)
+
+    # Connection 2: fresh TCP connection, Extended session, NO re-unlock.
+    # If security state survived the disconnect (the bug), this write
+    # would silently succeed instead of raising NRC 0x33.
+    async with UdsTester(_bus(), rx_id=0xE400, tx_id=0x0E00) as ecu2:
+        await ecu2.change_session(Session.EXTENDED)
+        try:
+            await ecu2.write_did(0xF187, b"EDS-DIP-001")
+            pytest.fail(
+                "SecurityAccess unlock survived a disconnect — expected "
+                "NRC 0x33 (securityAccessDenied) on the reconnected write, "
+                "got a positive response instead"
+            )
+        except NegativeResponseError as exc:
+            assert exc.nrc == 0x33, f"Expected NRC 0x33, got 0x{exc.nrc:02X}"
+
+
+# ===========================================================================
 # Test 11 — TesterPresent with suppressPosResponse=True
 # ===========================================================================
 

--- a/transport/doip/doip_server.c
+++ b/transport/doip/doip_server.c
@@ -458,8 +458,25 @@ uds_status_t eds_doip_server_run(doip_server_state_t *s,
             /* --- Read header --- */
             uint8_t hdr_buf[DOIP_HEADER_LEN];
             uint32_t hdr_received = 0U;
+            uint32_t hdr_read_attempts = 0U;
 
             while (hdr_received < (uint32_t)DOIP_HEADER_LEN) {
+                /* [EDS#193] Bound total partial reads, not just each read's
+                 * own silence timeout. Without this, a client trickling 1
+                 * byte per DOIP_TCP_RECV_TIMEOUT_MS window keeps making
+                 * "progress" forever and never triggers the per-read
+                 * timeout — the single connection slot never frees up for
+                 * the next tester. This file cannot call an RTOS clock
+                 * directly (platform interaction is ops-only, see file
+                 * header), so a read-attempt bound is used in place of a
+                 * true wall-clock deadline — DOIP_MAX_FRAME_READ_ATTEMPTS
+                 * generously covers any legitimate fragmentation pattern
+                 * while still bounding the worst case. */
+                if (hdr_read_attempts >= (uint32_t)DOIP_MAX_FRAME_READ_ATTEMPTS) {
+                    goto connection_closed;
+                }
+                hdr_read_attempts++;
+
                 int bytes = s_ops->tcp_recv(s->conn_ctx,
                                             &hdr_buf[hdr_received],
                                             (size_t)((uint32_t)DOIP_HEADER_LEN - hdr_received),
@@ -487,7 +504,18 @@ uds_status_t eds_doip_server_run(doip_server_state_t *s,
             /* --- Read payload --- */
             if (payload_len > 0U) {
                 uint32_t received = 0U;
+                uint32_t payload_read_attempts = 0U;
+
                 while (received < payload_len) {
+                    /* [EDS#193] Same read-attempt bound as the header loop
+                     * above — a large payload legitimately takes more reads
+                     * than a header does, so this is tracked separately
+                     * rather than sharing the header loop's budget. */
+                    if (payload_read_attempts >= (uint32_t)DOIP_MAX_FRAME_READ_ATTEMPTS) {
+                        goto connection_closed;
+                    }
+                    payload_read_attempts++;
+
                     int bytes = s_ops->tcp_recv(s->conn_ctx,
                                                 &s->rx_buf[received],
                                                 (size_t)(payload_len - received),
@@ -523,6 +551,28 @@ connection_closed:
         s->conn_ctx       = NULL;
         s->routing_active = false;
         s->tester_address = 0U;
+
+        /* [EDS#191] Reset UDS session/security state on every disconnect —
+         * only DoIP-layer routing state was reset above. Without this, a
+         * new TCP connection (a different tester, or the same one
+         * reconnecting) inherits whatever session/security state the
+         * previous connection left behind (e.g. Extended session +
+         * SecurityAccess unlocked) until S3 eventually times it out.
+         *
+         * Same lesson as [SEC-S3-RESET-01] (core/uds_server.c) recurring
+         * in a different code path: that fix taught this exact codebase
+         * that a forced return to DEFAULT (there, an S3 timeout) must
+         * reset SecurityAccess too, or the unlock survives the transition
+         * — a disconnect is a second, independent way a tester's session
+         * can end, and needed the identical pairing.
+         *
+         * uds_session_transition() to DEFAULT is unconditionally valid
+         * from any current session (see session_validate_transition()),
+         * and uds_security_reset() locks security while correctly
+         * preserving the failed-attempt/lockout counters per ISO
+         * 14229-1 §10.4.5.3 — same two calls SEC-S3-RESET-01 makes. */
+        (void)uds_session_transition(uds_ctx->cfg.session_ctx, UDS_SESSION_DEFAULT);
+        (void)uds_security_reset(uds_ctx->cfg.security_ctx);
     }
 
     /* Unreachable in normal operation */

--- a/transport/doip/doip_server.h
+++ b/transport/doip/doip_server.h
@@ -112,6 +112,21 @@ extern "C" {
 #define DOIP_ALIVE_CHECK_PERIOD_MS (500U)
 #endif
 
+/**
+ * [EDS#193] Maximum partial tcp_recv() attempts allowed while assembling
+ * one header or one payload. DOIP_TCP_RECV_TIMEOUT_MS bounds each
+ * individual read's *silence*, but a client sending 1 byte per window
+ * makes "progress" on every read and never trips that timeout — this
+ * bounds the total attempts instead, so frame assembly always terminates
+ * even against a client trickling data indefinitely. Generous enough
+ * that no legitimate fragmentation pattern should hit it (256 reads at a
+ * 1-byte minimum still covers the full DOIP_MAX_PDU_SIZE payload with
+ * margin); tune down if a tighter bound is wanted for a given deployment.
+ */
+#ifndef DOIP_MAX_FRAME_READ_ATTEMPTS
+#define DOIP_MAX_FRAME_READ_ATTEMPTS (256U)
+#endif
+
 /* ============================================================================
  * Platform operations — implement one set per RTOS/IP-stack combination.
  *

--- a/transport/doip/zephyr_lwip.c
+++ b/transport/doip/zephyr_lwip.c
@@ -76,6 +76,12 @@ static doip_server_state_t s_doip_state;
 static uds_server_ctx_t   *s_uds_ctx    = NULL;
 static uint16_t             s_port       = DOIP_PORT;
 
+/* [EDS#192] doip_thread blocks on this instead of assuming a fixed startup
+ * delay. Given by zephyr_doip_platform_init() once s_uds_ctx is set and
+ * platform ops are registered — a real synchronization point, not a
+ * timing budget that a slower init path could silently exceed. */
+static K_SEM_DEFINE(s_doip_ready_sem, 0, 1);
+
 /* ---------------------------------------------------------------------------
  * Platform ops — zsock_* implementations
  * ------------------------------------------------------------------------ */
@@ -222,6 +228,12 @@ static void doip_thread_entry(void *p1, void *p2, void *p3)
 {
     (void)p1; (void)p2; (void)p3;
 
+    /* [EDS#192] Block until zephyr_doip_platform_init() has set s_uds_ctx
+     * and registered platform ops, rather than assuming a fixed delay is
+     * always enough. A slower init path (more DIDs, a different NVM
+     * backend, a debug build) no longer silently races this thread. */
+    k_sem_take(&s_doip_ready_sem, K_FOREVER);
+
     LOG_INF("DoIP server thread starting (logical_addr=0x%04X port=%u)",
             (unsigned)s_doip_state.logical_address, (unsigned)s_port);
 
@@ -231,17 +243,17 @@ static void doip_thread_entry(void *p1, void *p2, void *p3)
     LOG_ERR("DoIP server exited unexpectedly: 0x%02X", (unsigned)rc);
 }
 
-/* Thread defined at link time — started by the Zephyr kernel once
- * all static initialisers have run.  The thread body blocks in
- * eds_doip_server_run() → tcp_listen() until zephyr_doip_platform_init()
- * has been called and s_uds_ctx is non-NULL. */
+/* Thread defined at link time — started by the Zephyr kernel once all
+ * static initialisers have run. Its body immediately blocks on
+ * s_doip_ready_sem (see above) until zephyr_doip_platform_init() signals
+ * it — no artificial startup delay. */
 K_THREAD_DEFINE(doip_thread,
                 CONFIG_DOIP_STACK_SIZE,
                 doip_thread_entry,
                 NULL, NULL, NULL,
                 K_PRIO_PREEMPT(CONFIG_DOIP_THREAD_PRIORITY),
                 0,
-                /* delay_ms = */ 500);  /* 500 ms head-start for UDS init */
+                0);
 
 /* ---------------------------------------------------------------------------
  * Public: zephyr_doip_platform_init
@@ -261,7 +273,13 @@ uds_status_t zephyr_doip_platform_init(uint16_t          logical_address,
     }
 
     s_port    = port;
-    s_uds_ctx = uds_ctx;   /* thread reads this after 500 ms delay */
+    s_uds_ctx = uds_ctx;
 
-    return eds_doip_register_platform(&s_zephyr_doip_ops);
+    rc = eds_doip_register_platform(&s_zephyr_doip_ops);
+    if (rc == UDS_STATUS_OK) {
+        /* [EDS#192] s_uds_ctx and platform ops are both ready — release
+         * doip_thread now instead of leaving it to a fixed delay. */
+        k_sem_give(&s_doip_ready_sem);
+    }
+    return rc;
 }


### PR DESCRIPTION
Closes #191, #192, #193.

Bundles all three into one PR per the batching guidance from this campaign — they all live in `transport/doip/` + the two DoIP example `main.c` files, same subsystem, same reviewer context, one CI run instead of three.

## #191a — DoIP-only examples never ticked UDS timers
Neither `examples/basic_ecu_doip/src/main.c` (Zephyr) nor `examples/basic_ecu_doip_freertos/src/main.c` (FreeRTOS) called `uds_server_tick_1ms()`/`uds_periodic_tick_1ms()` anywhere — with no CAN `diag_task` in a DoIP-only build, S3 session timeout and SecurityAccess lockout countdown never progressed. Added a dedicated 1ms tick task/thread to both. **Not** a reuse of FreeRTOS's `eds_freertos_start()` poll task — that's CAN/ISO-TP-specific and would call `can_transport_receive()`/`isotp_tick_1ms()` against a NULL transport this build has no context for.

## #191b — DoIP disconnect didn't reset UDS session/security state
`doip_server.c`'s `connection_closed` path only reset DoIP-layer `routing_active`/`tester_address` — a new connection inherited whatever session/security state the previous one left behind. **Same lesson as `[SEC-S3-RESET-01]`** (`core/uds_server.c`) recurring in a different code path. Added `uds_session_transition(..., UDS_SESSION_DEFAULT)` + `uds_security_reset(...)`, mirroring that fix's exact pairing — verified `uds_session_transition` to DEFAULT is unconditionally valid from any session, and that `service_0x10.c` only resets security on transition *to* DEFAULT (confirming an Extended-session reconnect wouldn't have self-healed this without the fix).

New regression test: `test_doip_disconnect_resets_security_and_session` — unlocks on connection 1, proves it with a write, reconnects without re-unlocking, confirms the same write now correctly fails NRC 0x33.

## #192 — DoIP Zephyr thread startup used a fixed 500ms delay
`K_THREAD_DEFINE(doip_thread, ..., delay_ms = 500)` assumed init always completes within 500ms. Replaced with a semaphore (`s_doip_ready_sem`) `zephyr_doip_platform_init()` gives once `s_uds_ctx` is set and platform ops are registered. FreeRTOS's analogous `vTaskDelay(500)` is justified differently (network bring-up, not this race — its task is created *after* `s_uds_ctx` is already set) — left alone, out of scope here.

## #193 — DoIP had no absolute frame-assembly deadline
Each `tcp_recv()` had its own 150ms-silence timeout, but a client sending 1 byte per window never tripped it. `doip_server.c` can't call an RTOS clock directly (platform interaction is ops-only), so added a read-*attempt* bound (`DOIP_MAX_FRAME_READ_ATTEMPTS`, 256, tuneable) instead of a true wall-clock deadline.

## Verification
`bash build_tests.sh` — 44 passed, 894 cases, 0 failed (`test_doip_server` 30/30). The new Python integration test targets a real compiled binary (Zephyr SDK + native_sim + `xaloqi-tester`), not available in this environment — logic verified by tracing the relevant reset conditions rather than a local run; CI's DoIP Integration job executes it for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)