### PR TITLE
fix(platform): wire nvm_store_init() into real Zephyr init paths (#200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,59 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`nvm_store_init()` never called anywhere in the real Zephyr platform
+  init — NVM persistence (DTC mirror, and security counter/lockout
+  persistence once wired) silently non-functional** (#200; found while
+  implementing #190). `nvm_store_is_ready()` returned `false` forever on
+  every Zephyr build, degrading gracefully rather than crashing (which is
+  exactly why this went unnoticed) but never actually activating.
+  FreeRTOS was unaffected — `eds_platform_init()` already called
+  `nvm_store_init()`.
+
+  Wired the missing call into `main()` for every Zephyr example, before
+  `uds_generated_init()` (which calls `dtc_mirror_init()` at Step 3.5):
+  - `basic_ecu` — cross-compiled by CI against 4 different board targets
+    (native_sim + 3 real boards, each with its own `diag_nvs` DTS
+    partition and physical erase-page size). Resolves
+    `FIXED_PARTITION_DEVICE`/`OFFSET`/`SIZE(eds_nvs_slot)` — the DTS
+    *node label*, not the partition's string `"diag_nvs"` `label`
+    property; the string form compiles but fails to link — and queries
+    the real page size at runtime via `flash_get_page_info_by_offs()`
+    rather than hardcoding a sector size — one hardcoded value cannot be
+    correct across boards with 128 KB and 8 KB physical sectors.
+    Uncovered a real latent bug in the process: `nvm_store_cfg_t.sector_size`
+    was `uint16_t`, silently truncating 128 KB (`0x20000`) to 0 on two of
+    the three real boards — widened to `uint32_t` (`platform/nvm_store.h`).
+  - `safeboot_ecu` — its board's `diag_nvs` partition and sector geometry
+    are already fully documented in
+    `boards/nucleo_h743zi/nucleo_h743zi.overlay`; wired directly from
+    that.
+  - `basic_ecu_doip`, `bms_ecu`, `motor_controller_ecu`,
+    `robot_joint_controller_ecu`, `sensor_ecu` — native_sim-only targets,
+    where `platform/zephyr/nvm_store_mock.c` (RAM-backed) is always
+    linked regardless; `nvm_store_init(NULL)` is correct there (mock
+    ignores `cfg` — see `nvm_store.h`: "may be NULL on host").
+
+  Two real boards are deliberate, documented exceptions, left unfixed
+  rather than guessed at:
+  - `ardep_ecu` — its board overlay enables `CONFIG_NVS=y` but defines no
+    `diag_nvs` partition at all, and the ARDEP board DTS itself lives in
+    an external, non-vendored module — guessing at a flash layout for
+    hardware this repo has no visibility into is exactly the risk this
+    issue originally flagged. Not compiled by CI either way
+    (`example-ardep` only validates generated files, no `west build`).
+  - `mr_canhubk3` (NXP S32K344, one of `basic_ecu`'s 4 CI board targets)
+    — its `diag_nvs` partition resolves correctly with the node-label fix
+    above, but the build still fails to *link*:
+    `'__device_dts_ord_199' undeclared` inside `FIXED_PARTITION_DEVICE`'s
+    expansion, meaning `&flash0` has a devicetree node on this SoC but no
+    instantiated Zephyr `struct device` behind it in Zephyr v3.7.0 —
+    unlike the other two real boards, where the identical pattern links
+    cleanly. `nvm_store_init(NULL)` on this board only (compiles, and
+    correctly, honestly reports `UDS_STATUS_ERR_NULL_PTR` every boot
+    rather than silently succeeding) until someone with real S32K3
+    hardware or HAL knowledge can root-cause the flash driver gap.
+
 - **Periodic DID frame silently dropped when ISO-TP transmit is busy**
   (#194; Tier-1 round-3 due diligence). `uds_periodic_pop_due()` cleared
   a subscription's due flag before the caller attempted transmit — a

--- a/examples/basic_ecu/src/main.c
+++ b/examples/basic_ecu/src/main.c
@@ -46,6 +46,7 @@
 #include "zephyr_mutex.h"
 #include "zephyr_timer.h"
 #include "zephyr_wdt.h"
+#include "nvm_store.h"
 
 /* --------------------------------------------------------------------------
  * Generated headers (from diagnostics_config.yaml via codegen.py)
@@ -60,7 +61,9 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/can.h>
+#include <zephyr/drivers/flash.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/storage/flash_map.h>
 
 LOG_MODULE_REGISTER(basic_ecu, LOG_LEVEL_INF);
 
@@ -336,6 +339,84 @@ int main(void)
             LOG_ERR("Platform init failed: 0x%02X", (unsigned)status);
             return -1;
         }
+    }
+
+    /*
+     * [EDS#200] Must run before uds_generated_init() (dtc_mirror_init() at
+     * Step 3.5 sits on top of nvm_store and silently no-ops until this
+     * succeeds).
+     *
+     * Unlike every other example in this repo, basic_ecu is cross-compiled
+     * by CI against FOUR different board targets (see .github/workflows/
+     * ci.yml jobs "zephyr-native" and 5a/5b/5c): native_sim, nucleo_h743zi,
+     * frdm_mcxn947, and mr_canhubk3 — each supplying its own overlay/conf
+     * from the top-level boards/<name>/ directory rather than
+     * examples/basic_ecu/boards/. All four real-board overlays define a
+     * "diag_nvs" fixed partition, but with three DIFFERENT flash page
+     * (erase-sector) sizes (128 KB / 128 KB / 8 KB respectively — see each
+     * boards/<name>/<name>.overlay's own comment block). A single hardcoded
+     * sector_size, as used in safeboot_ecu/src/main.c for its one specific
+     * board, would be wrong for at least two of these three. Query the
+     * real page size at runtime via flash_get_page_info_by_offs() instead
+     * — the portable, board-agnostic way to populate nvm_store_cfg_t.
+     *
+     * On native_sim, platform/zephyr/nvm_store_mock.c (RAM-backed) is
+     * linked instead of the real NVS backend (see this file's CMakeLists.txt
+     * "NVM store: platform-conditional source selection") — its
+     * nvm_store_init() ignores cfg entirely, so NULL is correct there (see
+     * nvm_store.h: "may be NULL on host") and there is no "diag_nvs"
+     * partition to resolve.
+     *
+     * FIXED_PARTITION_DEVICE/OFFSET/SIZE below take the DTS *node label*
+     * (eds_nvs_slot), not the partition's string "label" property
+     * ("diag_nvs") — passing "diag_nvs" fails to compile with
+     * "'__device_dts_ord_DT_N_NODELABEL_diag_nvs...' undeclared" (caught
+     * in this PR's own CI on all three real boards). All four overlays
+     * name the partition node eds_nvs_slot even though its "label" string
+     * is "diag_nvs" — see e.g. boards/nucleo_h743zi/nucleo_h743zi.overlay.
+     *
+     * mr_canhubk3 (NXP S32K344) is a further, deliberate exception: with
+     * the node-label fix above it still fails to *link* --
+     * "'__device_dts_ord_199' undeclared" in FIXED_PARTITION_DEVICE's
+     * expansion (also caught in this PR's own CI) -- meaning &flash0 on
+     * this SoC has a devicetree node but no instantiated struct device
+     * behind it in this Zephyr version (v3.7.0), unlike STM32H743/MCXN947
+     * where the same pattern links cleanly. Root-causing an NXP S32K3
+     * flash driver gap needs real hardware or S32K3 HAL knowledge this
+     * repo doesn't have -- same category of risk as ardep_ecu below, so
+     * left as a documented gap here rather than guessed at a third time.
+     */
+#if defined(CONFIG_BOARD_NATIVE_SIM) || defined(CONFIG_BOARD_MR_CANHUBK3)
+    status = nvm_store_init(NULL);
+#else
+    {
+        const struct device    *nvs_dev = FIXED_PARTITION_DEVICE(eds_nvs_slot);
+        const off_t              nvs_off = FIXED_PARTITION_OFFSET(eds_nvs_slot);
+        const size_t              nvs_sz = FIXED_PARTITION_SIZE(eds_nvs_slot);
+        struct flash_pages_info  page_info;
+        int rc = flash_get_page_info_by_offs(nvs_dev, nvs_off, &page_info);
+
+        if (rc != 0) {
+            LOG_ERR("NVM store: flash_get_page_info_by_offs failed: %d", rc);
+            status = UDS_STATUS_ERR_PLATFORM;
+        } else {
+            const nvm_store_cfg_t nvm_cfg = {
+                .flash_dev    = (const void *)nvs_dev,
+                .flash_offset = (uint32_t)nvs_off,
+                .sector_size  = (uint32_t)page_info.size,
+                /* diag_nvs is sized as an exact multiple of the page size
+                 * on every board this targets; NVS requires >= 2 sectors
+                 * for wear levelling (see nvm_store.c). */
+                .sector_count = (uint8_t)(nvs_sz / page_info.size),
+            };
+
+            status = nvm_store_init(&nvm_cfg);
+        }
+    }
+#endif
+    if (status != UDS_STATUS_OK) {
+        LOG_ERR("NVM store init failed: 0x%02X — DTC mirror will not "
+                "survive reset this run.", (unsigned)status);
     }
 
     /*

--- a/examples/basic_ecu_doip/src/main.c
+++ b/examples/basic_ecu_doip/src/main.c
@@ -67,6 +67,7 @@
  * -------------------------------------------------------------------------- */
 #include "platform_doip.h"   /* eds_doip_platform_start() */
 #include "doip_server.h"     /* DOIP_PORT */
+#include "nvm_store.h"
 
 /* --------------------------------------------------------------------------
  * Generated headers (from diagnostics_config.yaml via codegen.py)
@@ -240,6 +241,20 @@ int main(void)
      */
     LOG_WRN("[SEC] Using placeholder AES keys — inject OEM keys before production.");
     (void)uds_security_algo_set_rng_cb(NULL);
+
+    /*
+     * [EDS#200] Must run before uds_generated_init() (dtc_mirror_init() at
+     * Step 3.5 sits on top of nvm_store and silently no-ops until this
+     * succeeds). This example only targets native_sim, where
+     * platform/zephyr/nvm_store_mock.c (RAM-backed) is linked instead of
+     * the real NVS backend — its nvm_store_init() ignores cfg entirely, so
+     * NULL is correct here (see nvm_store.h: "may be NULL on host").
+     */
+    status = nvm_store_init(NULL);
+    if (status != UDS_STATUS_OK) {
+        LOG_ERR("NVM store init failed: 0x%02X — DTC mirror will not "
+                "survive reset this run.", (unsigned)status);
+    }
 
     /*
      * UDS stack init — DoIP build passes NULL for the CAN transport

--- a/examples/bms_ecu/src/main.c
+++ b/examples/bms_ecu/src/main.c
@@ -83,6 +83,7 @@
 #include "zephyr_mutex.h"
 #include "zephyr_timer.h"
 #include "zephyr_wdt.h"
+#include "nvm_store.h"
 
 /* --------------------------------------------------------------------------
  * Generated headers (from diagnostics_config.yaml via codegen.py)
@@ -1075,6 +1076,21 @@ int main(void)
         return -EIO;
     }
     LOG_INF("[BMS] CAN transport ready (device: %s).", can_dev->name);
+
+    /* --- 3.5. NVM store initialization ------------------------------------ */
+    /*
+     * [EDS#200] Must run before uds_generated_init() (dtc_mirror_init() at
+     * Step 3.5 sits on top of nvm_store and silently no-ops until this
+     * succeeds). This example only targets native_sim, where
+     * platform/zephyr/nvm_store_mock.c (RAM-backed) is linked instead of
+     * the real NVS backend — its nvm_store_init() ignores cfg entirely, so
+     * NULL is correct here (see nvm_store.h: "may be NULL on host").
+     */
+    st = nvm_store_init(NULL);
+    if (st != UDS_STATUS_OK) {
+        LOG_ERR("[BMS] NVM store init failed: 0x%02X — DTC mirror will not "
+                "survive reset this run.", (unsigned)st);
+    }
 
     /* --- 4. Security algorithm init ------------------------------------- */
     /*

--- a/examples/motor_controller_ecu/src/main.c
+++ b/examples/motor_controller_ecu/src/main.c
@@ -79,6 +79,7 @@
 #include "zephyr_mutex.h"
 #include "zephyr_timer.h"
 #include "zephyr_wdt.h"
+#include "nvm_store.h"
 
 /* --------------------------------------------------------------------------
  * Generated headers (from diagnostics_config.yaml via codegen.py)
@@ -748,6 +749,21 @@ static void diag_task_fn(void *p1, void *p2, void *p3)
     if (status != UDS_STATUS_OK) {
         LOG_ERR("[MC] zephyr_port_init failed: 0x%02X", (unsigned)status);
         return;
+    }
+
+    /* ── NVM store initialization ────────────────────────────────────────── */
+    /*
+     * [EDS#200] Must run before uds_generated_init() (dtc_mirror_init() at
+     * Step 3.5 sits on top of nvm_store and silently no-ops until this
+     * succeeds). This example only targets native_sim, where
+     * platform/zephyr/nvm_store_mock.c (RAM-backed) is linked instead of
+     * the real NVS backend — its nvm_store_init() ignores cfg entirely, so
+     * NULL is correct here (see nvm_store.h: "may be NULL on host").
+     */
+    status = nvm_store_init(NULL);
+    if (status != UDS_STATUS_OK) {
+        LOG_ERR("[MC] NVM store init failed: 0x%02X — DTC mirror will not "
+                "survive reset this run.", (unsigned)status);
     }
 
     /* ── UDS stack init ────────────────────────────────────────────────────── */

--- a/examples/robot_joint_controller_ecu/src/main.c
+++ b/examples/robot_joint_controller_ecu/src/main.c
@@ -51,6 +51,7 @@
 #include "zephyr_mutex.h"
 #include "zephyr_timer.h"
 #include "zephyr_wdt.h"
+#include "nvm_store.h"
 #include "uds_init.h"
 #include "uds_security_algo.h"
 #include "generated_config.h"
@@ -296,6 +297,21 @@ int main(void)
     rc = zephyr_port_init(&port_cfg, &can);
     if (rc != UDS_STATUS_OK) {
         LOG_ERR("Platform init failed: 0x%02X", (unsigned)rc); return -1;
+    }
+
+    /* NVM store */
+    /*
+     * [EDS#200] Must run before uds_generated_init() (dtc_mirror_init() at
+     * Step 3.5 sits on top of nvm_store and silently no-ops until this
+     * succeeds). This example only targets native_sim, where
+     * platform/zephyr/nvm_store_mock.c (RAM-backed) is linked instead of
+     * the real NVS backend — its nvm_store_init() ignores cfg entirely, so
+     * NULL is correct here (see nvm_store.h: "may be NULL on host").
+     */
+    rc = nvm_store_init(NULL);
+    if (rc != UDS_STATUS_OK) {
+        LOG_ERR("NVM store init failed: 0x%02X — DTC mirror will not "
+                "survive reset this run.", (unsigned)rc);
     }
 
     /* Security */

--- a/examples/safeboot_ecu/src/main.c
+++ b/examples/safeboot_ecu/src/main.c
@@ -68,6 +68,7 @@
 #include "zephyr_mutex.h"
 #include "zephyr_timer.h"
 #include "zephyr_wdt.h"
+#include "nvm_store.h"
 
 /* --------------------------------------------------------------------------
  * Generated headers
@@ -83,6 +84,7 @@
 #include <zephyr/drivers/can.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/dfu/mcuboot.h>
+#include <zephyr/storage/flash_map.h>
 
 LOG_MODULE_REGISTER(safeboot_ecu, LOG_LEVEL_INF);
 
@@ -557,6 +559,50 @@ int main(void)
         }
     }
     LOG_INF("CAN transport ready.");
+
+    /* ── NVM store initialization ────────────────────────────────────────── */
+    /*
+     * [EDS#200] Must run before uds_generated_init(), which calls
+     * dtc_mirror_init() (Step 3.5) and, once security NVM persistence
+     * (#190) is wired for this product, uds_security_init() (Step 7) —
+     * both sit on top of nvm_store and silently no-op
+     * (nvm_store_is_ready() == false) until this call has succeeded.
+     *
+     * FIXED_PARTITION_DEVICE()/FIXED_PARTITION_OFFSET() take the DTS
+     * *node label* (eds_nvs_slot), not the partition's string "label"
+     * property ("diag_nvs") — passing the latter fails to compile with
+     * "'__device_dts_ord_DT_N_NODELABEL_diag_nvs...' undeclared" (caught
+     * in this PR's own CI, all three real-board Zephyr builds). The
+     * eds_nvs_slot node is defined in
+     * boards/nucleo_h743zi/nucleo_h743zi.overlay — see that overlay's
+     * "NVS flash partition for platform/nvm_store.c" comment block for the
+     * full STM32H743ZI flash layout. sector_size/sector_count below match
+     * that partition exactly (2 x 128 KB physical Bank-2 sectors — Zephyr
+     * NVS requires >= 2 sectors for wear levelling); if the partition
+     * geometry there ever changes, these two values must change with it.
+     */
+    {
+        const nvm_store_cfg_t nvm_cfg = {
+            .flash_dev    = (const void *)FIXED_PARTITION_DEVICE(eds_nvs_slot),
+            .flash_offset = (uint32_t)FIXED_PARTITION_OFFSET(eds_nvs_slot),
+            .sector_size  = (uint32_t)0x20000U, /* 128 KB */
+            .sector_count = (uint8_t)2U,
+        };
+
+        status = nvm_store_init(&nvm_cfg);
+        if (status != UDS_STATUS_OK) {
+            /* Non-fatal: DTC mirror / security persistence degrade
+             * gracefully (nvm_store_is_ready() == false) rather than
+             * crash — see docs/SECURITY_NOTICE.md and config/dtc_mirror.c.
+             * Diagnostics still start; persisted state is just unavailable
+             * for this power cycle. */
+            LOG_ERR("NVM store init failed: 0x%02X — DTC mirror and "
+                    "security persistence will not survive reset this "
+                    "power cycle.", (unsigned)status);
+        } else {
+            LOG_INF("NVM store ready (diag_nvs partition mounted).");
+        }
+    }
 
     /* ── Security algorithm init (TRNG + key injection) ─────────────────── */
     /* [P1-SEC] Must run before uds_generated_init() so the TRNG callback

--- a/examples/sensor_ecu/src/main.c
+++ b/examples/sensor_ecu/src/main.c
@@ -48,6 +48,7 @@
 #include "zephyr_mutex.h"
 #include "zephyr_timer.h"
 #include "zephyr_wdt.h"
+#include "nvm_store.h"
 #include "uds_init.h"
 #include "uds_security_algo.h"
 #include "generated_config.h"
@@ -319,6 +320,21 @@ int main(void)
     if (status != UDS_STATUS_OK) {
         LOG_ERR("Platform init failed.");
         return -1;
+    }
+
+    /* ── NVM store ───────────────────────────────────────────────────────── */
+    /*
+     * [EDS#200] Must run before uds_generated_init() (dtc_mirror_init() at
+     * Step 3.5 sits on top of nvm_store and silently no-ops until this
+     * succeeds). This example only targets native_sim, where
+     * platform/zephyr/nvm_store_mock.c (RAM-backed) is linked instead of
+     * the real NVS backend — its nvm_store_init() ignores cfg entirely, so
+     * NULL is correct here (see nvm_store.h: "may be NULL on host").
+     */
+    status = nvm_store_init(NULL);
+    if (status != UDS_STATUS_OK) {
+        LOG_ERR("NVM store init failed: 0x%02X — DTC mirror will not "
+                "survive reset this run.", (unsigned)status);
     }
 
     /* ── Security algo ───────────────────────────────────────────────────── */

--- a/platform/nvm_store.h
+++ b/platform/nvm_store.h
@@ -117,8 +117,13 @@ typedef struct nvm_store_cfg {
     /** Flash storage offset (NVS sector start, from DTS). */
     uint32_t    flash_offset;
 
-    /** NVS sector size in bytes (typically 4096 for most flash). */
-    uint16_t    sector_size;
+    /** NVS sector size in bytes (typically 4096 for most flash).
+     *  [EDS#200] uint32_t, not uint16_t: some real targets' physical erase
+     *  pages exceed 65535 bytes (e.g. STM32H743ZI and NXP MCX N947 both
+     *  use 128 KB = 0x20000 sectors — see boards/nucleo_h743zi/*.overlay
+     *  and boards/frdm_mcxn947/*.overlay). A uint16_t here silently
+     *  truncated 0x20000 to 0, which nvs_mount() would reject. */
+    uint32_t    sector_size;
 
     /** Number of NVS sectors to use for diagnostics NVM (minimum 2). */
     uint8_t     sector_count;


### PR DESCRIPTION
## Summary

Addresses #200 — per the issue owner's explicit instruction this PR does **not** close the issue; see the issue comment posted alongside this PR for why (real-hardware validation still pending).

`nvm_store_init()` was defined but never called anywhere in a real Zephyr init path — not `zephyr_port_init()`, not any example's `main()`, nowhere outside unit tests. `nvm_store_is_ready()` therefore returned `false` forever on every Zephyr build: DTC mirror persistence (already documented as surviving power cycles) and security counter/lockout persistence (once wired, #190) both silently never activated. Both degrade gracefully rather than crash, which is exactly why this went unnoticed. FreeRTOS was unaffected — `eds_platform_init()` already calls `nvm_store_init()`.

## Changes

Wired the missing call into `main()`, before `uds_generated_init()` (whose Step 3.5 calls `dtc_mirror_init()`, which needs `nvm_store` ready):

- **`basic_ecu`** — the one example CI actually cross-compiles for 4 different board targets (native_sim + nucleo_h743zi + frdm_mcxn947 + mr_canhubk3, each with its own `diag_nvs` DTS partition and physical erase-page size: 128 KB / 128 KB / 8 KB respectively). Resolves `FIXED_PARTITION_DEVICE`/`OFFSET`/`SIZE(diag_nvs)` and queries the real sector size at runtime via `flash_get_page_info_by_offs()` rather than hardcoding one — a single hardcoded value cannot be correct across boards with such different physical sector sizes.

  This surfaced a real latent bug: `nvm_store_cfg_t.sector_size` was `uint16_t`, which silently truncates 128 KB (`0x20000`) to 0 — would have broken `nvs_mount()` on 2 of the 3 real boards. Widened to `uint32_t` (`platform/nvm_store.h`); `s_nvs_fs.sector_size` was already `uint32_t` internally, so this is a pure widening with no other call site affected.

- **`safeboot_ecu`** — its board's `diag_nvs` partition and exact sector geometry are already fully documented in `boards/nucleo_h743zi/nucleo_h743zi.overlay` (added earlier for a different purpose) — wired directly from that. Not currently compiled by CI (`example-safeboot` only validates generated files), so this one is the most in need of the real-hardware validation this issue stays open for.

- **`basic_ecu_doip`, `bms_ecu`, `motor_controller_ecu`, `robot_joint_controller_ecu`, `sensor_ecu`** — native_sim-only targets, where `platform/zephyr/nvm_store_mock.c` (RAM-backed) is always linked regardless of what's passed — `nvm_store_init(NULL)` is correct and sufficient there (`nvm_store.h`: "may be NULL on host").

**`ardep_ecu` is a deliberate, documented exception, left unfixed**: `CONFIG_NVS=y` is set but no `diag_nvs` partition exists in its overlay, and the ARDEP board DTS itself lives in an external, non-vendored Zephyr module. Guessing a flash layout for hardware this repo has no visibility into is exactly the risk this issue originally flagged against. Not compiled by CI either way (`example-ardep` only validates generated files, no `west build`).

## Verification

- `bash build_tests.sh`: 45 passed, 912 cases, 0 failed — these files aren't part of the host test build, so this is a no-regression check, not positive verification of the new code.
- A local west workspace bring-up to compile-verify directly was attempted and abandoned (`west update` failed in this sandbox environment).
- Real verification for this fix is this project's actual Zephyr CI cross-compile jobs in this PR (native_sim + 3 real boards for `basic_ecu`) — please confirm all green before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)