### PR TITLE
fix: MISRA CI failure was a real -Wcomment hit, misattributed by tooling (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **"Static Analysis + MISRA C:2012" CI job failing: a `-Wcomment` GCC
+  warning inside `platform/nvm_store.h`, misattributed to whichever `.c`
+  file happened to `#include` it** (#206). Root cause was two separate
+  things, both fixed:
+  1. `sector_size`'s doc comment (added for #200) referenced
+     `boards/nucleo_h743zi/*.overlay` and `boards/frdm_mcxn947/*.overlay`
+     — the `/*` immediately after each path's `/` reads to GCC as a
+     nested-comment start inside the enclosing `/** ... */` doc comment.
+     Reworded to avoid the glob syntax.
+  2. `misra_analysis.py`'s GCC-based pass hardcoded every finding's
+     reported file to the top-level `.c` file being compiled
+     (`rel_file = str(src)`), discarding GCC's own correctly-reported
+     `file:line` when a warning actually originates inside an
+     `#include`d header. This made the one real, fully deterministic
+     header issue above look like 6 separate findings scattered across
+     3 unrelated `.c` files that merely happen to include
+     `nvm_store.h` (`config/dtc_mirror.c`, `core/uds_security_nvm.c`,
+     `core/uds_session_stats.c`) — misdiagnosed in #206's original
+     filing as cppcheck non-determinism. Fixed to use GCC's own
+     reported file; the existing `(file, line, rule)` dedup key now also
+     correctly collapses a shared header finding into one entry instead
+     of one per including translation unit, rather than inflating the
+     open-violation count.
+
+  Verified locally via `python3 misra_analysis.py --gcc-only`
+  (cppcheck unavailable in this environment): 0 open violations, down
+  from 7 GCC findings (6 open) before the fix; `bash build_tests.sh`
+  unaffected (comment-only + tooling change, 45 passed, 915 cases).
+
 - **`nvm_store_init()` never called anywhere in the real Zephyr platform
   init — NVM persistence (DTC mirror, and security counter/lockout
   persistence once wired) silently non-functional** (#200; found while

--- a/misra_analysis.py
+++ b/misra_analysis.py
@@ -1557,7 +1557,18 @@ def run_gcc_analysis(
                 continue
 
             flag      = m.group("flag") or ""
-            rel_file  = str(src)
+            # [EDS#206] Use the diagnostic's own reported file, not the
+            # top-level .c file being compiled. GCC correctly reports the
+            # file:line where a warning actually originates, including
+            # inside an #included header -- hardcoding str(src) here
+            # misattributed every header-originated finding (e.g. a
+            # -Wcomment hit inside platform/nvm_store.h) to whichever .c
+            # file happened to include that header and get compiled,
+            # once per such .c file. That looked like the same finding
+            # non-deterministically appearing in different, unrelated
+            # files across runs -- it was one real, fully deterministic
+            # finding, just reported under the wrong file every time.
+            rel_file  = m.group("file") or str(src)
             line_no   = int(m.group("line"))
             message   = m.group("message").strip()
 

--- a/platform/nvm_store.h
+++ b/platform/nvm_store.h
@@ -120,9 +120,9 @@ typedef struct nvm_store_cfg {
     /** NVS sector size in bytes (typically 4096 for most flash).
      *  [EDS#200] uint32_t, not uint16_t: some real targets' physical erase
      *  pages exceed 65535 bytes (e.g. STM32H743ZI and NXP MCX N947 both
-     *  use 128 KB = 0x20000 sectors — see boards/nucleo_h743zi/*.overlay
-     *  and boards/frdm_mcxn947/*.overlay). A uint16_t here silently
-     *  truncated 0x20000 to 0, which nvs_mount() would reject. */
+     *  use 128 KB = 0x20000 sectors — see boards/nucleo_h743zi and
+     *  boards/frdm_mcxn947's board overlay files). A uint16_t here
+     *  silently truncated 0x20000 to 0, which nvs_mount() would reject. */
     uint32_t    sector_size;
 
     /** Number of NVS sectors to use for diagnostics NVM (minimum 2). */


### PR DESCRIPTION
## Summary

Closes #206.

The original filing of #206 concluded the "Static Analysis + MISRA C:2012" job's failure was cppcheck non-determinism. That was wrong — it's a real, 100% deterministic GCC `-Wcomment` warning caused by my own #200 fix, that a genuine tooling bug in `misra_analysis.py` made look like flaky cross-file noise.

## Root cause (two parts)

1. **`platform/nvm_store.h`'s `sector_size` doc comment** (added in #205/#200) reads `boards/nucleo_h743zi/*.overlay` — the `/` immediately followed by `*.overlay` is lexically `/*` to GCC's comment scanner, read as a nested-comment-open inside the enclosing `/** ... */` doc comment. Reworded both occurrences (nucleo_h743zi and frdm_mcxn947) to drop the glob syntax.
2. **`misra_analysis.py`'s GCC-based pass hardcoded every finding's reported file** to whichever top-level `.c` file was being compiled (`rel_file = str(src)`), discarding GCC's own correctly-reported `file:line` when a diagnostic actually originates inside an `#include`d header. Since 3 unrelated `.c` files (`config/dtc_mirror.c`, `core/uds_security_nvm.c`, `core/uds_session_stats.c`) all transitively include `nvm_store.h`, the *one* real header issue got reported once per including translation unit and attributed to each of their filenames instead of `nvm_store.h`'s — exactly what read as "the same finding non-deterministically appearing in different files across runs" during #206's original investigation.

   Fixed to use GCC's own reported file. A direct, independent benefit: the existing `(file, line, rule)` dedup key in `build_report()` now correctly collapses a shared header finding into one entry instead of inflating the open-violation count once per including `.c` file — and a future deviation record scoped to one `.c` file can no longer accidentally absorb an unrelated header's finding.

## Verification

- `python3 misra_analysis.py --gcc-only` (cppcheck unavailable in this sandbox): **7 GCC findings / 6 open → 1 GCC finding / 0 open** after both fixes.
- Directly reproduced the exact `-Wcomment` warning with a standalone `gcc` invocation replicating `misra_analysis.py`'s flags, before and after the comment edit.
- `bash build_tests.sh`: 45 passed, 915 cases, 0 failed — unaffected, as expected (doc comment + tooling only, no runtime code touched).
- This PR's own CI (which does have cppcheck) is the final confirmation — watching now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)