### PR TITLE
fix(security): opt-in fail-closed posture for genuine NVM read faults (#196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,23 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Opt-in fail-closed posture for SecurityAccess on a genuine NVM read
+  fault** (#196; Tier-1 round-3 due diligence). Previously,
+  `uds_security_init()` treated *any* non-OK `nvm_load_cb` result the same
+  as first-boot: proceed with a zero attempt counter, no lockout — masking
+  a real read error (corrupt record, platform fault) behind the same
+  behavior as "no data yet". Added `uds_security_cfg_t.nvm_load_fail_closed`
+  (default `false`, so every existing generated product is unaffected — a
+  zero-initialized struct leaves the new field `false`). When set `true`,
+  a genuine fault (anything other than success or the expected
+  `UDS_STATUS_ERR_DID_NOT_FOUND`) now locks SecurityAccess out for the
+  rest of the power cycle instead of silently resetting the counter. See
+  `docs/SECURITY_NOTICE.md`'s "Failed Attempt Lockout Policy" section for
+  the trade-off and how to opt in. 3 new unit tests in
+  `test_uds_security.c` (default fail-open, opt-in fail-closed, first-boot
+  unaffected by the flag either way); the fail-closed test was confirmed
+  to genuinely fail when the new branch is disabled, then restored.
+
 - **`tests/unit_runnable/test_service_0x2E.c`** (#195; Tier-1 round-3 due
   diligence). No dedicated C unit test existed for WriteDataByIdentifier
   despite 0x22/0x23/0x27/0x28/0x2A/0x2F all having one — the primary

--- a/core/uds_security.c
+++ b/core/uds_security.c
@@ -93,8 +93,13 @@ uds_status_t uds_security_init(
      * count and lockout residual that were saved before the last power-down.
      * This prevents an attacker from bypassing lockout by power-cycling the ECU.
      *
-     * ERR_DID_NOT_FOUND is expected on first boot — treat as zero counter.
-     * Any other error: log and proceed with zero counter (safe degradation).
+     * ERR_DID_NOT_FOUND is expected on first boot — always treated as a
+     * safe, normal zero counter, regardless of nvm_load_fail_closed below;
+     * "no data yet" is not a fault.
+     *
+     * [EDS#196] Any OTHER error is a genuine NVM fault (corrupt record,
+     * platform read failure) and is where cfg->nvm_load_fail_closed
+     * decides the posture — see its doc comment in uds_security.h.
      */
     if (cfg->nvm_load_cb != NULL) {
         uint8_t  loaded_attempts  = (uint8_t)0U;
@@ -111,8 +116,19 @@ uds_status_t uds_security_init(
                 ctx->locked_out       = true;
                 ctx->lockout_timer_ms = loaded_lockout;
             }
+        } else if ((load_rc != UDS_STATUS_ERR_DID_NOT_FOUND) &&
+                   cfg->nvm_load_fail_closed) {
+            /* [EDS#196] Fail closed: cannot trust that persisted
+             * lockout/attempt state wasn't lost or tampered with — block
+             * SecurityAccess for this power cycle rather than risk an
+             * unlimited-attempt window. UINT32_MAX ms (~49.7 days) at the
+             * 1ms tick rate is, for any realistic ECU uptime, permanent
+             * for this boot; a healthy re-init (NVM read succeeds) is the
+             * only way out, not a timer expiring. */
+            ctx->locked_out       = true;
+            ctx->lockout_timer_ms = UINT32_MAX;
         }
-        /* ERR_DID_NOT_FOUND (first boot) and other errors: start from zero. */
+        /* Else (fail-open, the default): start from zero, as before. */
     }
 
     ctx->initialized = true;

--- a/core/uds_security.h
+++ b/core/uds_security.h
@@ -171,6 +171,30 @@ typedef struct uds_security_cfg {
      */
     uds_status_t (*nvm_save_cb)(uint8_t attempts, uint32_t lockout_ms);
 
+    /**
+     * @brief [EDS#196] Posture when nvm_load_cb reports a genuine fault
+     *        (anything other than UDS_STATUS_OK or the expected
+     *        first-boot UDS_STATUS_ERR_DID_NOT_FOUND — a real read
+     *        error, not "no data yet").
+     *
+     * false (default — matches every generated product's behavior before
+     *   this field existed, since a zero-initialized struct leaves it
+     *   false): fail open. uds_security_init() proceeds with a zero
+     *   attempt counter and no lockout, prioritizing diagnostic
+     *   availability over brute-force resistance when NVM is unhealthy.
+     *
+     * true: fail closed. uds_security_init() locks SecurityAccess out
+     *   for the remainder of this power cycle rather than risk trusting
+     *   an unreadable/corrupt persisted state — see
+     *   docs/SECURITY_NOTICE.md's "Failed Attempt Lockout Policy"
+     *   section for the full trade-off and how to opt in.
+     *
+     * Not consulted when nvm_load_cb is NULL (no persistence configured
+     * at all — a separate, unrelated posture) or when the load succeeds
+     * or correctly reports first-boot.
+     */
+    bool nvm_load_fail_closed;
+
 } uds_security_cfg_t;
 
 /* --------------------------------------------------------------------------

--- a/docs/SECURITY_NOTICE.md
+++ b/docs/SECURITY_NOTICE.md
@@ -234,6 +234,28 @@ the power-cycle bypass. If your product's threat model includes an
 attacker with physical access to power, wire NVM persistence — the stack
 does not require it, but it does not protect you without it either.
 
+**NVM read faults: fail-open by default, fail-closed opt-in.** With
+persistence wired, `uds_security_init()` calls `nvm_load_cb` at boot to
+restore the counter and any residual lockout. Two outcomes are expected and
+harmless: a successful load, and `UDS_STATUS_ERR_DID_NOT_FOUND` (first
+boot — no record has been written yet). Any *other* return is a genuine NVM
+fault: a corrupt record, or a platform-level read error. How EDS reacts to
+that fault is controlled by `uds_security_cfg_t.nvm_load_fail_closed`:
+
+| Setting | Behavior on a genuine NVM fault |
+|---|---|
+| `false` (default) | **Fail open.** `uds_security_init()` proceeds with the counter at zero and no lockout. Preserves diagnostic availability when NVM is unhealthy, at the cost of losing brute-force resistance across that one fault. Matches the stack's behavior before this flag existed — no change for any existing product. |
+| `true` | **Fail closed.** SecurityAccess is locked out for the remainder of the current power cycle (`lockout_timer_ms` set to `UINT32_MAX` — effectively permanent for one boot, not a short timer that quietly expires). The only way out is a healthy reboot where `nvm_load_cb` succeeds. Prioritizes brute-force resistance over availability: an attacker cannot exploit a broken/corrupted NVM path to force an always-fresh attempt counter. |
+
+Set `nvm_load_fail_closed = true` if your threat model treats "SecurityAccess
+briefly unavailable" as strictly preferable to "SecurityAccess silently
+un-throttled because storage is unhealthy" — e.g. products where an attacker
+could plausibly induce NVM faults (corrupted sectors, glitching a flash
+write) to reset the attempt counter. Leave it at the default if your product
+prioritizes keeping diagnostics reachable even when NVM itself is degraded.
+This flag is only consulted for a genuine fault; it never affects the
+first-boot (`UDS_STATUS_ERR_DID_NOT_FOUND`) or successful-load paths.
+
 ---
 
 ## Questions

--- a/tests/unit_runnable/test_uds_security.c
+++ b/tests/unit_runnable/test_uds_security.c
@@ -148,6 +148,23 @@ static uds_status_t do_full_unlock(uds_security_ctx_t *ctx)
 }
 
 /* =========================================================================
+ * [EDS#196] Mock nvm_load_cb — return value fully controlled by each test,
+ * independent of the real uds_security_nvm.c / nvm_store mock chain
+ * (test_phase3_nvm_security.c already covers that real integration; these
+ * tests are about uds_security_init()'s decision logic given *any*
+ * nvm_load_cb result, so a hand-controlled mock is the more direct fit).
+ * ========================================================================= */
+
+static uds_status_t s_nvm_load_rc;
+
+static uds_status_t mock_nvm_load(uint8_t *out_attempts, uint32_t *out_lockout_ms)
+{
+    *out_attempts   = 0U;
+    *out_lockout_ms = 0U;
+    return s_nvm_load_rc;
+}
+
+/* =========================================================================
  * Test suite: uds_security_init
  * ========================================================================= */
 
@@ -243,6 +260,98 @@ ZTEST(test_uds_security_init, test_double_init)
     };
     zassert_equal(uds_security_init(&ctx, &k_cfg), UDS_STATUS_ERR_ALREADY_INITIALIZED,
                   "double init must fail");
+}
+
+/**
+ * TC-SEC-INIT-007: [EDS#196] Genuine NVM load fault, nvm_load_fail_closed
+ *                  left at its default (false) → fail OPEN. Unchanged
+ *                  behavior from before this field existed: zero counter,
+ *                  not locked out, SecurityAccess usable.
+ */
+ZTEST(test_uds_security_init, test_nvm_load_error_default_fails_open)
+{
+    s_nvm_load_rc = UDS_STATUS_ERR_PLATFORM;  /* genuine fault, not first-boot */
+
+    uds_security_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    static const uds_security_cfg_t k_cfg = {
+        .max_attempts     = 3U,
+        .lockout_ms       = 100U,
+        .key_validate_cb  = test_key_validate,
+        .seed_generate_cb = test_seed_generate,
+        .nvm_load_cb      = mock_nvm_load,
+        /* .nvm_load_fail_closed left unset -> false (the default) */
+    };
+
+    zassert_equal(uds_security_init(&ctx, &k_cfg), UDS_STATUS_OK, "init must succeed");
+    zassert_false(ctx.locked_out,
+                  "default posture (fail-open) must NOT lock out on a genuine NVM fault");
+    zassert_equal(ctx.failed_attempts, 0U,
+                  "default posture must start the attempt counter at zero");
+}
+
+/**
+ * TC-SEC-INIT-008: [EDS#196] Genuine NVM load fault, nvm_load_fail_closed
+ *                  explicitly true → fail CLOSED. SecurityAccess locked
+ *                  out for the rest of this power cycle.
+ */
+ZTEST(test_uds_security_init, test_nvm_load_error_fail_closed_locks_out)
+{
+    s_nvm_load_rc = UDS_STATUS_ERR_PLATFORM;  /* genuine fault, not first-boot */
+
+    uds_security_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    static const uds_security_cfg_t k_cfg = {
+        .max_attempts          = 3U,
+        .lockout_ms             = 100U,
+        .key_validate_cb        = test_key_validate,
+        .seed_generate_cb       = test_seed_generate,
+        .nvm_load_cb            = mock_nvm_load,
+        .nvm_load_fail_closed   = true,
+    };
+
+    zassert_equal(uds_security_init(&ctx, &k_cfg), UDS_STATUS_OK,
+                  "init itself must still succeed -- fail-closed locks SecurityAccess, "
+                  "not the stack");
+    zassert_true(ctx.locked_out,
+                  "fail-closed posture must lock out on a genuine NVM fault");
+    zassert_equal(ctx.lockout_timer_ms, UINT32_MAX,
+                  "fail-closed lockout must be effectively permanent for this boot, "
+                  "not a short timer that quietly expires");
+
+    /* And SecurityAccess must actually be unusable, not just the flag set. */
+    uint8_t seed[UDS_SECURITY_SEED_LEN];
+    uint8_t seed_len = 0U;
+    zassert_equal(do_seed_request(&ctx, seed, &seed_len),
+                  UDS_STATUS_ERR_SEC_ATTEMPT_EXCEEDED,
+                  "seed request must be rejected while fail-closed lockout is active");
+}
+
+/**
+ * TC-SEC-INIT-009: [EDS#196] First-boot (ERR_DID_NOT_FOUND) must NOT be
+ *                  treated as a fault by nvm_load_fail_closed, even when
+ *                  the flag is true -- "no data yet" is expected and safe,
+ *                  not a reason to lock a brand-new ECU out of diagnostics.
+ */
+ZTEST(test_uds_security_init, test_nvm_first_boot_unaffected_by_fail_closed)
+{
+    s_nvm_load_rc = UDS_STATUS_ERR_DID_NOT_FOUND;  /* first boot, no persisted data */
+
+    uds_security_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    static const uds_security_cfg_t k_cfg = {
+        .max_attempts          = 3U,
+        .lockout_ms             = 100U,
+        .key_validate_cb        = test_key_validate,
+        .seed_generate_cb       = test_seed_generate,
+        .nvm_load_cb            = mock_nvm_load,
+        .nvm_load_fail_closed   = true,
+    };
+
+    zassert_equal(uds_security_init(&ctx, &k_cfg), UDS_STATUS_OK, "init must succeed");
+    zassert_false(ctx.locked_out,
+                  "first boot must never lock out, even with fail_closed = true");
+    zassert_equal(ctx.failed_attempts, 0U, "first boot must start at zero attempts");
 }
 
 /* =========================================================================
@@ -676,6 +785,9 @@ extern void test_uds_security_init__test_null_key_cb(void);
 extern void test_uds_security_init__test_null_seed_cb(void);
 extern void test_uds_security_init__test_happy_path(void);
 extern void test_uds_security_init__test_double_init(void);
+extern void test_uds_security_init__test_nvm_load_error_default_fails_open(void);
+extern void test_uds_security_init__test_nvm_load_error_fail_closed_locks_out(void);
+extern void test_uds_security_init__test_nvm_first_boot_unaffected_by_fail_closed(void);
 extern void test_uds_security_seed__test_null_ctx(void);
 extern void test_uds_security_seed__test_null_seed_buf(void);
 extern void test_uds_security_seed__test_seed_generated(void);
@@ -705,6 +817,9 @@ void run_all_tests(void)
     RUN_TEST(test_uds_security_init__test_null_seed_cb);
     RUN_TEST(test_uds_security_init__test_happy_path);
     RUN_TEST(test_uds_security_init__test_double_init);
+    RUN_TEST(test_uds_security_init__test_nvm_load_error_default_fails_open);
+    RUN_TEST(test_uds_security_init__test_nvm_load_error_fail_closed_locks_out);
+    RUN_TEST(test_uds_security_init__test_nvm_first_boot_unaffected_by_fail_closed);
     RUN_TEST(test_uds_security_seed__test_null_ctx);
     RUN_TEST(test_uds_security_seed__test_null_seed_buf);
     RUN_TEST(test_uds_security_seed__test_seed_generated);


### PR DESCRIPTION
## Summary

Closes #196.

`uds_security_init()` previously treated *any* non-OK `nvm_load_cb` result the same as first boot: proceed with a zero attempt counter, no lockout. That masks a genuine NVM fault (corrupt record, platform read error) behind the same "safe" behavior as "no data yet" — a broken or attacker-induced NVM path could reset the failed-attempt counter for free.

Adds `uds_security_cfg_t.nvm_load_fail_closed` (default `false`):

- **`false` (default, unchanged behavior)** — fail open. Every existing generated product is unaffected: a zero-initialized struct leaves the new field `false`, so this is a pure additive library change — no codegen template or generated-code updates required, unlike #190's NVM wiring gap which needed real template changes.
- **`true` (opt-in)** — fail closed on a genuine fault (anything other than success or the expected `UDS_STATUS_ERR_DID_NOT_FOUND` first-boot case). Locks SecurityAccess out for the rest of the power cycle (`lockout_timer_ms = UINT32_MAX`, the same "effectively permanent for this boot" idiom `core/uds_safety.c` already uses for its saturating counters). Only a healthy reboot where `nvm_load_cb` succeeds clears it.

Documented the trade-off and how to opt in under `docs/SECURITY_NOTICE.md`'s "Failed Attempt Lockout Policy" section.

## Tests

3 new cases in `tests/unit_runnable/test_uds_security.c`:
- default fail-open on a genuine fault (counter stays 0, not locked out)
- opt-in fail-closed locks out and blocks seed requests (`UDS_STATUS_ERR_SEC_ATTEMPT_EXCEEDED`)
- first-boot (`ERR_DID_NOT_FOUND`) unaffected by the flag either way

Per `lessons/run-014`: temporarily disabled the new branch, confirmed the fail-closed test genuinely fails naming the right defect (not an unrelated error), then restored it.

```
=== Unit Test Cases: 915 run, 0 failed ===
=== Unit Test Summary: 45 passed, 0 failed ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)