### PR TITLE
Periodic frame requeue-on-busy + WriteDataByIdentifier unit test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,8 +272,8 @@ jobs:
         run: |
           result=$(bash build_tests.sh 2>&1 | tail -3)
           echo "$result"
-          echo "$result" | grep -q "44 passed, 0 failed" || \
-            (echo "ERROR: Expected '44 passed, 0 failed'" && exit 1)
+          echo "$result" | grep -q "45 passed, 0 failed" || \
+            (echo "ERROR: Expected '45 passed, 0 failed'" && exit 1)
 
       # [#119] Prose-side counterpart of the step above. The step above keeps
       # this workflow honest about the module count; nothing used to keep the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,48 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Periodic DID frame silently dropped when ISO-TP transmit is busy**
+  (#194; Tier-1 round-3 due diligence). `uds_periodic_pop_due()` cleared
+  a subscription's due flag before the caller attempted transmit — a
+  `BUSY` return from `isotp_transmit()` (e.g. mid multi-frame send) lost
+  that period with no re-queue, no error surfaced, and no signal to the
+  application. Added `uds_periodic_requeue_last()`: re-arms the
+  most-recently-popped subscription for the next tick. Updated all 9
+  example `main.c` drain loops that call `uds_periodic_pop_due()` to
+  check `isotp_transmit()`'s return and requeue + stop draining on
+  failure, instead of discarding it. 4 new unit tests
+  (`test_uds_periodic.c`, TC-PERIODIC-015..018), including a positive
+  control: `tc016` genuinely fails if `uds_periodic_requeue_last()`'s
+  core re-arm line is disabled, confirmed by temporarily disabling it
+  before restoring.
+
+- **NULL-pointer crash in `service_0x2E.c` if a DID has `DID_ACCESS_WRITE`
+  set but `write_cb == NULL`** (#202, found while implementing #195).
+  `s_did_safe_write()`'s 5-step ASIL-B chain invoked the write callback
+  unconditionally — every other DID-callback dispatch in this codebase
+  (`service_0x2F.c`'s `io_control_cb`, `uds_periodic_pop_due()`'s
+  `read_cb`) checks for NULL first; this one didn't. Unreachable from a
+  correctly code-generated product, but a real crash from a malformed or
+  hand-edited DID table. Fixed to mirror `service_0x2F.c`'s exact
+  precedent: `ERR_REQUEST_OUT_OF_RANGE` (NRC 0x31) instead of a
+  dereference.
+
+### Added
+
+- **`tests/unit_runnable/test_service_0x2E.c`** (#195; Tier-1 round-3 due
+  diligence). No dedicated C unit test existed for WriteDataByIdentifier
+  despite 0x22/0x23/0x27/0x28/0x2A/0x2F all having one — the primary
+  write path, and the one `ASIL_B_REQUIRE_WRITE_SECURITY` exists to
+  protect, had none. 14 test cases covering the full 5-step chain (NULL,
+  DID-not-found, wrong session, wrong security, wrong data length short
+  and long, NULL callback, callback failure, valid writes at both
+  security levels, a 1-byte boundary case, response format, and
+  sequential-write isolation). Writing it immediately found the
+  NULL-`write_cb` crash above — added to `build_tests.sh`'s `TESTS`
+  array and `tests/CMakeLists.txt`.
+
+### Fixed
+
 - **Security NVM persistence never wired into any generated product**
   (#190; Tier-1 round-3 due diligence). `core/uds_security_nvm.c`
   implements the failed-attempt-counter/lockout persistence

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Bug reports, documentation improvements, and issue comments never require a CLA.
 - Changes that remove or weaken any step of the 5-step ASIL-B safety wrapper chain
 - Dynamic memory allocation (`malloc`, `free`) anywhere in the stack
 - Recursion in any safety-critical module
-- Changes that break the `native_sim` CI build or cause any unit test to fail (currently 44 — see build_tests.sh, which enforces its own count via an anti-drift check)
+- Changes that break the `native_sim` CI build or cause any unit test to fail (currently 45 — see build_tests.sh, which enforces its own count via an anti-drift check)
 - Hand-written changes to files under `generated/` — these are codegen output;
   fix the template in `tools/templates/` instead
 - External runtime dependencies not already present in the stack
@@ -126,7 +126,7 @@ python3 tools/codegen.py \
   --out generated/ \
   --safety-wrappers --asil-level B --test-gen
 
-# All unit tests must pass (currently 44)
+# All unit tests must pass (currently 45)
 bash build_tests.sh
 
 # All 68 harness tests must pass

--- a/build_tests.sh
+++ b/build_tests.sh
@@ -340,6 +340,7 @@ TESTS=(
     test_service_0x22
     test_service_0x27
     test_service_0x28
+    test_service_0x2E
     test_uds_periodic
     test_service_0x2A
     test_service_0x2F

--- a/core/uds_periodic.c
+++ b/core/uds_periodic.c
@@ -48,6 +48,13 @@ typedef struct {
 static uds_periodic_sub_t s_subs[UDS_PERIODIC_MAX_SUBSCRIPTIONS];
 static uint8_t            s_count;
 
+/* [EDS#194] periodic_id of the subscription most recently returned by
+ * uds_periodic_pop_due(), or 0 if none is currently outstanding (never
+ * popped yet, or already consumed by a prior uds_periodic_requeue_last()
+ * call). Single-slot by design: uds_periodic_pop_due() returns at most
+ * one frame per call, so there is never more than one "in flight". */
+static uint8_t s_last_popped_id;
+
 /* --------------------------------------------------------------------------
  * Internal helpers
  * -------------------------------------------------------------------------- */
@@ -231,8 +238,35 @@ uds_status_t uds_periodic_pop_due(uds_msg_buf_t *out_frame)
 
         out_frame->length = (uint16_t)2U + out_len;
 
+        /* [EDS#194] Record what was just popped so a failed transmit can
+         * ask for it back via uds_periodic_requeue_last(). */
+        s_last_popped_id = s_subs[i].periodic_id;
+
         return UDS_STATUS_OK;
     }
 
     return UDS_STATUS_ERR_NOT_FOUND;
+}
+
+uds_status_t uds_periodic_requeue_last(void)
+{
+    uds_periodic_sub_t *slot;
+    uint8_t              id;
+
+    id = s_last_popped_id;
+    s_last_popped_id = (uint8_t)0U;  /* consumed — one requeue per pop */
+
+    if (id == (uint8_t)0U) {
+        return UDS_STATUS_ERR_NOT_FOUND;
+    }
+
+    slot = s_find_slot(id);
+    if (slot == NULL) {
+        /* Subscription was cancelled between the pop and this call —
+         * nothing to re-arm, not an error the caller needs to react to. */
+        return UDS_STATUS_ERR_NOT_FOUND;
+    }
+
+    slot->due = true;
+    return UDS_STATUS_OK;
 }

--- a/core/uds_periodic.h
+++ b/core/uds_periodic.h
@@ -156,6 +156,25 @@ uds_status_t uds_periodic_tick_1ms(void);
  */
 uds_status_t uds_periodic_pop_due(uds_msg_buf_t *out_frame);
 
+/**
+ * @brief [EDS#194] Re-queue the subscription most recently popped by
+ *        uds_periodic_pop_due() for the next tick.
+ *
+ * Call this when a transmit of the frame uds_periodic_pop_due() just
+ * returned fails (e.g. isotp_transmit() returns BUSY mid multi-frame
+ * send) — without it, that period is silently lost rather than retried,
+ * since uds_periodic_pop_due() already cleared the due flag before
+ * returning. Consumes the "last popped" record: calling this twice in a
+ * row without an intervening successful pop is a no-op the second time
+ * (ERR_NOT_FOUND) — there is only ever one frame to re-queue.
+ *
+ * @return UDS_STATUS_OK if the subscription was found and re-armed.
+ * @return UDS_STATUS_ERR_NOT_FOUND if there is nothing to re-queue (no
+ *         prior pop, already consumed, or the subscription was cancelled
+ *         between the pop and this call).
+ */
+uds_status_t uds_periodic_requeue_last(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/uds_services/service_0x2E.c
+++ b/core/uds_services/service_0x2E.c
@@ -127,7 +127,21 @@ static uds_status_t s_did_safe_write(
     /* Step 4: Validate write data length == DID data_length (REQ-SAFE-006). */
     UDS_SAFETY_RETURN_IF_ERR(uds_safety_check_write_data_length(entry, len));
 
-    /* Step 5: Invoke the DID write callback. */
+    /* Step 5: Invoke the DID write callback.
+     *
+     * [EDS#195] A DID with DID_ACCESS_WRITE set but write_cb == NULL
+     * (a codegen/configuration defect — real generated products always
+     * pair the two) previously reached this call unguarded, dereferencing
+     * a NULL function pointer. Every other DID-callback dispatch in this
+     * codebase (service_0x2F.c's io_control_cb, uds_periodic_pop_due()'s
+     * read_cb) checks for NULL before calling; this one didn't. Found by
+     * a new unit test (tc008_write_cb_null) written for this same issue.
+     * Mirrors service_0x2F.c's exact precedent: DID found but its
+     * required callback is NULL → ERR_REQUEST_OUT_OF_RANGE (NRC 0x31). */
+    if (entry->write_cb == NULL) {
+        return UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE;
+    }
+
     return entry->write_cb(buf, len);
 }
 

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -67,7 +67,7 @@ EDS/
 │   └── vscode-extension/   # VS Code extension (YAML validation, hover docs, Run Codegen)
 ├── gui/                    # React/TypeScript live dashboard + WebSocket ECU bridge
 ├── tests/
-│   ├── unit_runnable/      # 44 Unity C unit test modules
+│   ├── unit_runnable/      # 45 Unity C unit test modules
 │   ├── mocks/              # Test doubles shared by the unit modules
 │   ├── runner/             # ZTEST shim + test runner
 │   └── test_*.py           # Python DoIP-integration and license tests
@@ -646,7 +646,7 @@ cmake -B build_freertos \
 ninja -C build_freertos
 
 # ── Unit Tests ────────────────────────────────────────────────────────────────
-bash build_tests.sh                  # 44 Unity modules
+bash build_tests.sh                  # 45 Unity modules
 
 # ── Harness Tests ─────────────────────────────────────────────────────────────
 bash build_harness.sh                # 68 harness tests

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -218,14 +218,14 @@ embedded-diagnostics-suite/
 │   └── ...                     # + 8 more (DoIP, FreeRTOS, SafeBoot, sensor, robot variants)
 │
 ├── tests/
-│   ├── unit_runnable/          # Canonical Unity unit tests (44 modules)
+│   ├── unit_runnable/          # Canonical Unity unit tests (45 modules)
 │   ├── runner/                 # Shared Unity test-main scaffolding — build_tests.sh
 │   │                           # and tests/CMakeLists.txt each link one module's
 │   │                           # object against libeds_testable.a (built once) + this
 │   ├── mocks/                  # Zephyr port mock + NVM mock for host builds
 │   └── CMakeLists.txt          # CTest path — mirrors build_tests.sh's source list
 │
-├── build_tests.sh              # Runs all 44 unit test modules (repo root, not scripts/)
+├── build_tests.sh              # Runs all 45 unit test modules (repo root, not scripts/)
 ├── build_harness.sh            # Runs all 68 harness tests (repo root, not scripts/;
 │                                # Professional tier — harness/ sources are gitignored)
 └── run_python_tests.sh         # Canonical entrypoint for the whole Python suite —

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -6,7 +6,7 @@
 - Zephyr workspace with EDS checked out
 - A minimal ECU firmware built and running in the simulator
 - UDS service 0x22 (ReadDataByIdentifier) responding to requests
-- All 44 unit tests passing
+- All 45 unit tests passing
 
 **No prior Zephyr knowledge assumed.**
 
@@ -528,7 +528,7 @@ Run the integration tests in a second terminal to send traffic while it's runnin
 | `west build -b nucleo_h743zi2 examples/basic_ecu` | Cross-compile for STM32 Nucleo-H743ZI2 |
 | `west build -b mr_canhubk3 examples/basic_ecu -- -DEXTRA_CONF_FILE=boards/mr_canhubk3/mr_canhubk3.conf -DDTC_OVERLAY_FILE=boards/mr_canhubk3/mr_canhubk3.overlay` | Cross-compile for NXP MR-CANHUBK3 (S32K344) |
 | `west flash` | Flash to connected hardware |
-| `bash build_tests.sh` | Run 44 unit tests |
+| `bash build_tests.sh` | Run 45 unit tests |
 | `bash run_python_tests.sh` | Run the whole Python suite (repo `tests/` + every example, each correctly scoped) |
 | `cd gui && npm ci && npm start` | Start GUI configurator |
 | `python3 tools/testgen.py --config CONFIG --out OUT` | Generate pytest test suite |

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -1,7 +1,7 @@
 # Testing Strategy — Xaloqi EDS
 
 **Version:** v1.13.1  
-**Status:** 44/44 unit test modules passing. 68/68 harness tests passing. 21/21 CI jobs green. FreeRTOS, SafeBoot (Zephyr + FreeRTOS), DoIP, and sensor examples all covered.
+**Status:** 45/45 unit test modules passing. 68/68 harness tests passing. 21/21 CI jobs green. FreeRTOS, SafeBoot (Zephyr + FreeRTOS), DoIP, and sensor examples all covered.
 
 ---
 
@@ -130,7 +130,7 @@ bash build_tests.sh
 # Expected: 44 passed, 0 failed
 ```
 
-### Coverage — 44 unit test modules
+### Coverage — 45 unit test modules
 
 **UDS Core (4 modules)**
 
@@ -449,7 +449,7 @@ All test layers run automatically in GitHub Actions on every push and pull reque
 ```
 push / PR
    │
-   ├── unit-tests          44 Unity modules via build_tests.sh
+   ├── unit-tests          45 Unity modules via build_tests.sh
    │                       + ASIL-B assertion checks (self-test, key gate, write security)
    │
    ├── cmake-ctest-build   The same modules via cmake -S tests + ctest
@@ -495,7 +495,7 @@ drifted twice (#91, #119) — this line claimed 8.
 
 Added in v1.3.0. Builds `examples/basic_ecu_freertos` with `-DEDS_PLATFORM=freertos`
 targeting QEMU ARM Cortex-M4. Downloads FreeRTOS-Kernel from GitHub, runs codegen,
-builds the ELF, and verifies it exists. The same 44 unit tests run against the FreeRTOS
+builds the ELF, and verifies it exists. The same 45 unit tests run against the FreeRTOS
 platform HAL (they mock the platform layer and are platform-independent).
 
 ### SafeBoot CI job (within `unit-tests`)

--- a/examples/ardep_ecu/src/main.c
+++ b/examples/ardep_ecu/src/main.c
@@ -766,8 +766,16 @@ static void diag_task_entry(void *p1, void *p2, void *p3)
         {
             static uds_msg_buf_t s_periodic_frame;
             while (uds_periodic_pop_due(&s_periodic_frame) == UDS_STATUS_OK) {
-                (void)isotp_transmit(tp, s_periodic_frame.data,
-                                     (uint32_t)s_periodic_frame.length);
+                /* [EDS#194] Re-queue on ISO-TP busy instead of silently dropping
+                 * this period -- isotp_transmit() can legitimately return BUSY
+                 * mid multi-frame send; retry on the next 1ms tick rather than
+                 * losing the period, and stop draining this tick (the same busy
+                 * channel would just fail the next pop too). */
+                if (isotp_transmit(tp, s_periodic_frame.data,
+                                   (uint32_t)s_periodic_frame.length) != UDS_STATUS_OK) {
+                    (void)uds_periodic_requeue_last();
+                    break;
+                }
             }
         }
 

--- a/examples/basic_ecu/src/main.c
+++ b/examples/basic_ecu/src/main.c
@@ -206,8 +206,16 @@ static void diag_task_entry(void *p1, void *p2, void *p3)
         {
             static uds_msg_buf_t s_periodic_frame;
             while (uds_periodic_pop_due(&s_periodic_frame) == UDS_STATUS_OK) {
-                (void)isotp_transmit(tp, s_periodic_frame.data,
-                                     (uint32_t)s_periodic_frame.length);
+                /* [EDS#194] Re-queue on ISO-TP busy instead of silently dropping
+                 * this period -- isotp_transmit() can legitimately return BUSY
+                 * mid multi-frame send; retry on the next 1ms tick rather than
+                 * losing the period, and stop draining this tick (the same busy
+                 * channel would just fail the next pop too). */
+                if (isotp_transmit(tp, s_periodic_frame.data,
+                                   (uint32_t)s_periodic_frame.length) != UDS_STATUS_OK) {
+                    (void)uds_periodic_requeue_last();
+                    break;
+                }
             }
         }
 

--- a/examples/bms_ecu/src/main.c
+++ b/examples/bms_ecu/src/main.c
@@ -964,8 +964,16 @@ static void diag_task_entry(void *p1, void *p2, void *p3)
         {
             static uds_msg_buf_t s_periodic_frame;
             while (uds_periodic_pop_due(&s_periodic_frame) == UDS_STATUS_OK) {
-                (void)isotp_transmit(tp, s_periodic_frame.data,
-                                     (uint32_t)s_periodic_frame.length);
+                /* [EDS#194] Re-queue on ISO-TP busy instead of silently dropping
+                 * this period -- isotp_transmit() can legitimately return BUSY
+                 * mid multi-frame send; retry on the next 1ms tick rather than
+                 * losing the period, and stop draining this tick (the same busy
+                 * channel would just fail the next pop too). */
+                if (isotp_transmit(tp, s_periodic_frame.data,
+                                   (uint32_t)s_periodic_frame.length) != UDS_STATUS_OK) {
+                    (void)uds_periodic_requeue_last();
+                    break;
+                }
             }
         }
 

--- a/examples/motor_controller_ecu/src/main.c
+++ b/examples/motor_controller_ecu/src/main.c
@@ -796,8 +796,16 @@ static void diag_task_fn(void *p1, void *p2, void *p3)
             isotp_ctx_t *mc_tp = uds_generated_get_isotp();
             if (mc_tp != NULL) {
                 while (uds_periodic_pop_due(&s_periodic_frame) == UDS_STATUS_OK) {
-                    (void)isotp_transmit(mc_tp, s_periodic_frame.data,
-                                        (uint32_t)s_periodic_frame.length);
+                    /* [EDS#194] Re-queue on ISO-TP busy instead of silently dropping
+                     * this period -- isotp_transmit() can legitimately return BUSY
+                     * mid multi-frame send; retry on the next 1ms tick rather than
+                     * losing the period, and stop draining this tick (the same busy
+                     * channel would just fail the next pop too). */
+                    if (isotp_transmit(mc_tp, s_periodic_frame.data,
+                                       (uint32_t)s_periodic_frame.length) != UDS_STATUS_OK) {
+                        (void)uds_periodic_requeue_last();
+                        break;
+                    }
                 }
             }
         }

--- a/examples/robot_joint_controller_ecu/src/main.c
+++ b/examples/robot_joint_controller_ecu/src/main.c
@@ -231,8 +231,16 @@ static void diag_task_entry(void *p1, void *p2, void *p3)
         {
             static uds_msg_buf_t s_periodic_frame;
             while (uds_periodic_pop_due(&s_periodic_frame) == UDS_STATUS_OK) {
-                (void)isotp_transmit(tp, s_periodic_frame.data,
-                                     (uint32_t)s_periodic_frame.length);
+                /* [EDS#194] Re-queue on ISO-TP busy instead of silently dropping
+                 * this period -- isotp_transmit() can legitimately return BUSY
+                 * mid multi-frame send; retry on the next 1ms tick rather than
+                 * losing the period, and stop draining this tick (the same busy
+                 * channel would just fail the next pop too). */
+                if (isotp_transmit(tp, s_periodic_frame.data,
+                                   (uint32_t)s_periodic_frame.length) != UDS_STATUS_OK) {
+                    (void)uds_periodic_requeue_last();
+                    break;
+                }
             }
         }
 

--- a/examples/safeboot_ecu/src/main.c
+++ b/examples/safeboot_ecu/src/main.c
@@ -452,8 +452,16 @@ static void diag_task_entry(void *p1, void *p2, void *p3)
         {
             static uds_msg_buf_t s_periodic_frame;
             while (uds_periodic_pop_due(&s_periodic_frame) == UDS_STATUS_OK) {
-                (void)isotp_transmit(tp, s_periodic_frame.data,
-                                     (uint32_t)s_periodic_frame.length);
+                /* [EDS#194] Re-queue on ISO-TP busy instead of silently dropping
+                 * this period -- isotp_transmit() can legitimately return BUSY
+                 * mid multi-frame send; retry on the next 1ms tick rather than
+                 * losing the period, and stop draining this tick (the same busy
+                 * channel would just fail the next pop too). */
+                if (isotp_transmit(tp, s_periodic_frame.data,
+                                   (uint32_t)s_periodic_frame.length) != UDS_STATUS_OK) {
+                    (void)uds_periodic_requeue_last();
+                    break;
+                }
             }
         }
 

--- a/examples/safeboot_freertos_ecu/src/main.c
+++ b/examples/safeboot_freertos_ecu/src/main.c
@@ -197,8 +197,16 @@ static void uds_poll_task(void *arg)
         {
             static uds_msg_buf_t s_periodic_frame;
             while (uds_periodic_pop_due(&s_periodic_frame) == UDS_STATUS_OK) {
-                (void)isotp_transmit(tp, s_periodic_frame.data,
-                                     (uint32_t)s_periodic_frame.length);
+                /* [EDS#194] Re-queue on ISO-TP busy instead of silently dropping
+                 * this period -- isotp_transmit() can legitimately return BUSY
+                 * mid multi-frame send; retry on the next 1ms tick rather than
+                 * losing the period, and stop draining this tick (the same busy
+                 * channel would just fail the next pop too). */
+                if (isotp_transmit(tp, s_periodic_frame.data,
+                                   (uint32_t)s_periodic_frame.length) != UDS_STATUS_OK) {
+                    (void)uds_periodic_requeue_last();
+                    break;
+                }
             }
         }
     }

--- a/examples/sensor_ecu/src/main.c
+++ b/examples/sensor_ecu/src/main.c
@@ -240,8 +240,16 @@ static void diag_task_entry(void *p1, void *p2, void *p3)
         {
             static uds_msg_buf_t s_periodic_frame;
             while (uds_periodic_pop_due(&s_periodic_frame) == UDS_STATUS_OK) {
-                (void)isotp_transmit(tp, s_periodic_frame.data,
-                                     (uint32_t)s_periodic_frame.length);
+                /* [EDS#194] Re-queue on ISO-TP busy instead of silently dropping
+                 * this period -- isotp_transmit() can legitimately return BUSY
+                 * mid multi-frame send; retry on the next 1ms tick rather than
+                 * losing the period, and stop draining this tick (the same busy
+                 * channel would just fail the next pop too). */
+                if (isotp_transmit(tp, s_periodic_frame.data,
+                                   (uint32_t)s_periodic_frame.length) != UDS_STATUS_OK) {
+                    (void)uds_periodic_requeue_last();
+                    break;
+                }
             }
         }
 

--- a/examples/sensor_ecu_freertos/src/main.c
+++ b/examples/sensor_ecu_freertos/src/main.c
@@ -169,8 +169,16 @@ static void uds_poll_task(void *arg)
         {
             static uds_msg_buf_t s_periodic_frame;
             while (uds_periodic_pop_due(&s_periodic_frame) == UDS_STATUS_OK) {
-                (void)isotp_transmit(tp, s_periodic_frame.data,
-                                     (uint32_t)s_periodic_frame.length);
+                /* [EDS#194] Re-queue on ISO-TP busy instead of silently dropping
+                 * this period -- isotp_transmit() can legitimately return BUSY
+                 * mid multi-frame send; retry on the next 1ms tick rather than
+                 * losing the period, and stop draining this tick (the same busy
+                 * channel would just fail the next pop too). */
+                if (isotp_transmit(tp, s_periodic_frame.data,
+                                   (uint32_t)s_periodic_frame.length) != UDS_STATUS_OK) {
+                    (void)uds_periodic_requeue_last();
+                    break;
+                }
             }
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -511,6 +511,11 @@ add_diag_test(test_service_0x28
         "${TEST_UNIT_DIR}/test_service_0x28.c"
 )
 
+add_diag_test(test_service_0x2E
+    SOURCES
+        "${TEST_UNIT_DIR}/test_service_0x2E.c"
+)
+
 add_diag_test(test_uds_periodic
     SOURCES
         "${TEST_UNIT_DIR}/test_uds_periodic.c"

--- a/tests/unit_runnable/test_service_0x2E.c
+++ b/tests/unit_runnable/test_service_0x2E.c
@@ -1,0 +1,573 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2026 Xaloqi
+/*
+ * =============================================================================
+ * FILE: tests/unit_runnable/test_service_0x2E.c
+ *
+ * MODULE UNDER TEST: core/uds_services/service_0x2E.c
+ *                    SID 0x2E — WriteDataByIdentifier
+ *
+ * PURPOSE:
+ *   Verify all branches of the 0x2E handler: request-length validation,
+ *   the 5-step ASIL-B write chain (NULL/DID/session/security/data-length),
+ *   write-callback invocation and failure propagation, and positive-
+ *   response encoding.
+ *
+ *   [EDS#195] Every other DID-access service (0x22, 0x23, 0x27, 0x28,
+ *   0x2A, 0x2F) has a dedicated C unit test — 0x2E did not, despite
+ *   being the primary write path and the one ASIL_B_REQUIRE_WRITE_SECURITY
+ *   exists to protect. This file closes that gap.
+ *
+ * TEST CASES:
+ *   TC-0x2E-001  NULL ctx                                → ERR_NULL_PTR
+ *   TC-0x2E-002  Request < 4 bytes (no data byte)         → ERR_INVALID_PARAM (NRC 0x13)
+ *   TC-0x2E-003  DID not registered                       → ERR_DID_NOT_FOUND (NRC 0x31)
+ *   TC-0x2E-004  Wrong session (DEFAULT, DID needs EXTENDED) → ERR_SESSION_INVALID (NRC 0x22)
+ *   TC-0x2E-005  Wrong security (locked, DID needs level 1) → ERR_SEC_NOT_UNLOCKED (NRC 0x33)
+ *   TC-0x2E-006  Wrong data length (short)                → ERR_INVALID_PARAM (NRC 0x13)
+ *   TC-0x2E-007  Wrong data length (long)                 → ERR_INVALID_PARAM (NRC 0x13)
+ *   TC-0x2E-008  write_cb == NULL                          → propagates write_cb's absence safely
+ *   TC-0x2E-009  write_cb returns ERR_CONDITIONS_NOT_MET   → propagates (→ NRC 0x22)
+ *   TC-0x2E-010  Valid write (level 0, no security needed) → OK, callback invoked with exact bytes
+ *   TC-0x2E-011  Valid write (level 1, security unlocked)  → OK
+ *   TC-0x2E-012  Boundary: 1-byte data_length write        → OK
+ *   TC-0x2E-013  Response format: [0x6E, DID_hi, DID_lo], length == 3
+ *   TC-0x2E-014  Two DIDs in sequence don't cross-contaminate write_cb args
+ *
+ * FRAMEWORK: Zephyr Ztest (host shim in tests/runner/ztest_shim.h)
+ * =============================================================================
+ */
+
+#include <zephyr/ztest.h>
+#include <string.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#include "services.h"
+#include "uds_server.h"
+#include "uds_session.h"
+#include "uds_security.h"
+#include "did_database.h"
+#include "did_handlers.h"
+#include "uds_types.h"
+
+/* =========================================================================
+ * Test DIDs
+ *
+ * DID 0xA010: writable, level 0 (no security needed), data_length = 2.
+ * DID 0xA011: writable, EXTENDED session + security level 1 required,
+ *             data_length = 2.
+ * DID 0xA012: writable, level 0, data_length = 1 (boundary case).
+ * DID 0xA013: DID_ACCESS_WRITE set but write_cb == NULL.
+ * ========================================================================= */
+
+#define TEST_DID_OPEN     (0xA010U)  /**< No security required. */
+#define TEST_DID_GATED    (0xA011U)  /**< EXTENDED + level 1 required. */
+#define TEST_DID_ONEBYTE  (0xA012U)  /**< data_length == 1 (boundary). */
+#define TEST_DID_NO_CB    (0xA013U)  /**< write_cb == NULL. */
+#define TEST_DATA_LEN     (2U)
+
+/* =========================================================================
+ * Mock write callback — records the last call's arguments
+ * ========================================================================= */
+
+static uint8_t  s_last_write_data[DID_MAX_DATA_LEN];
+static uint16_t s_last_write_len;
+static uint16_t s_write_call_count;
+static uds_status_t s_mock_write_return;
+
+static uds_status_t mock_write_cb(const uint8_t *buf, uint16_t len)
+{
+    uint16_t i;
+
+    s_write_call_count++;
+    s_last_write_len = len;
+    for (i = (uint16_t)0U; i < len && i < (uint16_t)DID_MAX_DATA_LEN; i++) {
+        s_last_write_data[i] = buf[i];
+    }
+    return s_mock_write_return;
+}
+
+/* =========================================================================
+ * Stub read callback (required by did_entry_t; write-only DIDs still need
+ * a non-NULL read_cb to be found by uds_safety_find_did() in some paths)
+ * ========================================================================= */
+
+static uds_status_t stub_read_cb(uint8_t *buf, uint16_t buf_len, uint16_t *out_len)
+{
+    (void)buf; (void)buf_len;
+    *out_len = (uint16_t)0U;
+    return UDS_STATUS_OK;
+}
+
+/* =========================================================================
+ * Stubs for security seed/key (required by uds_security_init)
+ * ========================================================================= */
+
+static uds_status_t t_seed(uint8_t l, uint8_t *b, uint8_t n, uint8_t *o)
+{
+    (void)l;
+    for (uint8_t i = 0U; i < n && i < 4U; i++) { b[i] = (uint8_t)(0x10U + i); }
+    *o = (n < 4U) ? n : 4U;
+    return UDS_STATUS_OK;
+}
+
+static bool t_key(uint8_t l, const uint8_t *s, uint8_t sl,
+                  const uint8_t *k, uint8_t kl)
+{
+    (void)l;
+    if (sl != kl) { return false; }
+    for (uint8_t i = 0U; i < sl; i++) {
+        if (k[i] != (uint8_t)(s[i] ^ (uint8_t)0xAAU)) { return false; }
+    }
+    return true;
+}
+
+/* =========================================================================
+ * Context setup
+ * ========================================================================= */
+
+static uds_session_ctx_t  g_sess;
+static uds_security_ctx_t g_sec;
+static uds_server_ctx_t   g_srv;
+static bool               g_stack_ready = false;
+
+static void register_test_dids(void)
+{
+    did_entry_t entry;
+
+    /* DID 0xA010: writable, no security. */
+    memset(&entry, 0, sizeof(entry));
+    entry.did_id             = TEST_DID_OPEN;
+    entry.access_flags       = (uint8_t)(DID_ACCESS_READ | DID_ACCESS_WRITE);
+    entry.min_session        = (uint8_t)UDS_SESSION_DEFAULT;
+    entry.read_access_level  = (uint8_t)0U;
+    entry.write_access_level = (uint8_t)0U;
+    entry.data_length        = (uint16_t)TEST_DATA_LEN;
+    entry.read_cb            = stub_read_cb;
+    entry.write_cb           = mock_write_cb;
+    entry.description        = "Test open-write DID";
+    (void)did_database_register(&entry);
+
+    /* DID 0xA011: writable, EXTENDED session + security level 1. */
+    memset(&entry, 0, sizeof(entry));
+    entry.did_id             = TEST_DID_GATED;
+    entry.access_flags       = (uint8_t)(DID_ACCESS_READ | DID_ACCESS_WRITE);
+    entry.min_session        = (uint8_t)UDS_SESSION_EXTENDED;
+    entry.read_access_level  = (uint8_t)0U;
+    entry.write_access_level = (uint8_t)1U;
+    entry.data_length        = (uint16_t)TEST_DATA_LEN;
+    entry.read_cb            = stub_read_cb;
+    entry.write_cb           = mock_write_cb;
+    entry.description        = "Test gated-write DID";
+    (void)did_database_register(&entry);
+
+    /* DID 0xA012: writable, no security, data_length == 1 (boundary). */
+    memset(&entry, 0, sizeof(entry));
+    entry.did_id             = TEST_DID_ONEBYTE;
+    entry.access_flags       = (uint8_t)(DID_ACCESS_READ | DID_ACCESS_WRITE);
+    entry.min_session        = (uint8_t)UDS_SESSION_DEFAULT;
+    entry.read_access_level  = (uint8_t)0U;
+    entry.write_access_level = (uint8_t)0U;
+    entry.data_length        = (uint16_t)1U;
+    entry.read_cb            = stub_read_cb;
+    entry.write_cb           = mock_write_cb;
+    entry.description        = "Test 1-byte DID";
+    (void)did_database_register(&entry);
+
+    /* DID 0xA013: write flag set but write_cb == NULL. */
+    memset(&entry, 0, sizeof(entry));
+    entry.did_id             = TEST_DID_NO_CB;
+    entry.access_flags       = (uint8_t)DID_ACCESS_WRITE;
+    entry.min_session        = (uint8_t)UDS_SESSION_DEFAULT;
+    entry.read_access_level  = (uint8_t)0U;
+    entry.write_access_level = (uint8_t)0U;
+    entry.data_length        = (uint16_t)TEST_DATA_LEN;
+    entry.read_cb            = NULL;
+    entry.write_cb           = NULL;
+    entry.description        = "Test no-write-cb DID";
+    (void)did_database_register(&entry);
+}
+
+static void setup(void)
+{
+    if (!g_stack_ready) {
+        memset(&g_sess, 0, sizeof(g_sess));
+        memset(&g_sec,  0, sizeof(g_sec));
+        memset(&g_srv,  0, sizeof(g_srv));
+
+        uds_session_init(&g_sess, 5000U);
+
+        static const uds_security_cfg_t sc = {
+            .max_attempts     = 3U,
+            .lockout_ms       = 100U,
+            .key_validate_cb  = t_key,
+            .seed_generate_cb = t_seed,
+        };
+        uds_security_init(&g_sec, &sc);
+
+        (void)did_database_init();
+        (void)did_handlers_register_all();
+        register_test_dids();
+
+        static const uds_server_cfg_t svc = {
+            .p2_server_max_ms      = 25U,
+            .p2_star_server_max_ms = 5000U,
+            .session_ctx           = &g_sess,
+            .security_ctx          = &g_sec,
+            .service_table         = g_uds_service_table,
+            .service_table_count   = (uint8_t)UDS_SERVICE_TABLE_COUNT,
+        };
+        uds_server_init(&g_srv, &svc);
+        g_stack_ready = true;
+    }
+
+    /* Reset session/security and clear mock state before each test. */
+    uds_session_transition(&g_sess, UDS_SESSION_DEFAULT);
+    g_sec.active_level     = (uint8_t)0U;
+    s_write_call_count     = (uint16_t)0U;
+    s_last_write_len       = (uint16_t)0U;
+    s_mock_write_return    = UDS_STATUS_OK;
+    memset(s_last_write_data, 0, sizeof(s_last_write_data));
+}
+
+/** Build a 0x2E request: [0x2E, DID_hi, DID_lo, data...]. */
+static uds_msg_buf_t make_req(uint16_t did, const uint8_t *data, uint16_t data_len)
+{
+    uds_msg_buf_t r;
+    uint16_t      i;
+
+    memset(&r, 0, sizeof(r));
+    r.data[0] = (uint8_t)UDS_SID_WRITE_DATA_BY_ID;
+    r.data[1] = (uint8_t)((did >> 8U) & (uint8_t)0xFFU);
+    r.data[2] = (uint8_t)(did & (uint8_t)0xFFU);
+    for (i = (uint16_t)0U; i < data_len; i++) {
+        r.data[3U + i] = data[i];
+    }
+    r.length = (uint16_t)3U + data_len;
+    return r;
+}
+
+/* =========================================================================
+ * Test suite
+ * ========================================================================= */
+
+ZTEST_SUITE(test_service_0x2E, NULL, NULL, NULL, NULL, NULL);
+
+/* ---------------------------------------------------------------------- */
+
+/**
+ * TC-0x2E-001: NULL ctx → ERR_NULL_PTR.
+ */
+ZTEST(test_service_0x2E, tc001_null_ctx)
+{
+    setup();
+    uint8_t       data[TEST_DATA_LEN] = { 0x11U, 0x22U };
+    uds_msg_buf_t req  = make_req(TEST_DID_OPEN, data, (uint16_t)TEST_DATA_LEN);
+    uds_msg_buf_t resp = {0};
+
+    uds_status_t rc = uds_service_0x2E_handler(NULL, &req, &resp);
+
+    zassert_equal(rc, UDS_STATUS_ERR_NULL_PTR, "NULL ctx must return ERR_NULL_PTR");
+}
+
+/**
+ * TC-0x2E-002: Request < 4 bytes (SID+DID only, no data byte) → NRC 0x13.
+ */
+ZTEST(test_service_0x2E, tc002_request_too_short)
+{
+    setup();
+    uds_msg_buf_t req = make_req(TEST_DID_OPEN, NULL, (uint16_t)0U);
+    uds_msg_buf_t resp = {0};
+
+    uds_status_t rc = uds_service_0x2E_handler(&g_srv, &req, &resp);
+
+    zassert_equal(rc, UDS_STATUS_ERR_INVALID_PARAM,
+                  "request with no data byte must return ERR_INVALID_PARAM (NRC 0x13)");
+    zassert_equal(s_write_call_count, (uint16_t)0U,
+                  "write_cb must not be invoked when length validation fails");
+}
+
+/**
+ * TC-0x2E-003: DID not registered → ERR_DID_NOT_FOUND (NRC 0x31).
+ */
+ZTEST(test_service_0x2E, tc003_did_not_found)
+{
+    setup();
+    uint8_t       data[TEST_DATA_LEN] = { 0x11U, 0x22U };
+    uds_msg_buf_t req  = make_req((uint16_t)0xFFFFU, data, (uint16_t)TEST_DATA_LEN);
+    uds_msg_buf_t resp = {0};
+
+    uds_status_t rc = uds_service_0x2E_handler(&g_srv, &req, &resp);
+
+    zassert_equal(rc, UDS_STATUS_ERR_DID_NOT_FOUND,
+                  "unregistered DID must return ERR_DID_NOT_FOUND (NRC 0x31)");
+}
+
+/**
+ * TC-0x2E-004: Wrong session — DID needs EXTENDED, session is DEFAULT
+ *              → ERR_SESSION_INVALID (NRC 0x22).
+ */
+ZTEST(test_service_0x2E, tc004_wrong_session)
+{
+    setup();
+    uint8_t       data[TEST_DATA_LEN] = { 0x11U, 0x22U };
+    uds_msg_buf_t req  = make_req(TEST_DID_GATED, data, (uint16_t)TEST_DATA_LEN);
+    uds_msg_buf_t resp = {0};
+
+    /* session stays DEFAULT (setup() default); TEST_DID_GATED needs EXTENDED */
+    uds_status_t rc = uds_service_0x2E_handler(&g_srv, &req, &resp);
+
+    zassert_equal(rc, UDS_STATUS_ERR_SESSION_INVALID,
+                  "wrong session must return ERR_SESSION_INVALID (NRC 0x22)");
+    zassert_equal(s_write_call_count, (uint16_t)0U,
+                  "write_cb must not be invoked when session check fails");
+}
+
+/**
+ * TC-0x2E-005: Wrong security — DID needs level 1, security is locked
+ *              → ERR_SEC_NOT_UNLOCKED (NRC 0x33).
+ */
+ZTEST(test_service_0x2E, tc005_wrong_security)
+{
+    setup();
+    uds_session_transition(&g_sess, UDS_SESSION_EXTENDED);
+    /* g_sec.active_level stays 0 (locked) — TEST_DID_GATED needs level 1 */
+
+    uint8_t       data[TEST_DATA_LEN] = { 0x11U, 0x22U };
+    uds_msg_buf_t req  = make_req(TEST_DID_GATED, data, (uint16_t)TEST_DATA_LEN);
+    uds_msg_buf_t resp = {0};
+
+    uds_status_t rc = uds_service_0x2E_handler(&g_srv, &req, &resp);
+
+    zassert_equal(rc, UDS_STATUS_ERR_SEC_NOT_UNLOCKED,
+                  "locked security must return ERR_SEC_NOT_UNLOCKED (NRC 0x33)");
+    zassert_equal(s_write_call_count, (uint16_t)0U,
+                  "write_cb must not be invoked when security check fails");
+}
+
+/**
+ * TC-0x2E-006: Wrong data length (short: 1 byte for a 2-byte DID)
+ *              → ERR_INVALID_PARAM (NRC 0x13).
+ */
+ZTEST(test_service_0x2E, tc006_data_length_short)
+{
+    setup();
+    uint8_t       data[1] = { 0x11U };
+    uds_msg_buf_t req  = make_req(TEST_DID_OPEN, data, (uint16_t)1U);
+    uds_msg_buf_t resp = {0};
+
+    uds_status_t rc = uds_service_0x2E_handler(&g_srv, &req, &resp);
+
+    zassert_equal(rc, UDS_STATUS_ERR_INVALID_PARAM,
+                  "short data record must return ERR_INVALID_PARAM (NRC 0x13)");
+    zassert_equal(s_write_call_count, (uint16_t)0U,
+                  "write_cb must not be invoked when data-length check fails");
+}
+
+/**
+ * TC-0x2E-007: Wrong data length (long: 3 bytes for a 2-byte DID)
+ *              → ERR_INVALID_PARAM (NRC 0x13).
+ */
+ZTEST(test_service_0x2E, tc007_data_length_long)
+{
+    setup();
+    uint8_t       data[3] = { 0x11U, 0x22U, 0x33U };
+    uds_msg_buf_t req  = make_req(TEST_DID_OPEN, data, (uint16_t)3U);
+    uds_msg_buf_t resp = {0};
+
+    uds_status_t rc = uds_service_0x2E_handler(&g_srv, &req, &resp);
+
+    zassert_equal(rc, UDS_STATUS_ERR_INVALID_PARAM,
+                  "long data record must return ERR_INVALID_PARAM (NRC 0x13)");
+    zassert_equal(s_write_call_count, (uint16_t)0U,
+                  "write_cb must not be invoked when data-length check fails");
+}
+
+/**
+ * TC-0x2E-008: write_cb == NULL — must not crash; must return
+ *              ERR_REQUEST_OUT_OF_RANGE (NRC 0x31), mirroring
+ *              service_0x2F.c's identical io_control_cb-NULL precedent.
+ *
+ * This test originally only asserted "must not crash" — running it found
+ * a real NULL-pointer dereference in s_did_safe_write() (fixed in the
+ * same change as this test; see service_0x2E.c). Now pinned to the exact
+ * expected status so a regression back to the unguarded call is caught
+ * as a wrong-status failure, not just a crash.
+ */
+ZTEST(test_service_0x2E, tc008_write_cb_null)
+{
+    setup();
+    uint8_t       data[TEST_DATA_LEN] = { 0x11U, 0x22U };
+    uds_msg_buf_t req  = make_req(TEST_DID_NO_CB, data, (uint16_t)TEST_DATA_LEN);
+    uds_msg_buf_t resp = {0};
+
+    uds_status_t rc = uds_service_0x2E_handler(&g_srv, &req, &resp);
+
+    zassert_equal(rc, UDS_STATUS_ERR_REQUEST_OUT_OF_RANGE,
+                  "write_cb == NULL must return ERR_REQUEST_OUT_OF_RANGE (NRC 0x31), "
+                  "not crash or silently succeed");
+}
+
+/**
+ * TC-0x2E-009: write_cb returns ERR_CONDITIONS_NOT_MET → propagates (NRC 0x22).
+ */
+ZTEST(test_service_0x2E, tc009_write_cb_failure_propagates)
+{
+    setup();
+    s_mock_write_return = UDS_STATUS_ERR_CONDITIONS_NOT_MET;
+
+    uint8_t       data[TEST_DATA_LEN] = { 0x11U, 0x22U };
+    uds_msg_buf_t req  = make_req(TEST_DID_OPEN, data, (uint16_t)TEST_DATA_LEN);
+    uds_msg_buf_t resp = {0};
+
+    uds_status_t rc = uds_service_0x2E_handler(&g_srv, &req, &resp);
+
+    zassert_equal(rc, UDS_STATUS_ERR_CONDITIONS_NOT_MET,
+                  "write_cb's ERR_CONDITIONS_NOT_MET must propagate (→ NRC 0x22)");
+    zassert_equal(s_write_call_count, (uint16_t)1U,
+                  "write_cb must have been called exactly once");
+}
+
+/**
+ * TC-0x2E-010: Valid write, no security required → OK, callback sees the
+ *              exact bytes sent.
+ */
+ZTEST(test_service_0x2E, tc010_valid_write_open)
+{
+    setup();
+    uint8_t       data[TEST_DATA_LEN] = { 0xCAU, 0xFEU };
+    uds_msg_buf_t req  = make_req(TEST_DID_OPEN, data, (uint16_t)TEST_DATA_LEN);
+    uds_msg_buf_t resp = {0};
+
+    uds_status_t rc = uds_service_0x2E_handler(&g_srv, &req, &resp);
+
+    zassert_equal(rc, UDS_STATUS_OK, "valid write must return OK");
+    zassert_equal(s_write_call_count, (uint16_t)1U, "write_cb must be called exactly once");
+    zassert_equal(s_last_write_len, (uint16_t)TEST_DATA_LEN, "write_cb must see the full data length");
+    zassert_equal(s_last_write_data[0], (uint8_t)0xCAU, "write_cb must see byte 0 unmodified");
+    zassert_equal(s_last_write_data[1], (uint8_t)0xFEU, "write_cb must see byte 1 unmodified");
+}
+
+/**
+ * TC-0x2E-011: Valid write, EXTENDED session + security unlocked → OK.
+ */
+ZTEST(test_service_0x2E, tc011_valid_write_gated)
+{
+    setup();
+    uds_session_transition(&g_sess, UDS_SESSION_EXTENDED);
+    g_sec.active_level = (uint8_t)1U;  /* simulate a completed 0x27 unlock */
+
+    uint8_t       data[TEST_DATA_LEN] = { 0x01U, 0x02U };
+    uds_msg_buf_t req  = make_req(TEST_DID_GATED, data, (uint16_t)TEST_DATA_LEN);
+    uds_msg_buf_t resp = {0};
+
+    uds_status_t rc = uds_service_0x2E_handler(&g_srv, &req, &resp);
+
+    zassert_equal(rc, UDS_STATUS_OK,
+                  "write to a security-gated DID must succeed once unlocked");
+    zassert_equal(s_write_call_count, (uint16_t)1U, "write_cb must be called exactly once");
+}
+
+/**
+ * TC-0x2E-012: Boundary — 1-byte data_length DID, exact-length write → OK.
+ */
+ZTEST(test_service_0x2E, tc012_boundary_one_byte)
+{
+    setup();
+    uint8_t       data[1] = { 0x7FU };
+    uds_msg_buf_t req  = make_req(TEST_DID_ONEBYTE, data, (uint16_t)1U);
+    uds_msg_buf_t resp = {0};
+
+    uds_status_t rc = uds_service_0x2E_handler(&g_srv, &req, &resp);
+
+    zassert_equal(rc, UDS_STATUS_OK, "exact 1-byte write must return OK");
+    zassert_equal(s_last_write_len, (uint16_t)1U, "write_cb must see exactly 1 byte");
+    zassert_equal(s_last_write_data[0], (uint8_t)0x7FU, "write_cb must see the correct byte");
+}
+
+/**
+ * TC-0x2E-013: Response format: [0x6E, DID_hi, DID_lo], length == 3.
+ */
+ZTEST(test_service_0x2E, tc013_response_format)
+{
+    setup();
+    uint8_t       data[TEST_DATA_LEN] = { 0x11U, 0x22U };
+    uds_msg_buf_t req  = make_req(TEST_DID_OPEN, data, (uint16_t)TEST_DATA_LEN);
+    uds_msg_buf_t resp = {0};
+
+    (void)uds_service_0x2E_handler(&g_srv, &req, &resp);
+
+    zassert_equal(resp.data[0], (uint8_t)0x6EU,
+                  "resp[0] must be 0x6E (positive response for SID 0x2E)");
+    zassert_equal(resp.data[1], (uint8_t)((TEST_DID_OPEN >> 8U) & 0xFFU),
+                  "resp[1] must be the DID high byte");
+    zassert_equal(resp.data[2], (uint8_t)(TEST_DID_OPEN & 0xFFU),
+                  "resp[2] must be the DID low byte");
+    zassert_equal(resp.length, (uint16_t)3U, "response length must be exactly 3");
+}
+
+/**
+ * TC-0x2E-014: Two DIDs written in sequence don't cross-contaminate
+ *              write_cb's recorded arguments (regression guard against
+ *              any stale-buffer/aliasing bug between calls).
+ */
+ZTEST(test_service_0x2E, tc014_sequential_writes_no_cross_contamination)
+{
+    setup();
+    uint8_t       data1[TEST_DATA_LEN] = { 0xAAU, 0xBBU };
+    uds_msg_buf_t req1  = make_req(TEST_DID_OPEN, data1, (uint16_t)TEST_DATA_LEN);
+    uds_msg_buf_t resp1 = {0};
+    (void)uds_service_0x2E_handler(&g_srv, &req1, &resp1);
+
+    zassert_equal(s_last_write_data[0], (uint8_t)0xAAU, "first write byte 0 mismatch");
+    zassert_equal(s_last_write_data[1], (uint8_t)0xBBU, "first write byte 1 mismatch");
+
+    uint8_t       data2[1] = { 0x55U };
+    uds_msg_buf_t req2  = make_req(TEST_DID_ONEBYTE, data2, (uint16_t)1U);
+    uds_msg_buf_t resp2 = {0};
+    (void)uds_service_0x2E_handler(&g_srv, &req2, &resp2);
+
+    zassert_equal(s_write_call_count, (uint16_t)2U, "both writes must have invoked write_cb");
+    zassert_equal(s_last_write_len, (uint16_t)1U,
+                  "second write's recorded length must be 1, not leftover from the first");
+    zassert_equal(s_last_write_data[0], (uint8_t)0x55U,
+                  "second write's recorded byte must not be contaminated by the first write");
+}
+
+/* =========================================================================
+ * AUTO-GENERATED: run_all_tests — wires ZTEST functions into Unity runner
+ * ========================================================================= */
+
+extern void test_service_0x2E__tc001_null_ctx(void);
+extern void test_service_0x2E__tc002_request_too_short(void);
+extern void test_service_0x2E__tc003_did_not_found(void);
+extern void test_service_0x2E__tc004_wrong_session(void);
+extern void test_service_0x2E__tc005_wrong_security(void);
+extern void test_service_0x2E__tc006_data_length_short(void);
+extern void test_service_0x2E__tc007_data_length_long(void);
+extern void test_service_0x2E__tc008_write_cb_null(void);
+extern void test_service_0x2E__tc009_write_cb_failure_propagates(void);
+extern void test_service_0x2E__tc010_valid_write_open(void);
+extern void test_service_0x2E__tc011_valid_write_gated(void);
+extern void test_service_0x2E__tc012_boundary_one_byte(void);
+extern void test_service_0x2E__tc013_response_format(void);
+extern void test_service_0x2E__tc014_sequential_writes_no_cross_contamination(void);
+
+void run_all_tests(void)
+{
+    RUN_TEST(test_service_0x2E__tc001_null_ctx);
+    RUN_TEST(test_service_0x2E__tc002_request_too_short);
+    RUN_TEST(test_service_0x2E__tc003_did_not_found);
+    RUN_TEST(test_service_0x2E__tc004_wrong_session);
+    RUN_TEST(test_service_0x2E__tc005_wrong_security);
+    RUN_TEST(test_service_0x2E__tc006_data_length_short);
+    RUN_TEST(test_service_0x2E__tc007_data_length_long);
+    RUN_TEST(test_service_0x2E__tc008_write_cb_null);
+    RUN_TEST(test_service_0x2E__tc009_write_cb_failure_propagates);
+    RUN_TEST(test_service_0x2E__tc010_valid_write_open);
+    RUN_TEST(test_service_0x2E__tc011_valid_write_gated);
+    RUN_TEST(test_service_0x2E__tc012_boundary_one_byte);
+    RUN_TEST(test_service_0x2E__tc013_response_format);
+    RUN_TEST(test_service_0x2E__tc014_sequential_writes_no_cross_contamination);
+}

--- a/tests/unit_runnable/test_uds_periodic.c
+++ b/tests/unit_runnable/test_uds_periodic.c
@@ -32,6 +32,10 @@
  *   TC-PERIODIC-012  pop_due(NULL) → ERR_NULL_PTR
  *   TC-PERIODIC-013  pop_due with no subscriptions → ERR_NOT_FOUND
  *   TC-PERIODIC-014  frame format: data[0]=0x6A, data[1]=periodicId after FAST fires
+ *   TC-PERIODIC-015  [EDS#194] requeue_last() with nothing popped → ERR_NOT_FOUND
+ *   TC-PERIODIC-016  [EDS#194] pop_due + requeue_last() re-arms; next pop_due → OK
+ *   TC-PERIODIC-017  [EDS#194] requeue_last() twice in a row → 2nd is a no-op
+ *   TC-PERIODIC-018  [EDS#194] requeue_last() after unsubscribe → ERR_NOT_FOUND, safe
  *
  * FRAMEWORK: Zephyr Ztest (compiled as host Unity via ztest_shim.h)
  * =============================================================================
@@ -331,6 +335,110 @@ ZTEST(test_uds_periodic, tc014_frame_format)
                   "frame length must be 2 (header) + 2 (data) = 4");
 }
 
+/**
+ * TC-PERIODIC-015: [EDS#194] requeue_last() with nothing ever popped →
+ *                  ERR_NOT_FOUND, not a crash.
+ */
+ZTEST(test_uds_periodic, tc015_requeue_nothing_popped)
+{
+    setup();
+    uds_status_t rc = uds_periodic_requeue_last();
+    zassert_equal(rc, UDS_STATUS_ERR_NOT_FOUND,
+                  "requeue_last() with no prior pop must return ERR_NOT_FOUND");
+}
+
+/**
+ * TC-PERIODIC-016: [EDS#194] pop_due() then requeue_last() re-arms the
+ *                  subscription — the very next pop_due() (no further
+ *                  ticks needed) must return OK again. This is the actual
+ *                  regression this issue is about: without requeue_last()
+ *                  actually re-setting the due flag, a failed transmit's
+ *                  period would be lost until the next natural interval.
+ */
+ZTEST(test_uds_periodic, tc016_requeue_rearms_subscription)
+{
+    setup();
+    (void)uds_periodic_subscribe((uint8_t)0xABU, UDS_PERIODIC_MODE_FAST);
+
+    uint16_t t;
+    for (t = (uint16_t)0U; t < (uint16_t)UDS_PERIODIC_FAST_MS; t++) {
+        (void)uds_periodic_tick_1ms();
+    }
+
+    uds_msg_buf_t frame;
+    memset(&frame, 0, sizeof(frame));
+    uds_status_t rc = uds_periodic_pop_due(&frame);
+    zassert_equal(rc, UDS_STATUS_OK, "first pop_due must return OK");
+
+    /* Simulate a failed transmit: ask for it back, with NO further ticks. */
+    rc = uds_periodic_requeue_last();
+    zassert_equal(rc, UDS_STATUS_OK,
+                  "requeue_last() must succeed for the just-popped subscription");
+
+    memset(&frame, 0, sizeof(frame));
+    rc = uds_periodic_pop_due(&frame);
+    zassert_equal(rc, UDS_STATUS_OK,
+                  "pop_due() must return OK again immediately after requeue_last() "
+                  "— the period must not be lost");
+    zassert_equal(frame.data[1], (uint8_t)0xABU,
+                  "re-armed frame must still be for the same periodicId");
+}
+
+/**
+ * TC-PERIODIC-017: [EDS#194] requeue_last() consumes the "last popped"
+ *                  record — calling it a second time in a row (no
+ *                  intervening pop) must return ERR_NOT_FOUND, not
+ *                  re-arm the same subscription twice.
+ */
+ZTEST(test_uds_periodic, tc017_requeue_twice_second_is_noop)
+{
+    setup();
+    (void)uds_periodic_subscribe((uint8_t)0xABU, UDS_PERIODIC_MODE_FAST);
+
+    uint16_t t;
+    for (t = (uint16_t)0U; t < (uint16_t)UDS_PERIODIC_FAST_MS; t++) {
+        (void)uds_periodic_tick_1ms();
+    }
+
+    uds_msg_buf_t frame;
+    memset(&frame, 0, sizeof(frame));
+    (void)uds_periodic_pop_due(&frame);
+
+    uds_status_t rc1 = uds_periodic_requeue_last();
+    uds_status_t rc2 = uds_periodic_requeue_last();
+    zassert_equal(rc1, UDS_STATUS_OK, "first requeue_last() must succeed");
+    zassert_equal(rc2, UDS_STATUS_ERR_NOT_FOUND,
+                  "second requeue_last() with no intervening pop must be a no-op");
+}
+
+/**
+ * TC-PERIODIC-018: [EDS#194] requeue_last() after the subscription was
+ *                  cancelled between the pop and the requeue call must
+ *                  return ERR_NOT_FOUND, not crash or resurrect the
+ *                  cancelled subscription.
+ */
+ZTEST(test_uds_periodic, tc018_requeue_after_unsubscribe_is_safe)
+{
+    setup();
+    (void)uds_periodic_subscribe((uint8_t)0xABU, UDS_PERIODIC_MODE_FAST);
+
+    uint16_t t;
+    for (t = (uint16_t)0U; t < (uint16_t)UDS_PERIODIC_FAST_MS; t++) {
+        (void)uds_periodic_tick_1ms();
+    }
+
+    uds_msg_buf_t frame;
+    memset(&frame, 0, sizeof(frame));
+    (void)uds_periodic_pop_due(&frame);
+
+    (void)uds_periodic_unsubscribe((uint8_t)0xABU);
+
+    uds_status_t rc = uds_periodic_requeue_last();
+    zassert_equal(rc, UDS_STATUS_ERR_NOT_FOUND,
+                  "requeue_last() after unsubscribe must return ERR_NOT_FOUND, "
+                  "not resurrect the cancelled subscription");
+}
+
 /* =========================================================================
  * AUTO-GENERATED: run_all_tests — wires ZTEST functions into Unity runner
  * ========================================================================= */
@@ -349,6 +457,10 @@ extern void test_uds_periodic__tc011_fast_not_due_before_interval(void);
 extern void test_uds_periodic__tc012_pop_due_null_ptr(void);
 extern void test_uds_periodic__tc013_pop_due_empty_table(void);
 extern void test_uds_periodic__tc014_frame_format(void);
+extern void test_uds_periodic__tc015_requeue_nothing_popped(void);
+extern void test_uds_periodic__tc016_requeue_rearms_subscription(void);
+extern void test_uds_periodic__tc017_requeue_twice_second_is_noop(void);
+extern void test_uds_periodic__tc018_requeue_after_unsubscribe_is_safe(void);
 
 void run_all_tests(void)
 {
@@ -366,4 +478,8 @@ void run_all_tests(void)
     RUN_TEST(test_uds_periodic__tc012_pop_due_null_ptr);
     RUN_TEST(test_uds_periodic__tc013_pop_due_empty_table);
     RUN_TEST(test_uds_periodic__tc014_frame_format);
+    RUN_TEST(test_uds_periodic__tc015_requeue_nothing_popped);
+    RUN_TEST(test_uds_periodic__tc016_requeue_rearms_subscription);
+    RUN_TEST(test_uds_periodic__tc017_requeue_twice_second_is_noop);
+    RUN_TEST(test_uds_periodic__tc018_requeue_after_unsubscribe_is_safe);
 }


### PR DESCRIPTION
Closes #194, #195, #202.

## #194 — periodic frame silently dropped on ISO-TP busy
`uds_periodic_pop_due()` cleared a subscription's due flag before the caller attempted transmit — `isotp_transmit()` returning `BUSY` (e.g. mid multi-frame send) lost that period with no re-queue, no error surfaced, nothing. Added `uds_periodic_requeue_last()`: re-arms the most-recently-popped subscription for the next tick, consumed on use. Updated all 9 example `main.c` drain loops to check `isotp_transmit()`'s return and requeue + stop draining on failure.

4 new unit tests (`TC-PERIODIC-015..018`) — `tc016` verified as a genuine positive control: temporarily disabled the fix's core re-arm line, confirmed `tc016` fails, restored.

## #195 — no dedicated 0x2E unit test
Added `tests/unit_runnable/test_service_0x2E.c` — 14 test cases. The primary write path (and the one `ASIL_B_REQUIRE_WRITE_SECURITY` exists to protect) had zero dedicated C coverage despite every other DID-access service having one.

## #202 — found while writing the #195 test
Writing a straightforward "what if `write_cb` is NULL" case immediately segfaulted — `service_0x2E.c`'s `s_did_safe_write()` invoked the write callback unconditionally, unlike every other DID-callback dispatch in this codebase (`service_0x2F.c`'s `io_control_cb`, `uds_periodic_pop_due()`'s `read_cb`). Fixed to mirror `service_0x2F.c`'s exact precedent: `ERR_REQUEST_OUT_OF_RANGE` (NRC 0x31) instead of a crash.

## Verification
`bash build_tests.sh` — 45 passed (44+1 new module), 912 cases (898+14 new), 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)