### PR TITLE
docs: unit test count 44 → 45

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ For the full FreeRTOS integration guide (callbacks, NVM, reset, production porti
 ### Run the test suite
 
 ```bash
-# 44 Unity unit tests (host-native, no Zephyr SDK needed)
+# 45 Unity unit tests (host-native, no Zephyr SDK needed)
 bash build_tests.sh
 
 # 68 harness integration tests (Professional tier — requires harness/ sources)
@@ -323,7 +323,7 @@ Step 5  Data length correct?     → NRC 0x13 incorrectMessageLengthOrInvalidFor
 | `ide/vscode-extension/` | YAML validation, hover docs, Run Codegen command *(Developer/Professional tier)* |
 | `examples/` | basic\_ecu · basic\_ecu\_doip · basic\_ecu\_freertos · basic\_ecu\_doip\_freertos · sensor\_ecu · sensor\_ecu\_freertos · safeboot\_ecu · safeboot\_freertos\_ecu · robot\_joint\_controller\_ecu · bms\_ecu · motor\_controller\_ecu · ardep\_ecu · each with its own `generated/` subfolder |
 | `gui/` | React/TypeScript configurator + live dashboard *(Developer/Professional tier)* |
-| `tests/` | 44 Unity unit tests, harness, Python integration tests |
+| `tests/` | 45 Unity unit tests, harness, Python integration tests |
 
 ---
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -210,7 +210,7 @@ platform/
 tools/              codegen.py, testgen.py, mcp_server.py, 18 Jinja2 templates
 examples/           12 ECU examples — each with diagnostics_config.yaml + generated/
 gui/                React/TypeScript configurator and live dashboard
-tests/              44 Unity unit tests, Python integration tests, harness (68 tests)
+tests/              45 Unity unit tests, Python integration tests, harness (68 tests)
 ide/vscode-extension/  YAML validation, hover docs, Run Codegen command
 
 ## Requirements


### PR DESCRIPTION
Stale since round 3's `test_service_0x2E.c` (#203) and `test_uds_security.c`'s 3 new cases (#196) landed. Found via `xaloqi-knowledge`'s `check_release_docs.py` during a documentation-status sweep after round 3 merged; verified against a real `bash build_tests.sh` run (45 passed, 915 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)