### PR TITLE
harden: FreeRTOS production guards + DoIP connection limits (#215, #218)

### DIFF
--- a/build_tests.sh
+++ b/build_tests.sh
@@ -790,8 +790,81 @@ else
 fi
 echo ""
 
-if [[ ${BUILD_MODE_PROBE_FAIL} -ne 0 || ${CRIT4_FAIL} -ne 0 ]]; then
-    echo "FAIL: build-mode gate verification (SEC-BUILD-MODE-01 / SEC-KEY-GATE-01) failed."
+# ---------------------------------------------------------------------------
+# [EDS#215] Negative compile test — FreeRTOS RAM-stub flash production guard.
+#
+# Mirrors the CRIT-4 negative compile test above: proves the
+# freertos_flash_ops.c RAM-stub #error (mirroring SEC-KEY-GATE-01) is
+# actually reachable. Compiling the file with
+# -DCONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0 (production), without -DUNIT_TEST,
+# and without STM32H7xx/STM32H743xx defined (so the RAM stub backend is
+# selected) must FAIL to compile, citing EDS#215.
+#
+# Only the STM32H7xx HAL backend is skipped here (that branch needs the
+# vendored STM32Cube HAL headers this repo does not carry) — the RAM stub
+# backend under test has no such dependency, so this compiles cleanly on
+# the host like the CRIT-4 test above.
+# ---------------------------------------------------------------------------
+EDS215_TMP_OBJ="$(mktemp -u /tmp/eds_215_negtest.XXXXXX.o)"
+EDS215_INCLUDES=(
+    "${INCLUDES[@]}"
+    "-I${ROOT}/platform/freertos"
+)
+
+echo "================================================================"
+echo "  [EDS#215] FreeRTOS flash-stub production guard negative compile test"
+echo "================================================================"
+echo ""
+
+eds215_neg_out=$(
+    gcc -std=c11 -c -DCONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0 -DEDS_MSG_BUF_MAX_STACK_BYTES=8192 \
+        "${EDS215_INCLUDES[@]}" "${ROOT}/platform/freertos/freertos_flash_ops.c" -o "${EDS215_TMP_OBJ}" 2>&1
+) && eds215_neg_rc=0 || eds215_neg_rc=$?
+rm -f "${EDS215_TMP_OBJ}"
+
+EDS215_FAIL=0
+if [[ ${eds215_neg_rc} -ne 0 ]] && echo "${eds215_neg_out}" | grep -q "EDS#215"; then
+    echo "  PASS: production build (CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0, no UNIT_TEST,"
+    echo "        no STM32H7xx) correctly FAILS to compile, citing EDS#215."
+else
+    echo "  FAIL: expected an EDS#215 compile failure, got:"
+    echo "        rc=${eds215_neg_rc}"
+    echo "${eds215_neg_out}" | sed 's/^/        /'
+    EDS215_FAIL=1
+fi
+echo ""
+
+# Regression guard: the same file, same production config, but with
+# STM32H7xx defined (the real hardware backend) must NOT hit the RAM-stub
+# gate. It is expected to fail for an unrelated reason (this repo does not
+# vendor the STM32Cube HAL headers) — the check here is only that the
+# failure is a missing-header error, never an EDS#215 gate firing on the
+# real-hardware branch.
+eds215_pos_out=$(
+    gcc -std=c11 -c -DCONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=0 -DEDS_MSG_BUF_MAX_STACK_BYTES=8192 -DSTM32H743xx \
+        "${EDS215_INCLUDES[@]}" "${ROOT}/platform/freertos/freertos_flash_ops.c" -o "${EDS215_TMP_OBJ}" 2>&1
+) && eds215_pos_rc=0 || eds215_pos_rc=$?
+rm -f "${EDS215_TMP_OBJ}"
+
+if echo "${eds215_pos_out}" | grep -q "EDS#215"; then
+    echo "  FAIL: EDS#215 gate incorrectly fired on the STM32H7xx HAL backend"
+    echo "        (production hardware build, not the RAM stub):"
+    echo "${eds215_pos_out}" | sed 's/^/        /'
+    EDS215_FAIL=1
+elif [[ ${eds215_pos_rc} -ne 0 ]] && echo "${eds215_pos_out}" | grep -qi "stm32h7xx_hal.h"; then
+    echo "  PASS: STM32H7xx HAL backend selected (not the RAM stub) — EDS#215"
+    echo "        gate correctly did not fire; unrelated failure is the"
+    echo "        expected missing vendored HAL header."
+else
+    echo "  FAIL: expected a missing-stm32h7xx_hal.h failure (or success), got:"
+    echo "        rc=${eds215_pos_rc}"
+    echo "${eds215_pos_out}" | sed 's/^/        /'
+    EDS215_FAIL=1
+fi
+echo ""
+
+if [[ ${BUILD_MODE_PROBE_FAIL} -ne 0 || ${CRIT4_FAIL} -ne 0 || ${EDS215_FAIL} -ne 0 ]]; then
+    echo "FAIL: build-mode gate verification (SEC-BUILD-MODE-01 / SEC-KEY-GATE-01 / EDS#215) failed."
     exit 1
 fi
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -658,6 +658,37 @@ Global env: `XALOQI_LICENSE_SKIP=1` (codegen bypasses license check in CI — `_
 
 ---
 
+## 14.5. FreeRTOS vs Zephyr Platform Support Matrix
+
+[EDS#215] A side-by-side reference for evaluating which platform port to
+commit to — current backend and CI validation depth per subsystem, as of
+this release. This documents current state; it is distinct in scope from
+the broader hardware-dependent qualification-evidence work already tracked
+in #155 (WCET, HiL, fault injection — needs real hardware).
+
+| Subsystem | Zephyr | FreeRTOS |
+|---|---|---|
+| Transport (CAN / ISO-TP) | `platform/zephyr/zephyr_can.c` — Zephyr CAN driver API | `platform/freertos/freertos_can.c` — customer-provided `can_send` callback |
+| Transport (DoIP) | `transport/doip/zephyr_lwip.c` — Zephyr socket API (`zsock_*`) | `transport/doip/freertos_lwip.c` — LwIP BSD-socket API (`lwip_*`) |
+| Flash (SID 0x34–0x37 download services) | `platform/zephyr/zephyr_flash_ops.c` — real Zephyr flash API (DTS flash-map, board-backed) | `platform/freertos/freertos_flash_ops.c` — real STM32H743 HAL backend when `STM32H7xx`/`STM32H743xx` is defined; RAM stub otherwise. **A production build now fails to compile if it resolves to the RAM stub — see EDS#215 / SEC-KEY-GATE-01-style guard.** |
+| NVM (DID persistence, DTC mirror, session stats) | `platform/zephyr/zephyr_platform_api.c` — wired into real Zephyr `nvm_store_init()` paths | Customer-supplied NVM ops (persistent), or built-in RAM stub if none are supplied. **`eds_platform_init()` now fails closed (`UDS_STATUS_ERR_INVALID_PARAM`) rather than silently starting on the RAM stub in a production build — see EDS#215.** |
+| Security (SID 0x27 SecurityAccess) | `core/uds_security_algo.c` — shared, platform-agnostic | Same shared module — see §5 Security Manager and the single-security-context-per-process constraint (EDS#214) |
+| CI — simulator/emulator | `zephyr-native` job: `native_sim`, full test suite | `freertos-qemu` / `freertos-safeboot` jobs: QEMU Cortex-M4 (RAM stub flash — `freertos-safeboot` job name says so explicitly) |
+| CI — real-hardware cross-compile | `zephyr-stm32` (nucleo_h743zi), `zephyr-nxp` (frdm_mcxn947), `zephyr-nxp-s32k` (mr_canhubk3/S32K344) — 3 boards, compile-only | None — no FreeRTOS cross-compile CI job targets real hardware today |
+| HiL validation | Planned (Nucleo-H743ZI2 overlay written — see §14 Target Hardware); not yet executed in CI for either platform | Same — not yet executed in CI for either platform |
+
+**Reading this table:** Zephyr's flash and NVM backends both reach real
+hardware-facing code paths in every configuration; FreeRTOS's only do so
+when the integrator wires real ops (flash: define `STM32H7xx`/`STM32H743xx`
+and use the HAL backend; NVM: supply `read`/`write`/`is_ready` callbacks in
+`eds_platform_cfg_t`) — the EDS#215 guards above exist specifically because
+that wiring was previously optional even in a build declaring itself
+production. Zephyr also currently has broader real-hardware cross-compile
+CI coverage (three boards vs. none for FreeRTOS); neither platform has
+executed HiL validation yet.
+
+---
+
 ## 15. Extensibility
 
 The architecture supports future extensions without structural changes:

--- a/platform/freertos/freertos_flash_ops.c
+++ b/platform/freertos/freertos_flash_ops.c
@@ -29,6 +29,7 @@
 
 #include "freertos_flash_ops.h"
 #include "uds_flash_ops.h"
+#include "uds_security_algo.h" /* EDS_BUILD_IS_PRODUCTION, SEC-BUILD-MODE-01 */
 #include "uds_transfer_ctx.h"
 #include "uds_types.h"
 
@@ -200,6 +201,41 @@ static uds_status_t h7_flash_verify(uint32_t address,
  * Matches the flash layout constants but uses a static buffer.
  * Not suitable for production — flash writes are not persistent.
  */
+
+/* =============================================================================
+ * [EDS#215] Compile-time production guard for the RAM stub backend
+ *
+ * This RAM stub is a legitimate CI/QEMU fallback (no persistent flash
+ * hardware to target), but nothing previously stopped it from being
+ * silently linked into a real production build for a FreeRTOS MCU other
+ * than STM32H7xx (or an STM32H7xx build that forgot to define the guard
+ * macro) — no compile or link error, no warning, just a flash driver that
+ * discards every write on reset.
+ *
+ * Mirrors the existing SEC-KEY-GATE-01 pattern (core/uds_security_algo.c):
+ * when EDS_BUILD_IS_PRODUCTION (core/uds_security_algo.h,
+ * SEC-BUILD-MODE-01) is true, this stub becomes a hard compile failure
+ * instead of silently linking, forcing the integrator to either wire a
+ * real flash backend for their MCU or explicitly keep the build
+ * non-production (EDS_BUILD_IS_PRODUCTION=0 / the FreeRTOS
+ * CONFIG_DIAG_PLACEHOLDER_KEYS_ONLY=1 dev default) while still on the
+ * stub. `!defined(UNIT_TEST)` carries the same host-test exemption as
+ * SEC-KEY-GATE-01 — the host unit-test build has no flash hardware target
+ * at all and legitimately always uses this stub, including runs that
+ * force EDS_BUILD_IS_PRODUCTION=1 to exercise some other gate's
+ * production behaviour.
+ *
+ * TRACEABILITY: EDS#215, mirrors SEC-KEY-GATE-01 / CRIT-4.
+ * ============================================================================= */
+#if EDS_BUILD_IS_PRODUCTION && !defined(UNIT_TEST)
+#error "[EDS#215] Production build declared (EDS_BUILD_IS_PRODUCTION=1) but " \
+       "freertos_flash_ops.c is compiling its RAM-backed stub flash backend " \
+       "(neither STM32H7xx nor STM32H743xx is defined). This stub discards " \
+       "every flash write on reset and must never ship in production. Wire a " \
+       "real flash backend for your MCU (see the STM32H743 HAL backend above " \
+       "for the expected uds_flash_ops_t shape), or keep this build " \
+       "explicitly non-production if it is CI/QEMU-only."
+#endif
 
 #define STUB_FLASH_SIZE  (FREERTOS_FLASH_OTA_SIZE)
 

--- a/platform/freertos/freertos_platform_api.c
+++ b/platform/freertos/freertos_platform_api.c
@@ -41,6 +41,14 @@
  *            registered NVM ops, those are called; otherwise the RAM stub
  *            is used (data is lost on reset — only for development).
  *
+ *          [EDS#215] PRODUCTION GUARD: eds_platform_init() fails closed
+ *            (returns UDS_STATUS_ERR_INVALID_PARAM) instead of silently
+ *            activating the RAM NVM stub when EDS_BUILD_IS_PRODUCTION is
+ *            true and no customer NVM ops were supplied — see the gate in
+ *            eds_platform_init() below. Mirrors freertos_flash_ops.c's
+ *            compile-time #error for the same class of risk on the flash
+ *            side (SEC-KEY-GATE-01 pattern).
+ *
  * SAFETY  : ASIL-B candidate. Reset path is safety-relevant.
  * STANDARD: MISRA C:2012 alignment intended.
  * =============================================================================
@@ -50,6 +58,7 @@
 #include "freertos_can.h"
 #include "nvm_store.h"
 #include "dtc_mirror.h"
+#include "uds_security_algo.h" /* EDS_BUILD_IS_PRODUCTION, SEC-BUILD-MODE-01 */
 #include "uds_session_stats.h"
 #include "uds_types.h"
 
@@ -257,8 +266,27 @@ uds_status_t eds_platform_init(const eds_platform_cfg_t *cfg)
     else
     {
         /*
-         * No customer NVM ops — activate the built-in RAM stub.
-         * Clear state and register stub ops with freertos_nvm.c.
+         * [EDS#215] No customer NVM ops. Unlike the STM32H7xx flash
+         * backend selection (freertos_flash_ops.c), this fallback is a
+         * runtime decision driven by cfg->nvm, not a compile-time #if — a
+         * plain #error here cannot see which branch a given build will
+         * actually take. So the fail-closed check has to live here, at
+         * the point the stub would otherwise be silently activated:
+         * refuse to start in a build declared production
+         * (EDS_BUILD_IS_PRODUCTION, core/uds_security_algo.h,
+         * SEC-BUILD-MODE-01) rather than silently run on a non-persistent
+         * RAM stub that loses all NVM state on every reset.
+         * `!defined(UNIT_TEST)` carries the same host-test exemption as
+         * SEC-KEY-GATE-01 — host unit tests legitimately use the stub,
+         * including runs that force EDS_BUILD_IS_PRODUCTION=1 to exercise
+         * some other gate's production behaviour.
+         */
+#if EDS_BUILD_IS_PRODUCTION && !defined(UNIT_TEST)
+        return UDS_STATUS_ERR_INVALID_PARAM;
+#else
+        /*
+         * Activate the built-in RAM stub. Clear state and register stub
+         * ops with freertos_nvm.c.
          */
         (void)memset(s_nvm_records, 0, sizeof(s_nvm_records));
         s_nvm_stub_ready = false;
@@ -268,6 +296,7 @@ uds_status_t eds_platform_init(const eds_platform_cfg_t *cfg)
         s_nvm_ops.is_ready = nvm_stub_is_ready;
 
         freertos_nvm_register_ops(&s_nvm_ops);
+#endif
     }
 
     /* Activate the nvm_store layer (writes schema version record). */

--- a/transport/doip/doip_server.c
+++ b/transport/doip/doip_server.c
@@ -420,6 +420,17 @@ uds_status_t doip_handle_frame(doip_server_state_t *s,
  * Blocking server loop. One connection at a time per logical address.
  * Multiple clients connect sequentially; concurrent clients share the same
  * UDS session (routing_active is reset on new connection).
+ *
+ * [EDS#218] Two additional bounds beyond the per-read timeout
+ * (DOIP_TCP_RECV_TIMEOUT_MS) and per-frame read-attempt cap
+ * (DOIP_MAX_FRAME_READ_ATTEMPTS, EDS#193):
+ *   - DOIP_MAX_CONNECTION_FRAMES forces a disconnect after that many
+ *     frames on one connection, bounding both connection lifetime and
+ *     in-connection request rate.
+ *   - DOIP_RAPID_RECONNECT_THRESHOLD / DOIP_RECONNECT_BACKOFF_REJECTS
+ *     reject new connections outright for a while after a burst of
+ *     connections that never dispatched a single frame, mitigating
+ *     connect/disconnect cycling.
  * ------------------------------------------------------------------------ */
 
 uds_status_t eds_doip_server_run(doip_server_state_t *s,
@@ -439,12 +450,32 @@ uds_status_t eds_doip_server_run(doip_server_state_t *s,
         return UDS_STATUS_ERR_PLATFORM;
     }
 
+    /* [EDS#218] Rapid-reconnect tracking across connections — see
+     * DOIP_RAPID_RECONNECT_THRESHOLD / DOIP_RECONNECT_BACKOFF_REJECTS in
+     * doip_server.h for the rationale (no direct wall-clock in this
+     * file, so a bounded-count proxy is used instead of a real cooldown
+     * timer). */
+    uint32_t rapid_reconnects          = 0U;
+    uint32_t backoff_rejects_remaining = 0U;
+
     /* Accept → receive → handle → repeat */
     for (;;) {
         void *conn_ctx = NULL;
-        rc = s_ops->tcp_accept(server_ctx, &conn_ctx, 5000U /* 5s poll */);
+        rc = s_ops->tcp_accept(server_ctx, &conn_ctx, DOIP_ACCEPT_POLL_TIMEOUT_MS);
         if (rc != 0) {
             /* Timeout or transient error — keep listening */
+            continue;
+        }
+
+        if (backoff_rejects_remaining > 0U) {
+            /* [EDS#218] Reject outright: this connection follows a burst
+             * of connections that never completed any real work (see
+             * DOIP_RAPID_RECONNECT_THRESHOLD below), so it is treated as
+             * part of a connect/disconnect-cycling pattern rather than
+             * given a full serial slot. */
+            s_ops->tcp_close(conn_ctx);
+            backoff_rejects_remaining--;
+            s->connections_rate_rejected++;
             continue;
         }
 
@@ -452,6 +483,13 @@ uds_status_t eds_doip_server_run(doip_server_state_t *s,
         s->routing_active = false;
         s->tester_address = 0U;
         s->conn_ctx       = conn_ctx;
+
+        /* [EDS#218] Frames dispatched on this connection so far — bounds
+         * both total connection lifetime and in-connection request rate
+         * via DOIP_MAX_CONNECTION_FRAMES (see doip_server.h), and tells
+         * the rapid-reconnect tracking below whether this connection did
+         * any real work. */
+        uint32_t conn_frame_count = 0U;
 
         /* Per-connection receive loop */
         for (;;) {
@@ -544,6 +582,17 @@ uds_status_t eds_doip_server_run(doip_server_state_t *s,
                  * headers, rather than keep reading frames on it. */
                 goto connection_closed;
             }
+
+            /* [EDS#218] Enforce the per-connection frame cap — see
+             * DOIP_MAX_CONNECTION_FRAMES in doip_server.h. Force a
+             * disconnect once reached, same cleanup path as any other
+             * connection-ending condition, so the single serial slot is
+             * freed for the next client. */
+            conn_frame_count++;
+            if (conn_frame_count >= (uint32_t)DOIP_MAX_CONNECTION_FRAMES) {
+                s->connections_lifetime_capped++;
+                goto connection_closed;
+            }
         }
 
 connection_closed:
@@ -551,6 +600,22 @@ connection_closed:
         s->conn_ctx       = NULL;
         s->routing_active = false;
         s->tester_address = 0U;
+
+        /* [EDS#218] Rapid-reconnect tracking: a connection that never
+         * dispatched a single frame (malformed header, no routing
+         * activation, immediate disconnect, ...) counts toward the
+         * connect/disconnect-cycling threshold; any connection that did
+         * real work resets it. See DOIP_RAPID_RECONNECT_THRESHOLD /
+         * DOIP_RECONNECT_BACKOFF_REJECTS in doip_server.h. */
+        if (conn_frame_count > 0U) {
+            rapid_reconnects = 0U;
+        } else {
+            rapid_reconnects++;
+            if (rapid_reconnects >= (uint32_t)DOIP_RAPID_RECONNECT_THRESHOLD) {
+                backoff_rejects_remaining = (uint32_t)DOIP_RECONNECT_BACKOFF_REJECTS;
+                rapid_reconnects = 0U;
+            }
+        }
 
         /* [EDS#191] Reset UDS session/security state on every disconnect —
          * only DoIP-layer routing state was reset above. Without this, a

--- a/transport/doip/doip_server.h
+++ b/transport/doip/doip_server.h
@@ -127,6 +127,55 @@ extern "C" {
 #define DOIP_MAX_FRAME_READ_ATTEMPTS (256U)
 #endif
 
+/** Poll timeout for each eds_doip_server_run() tcp_accept() call while no
+ * client is connected — how often the accept loop wakes up to re-check. */
+#ifndef DOIP_ACCEPT_POLL_TIMEOUT_MS
+#define DOIP_ACCEPT_POLL_TIMEOUT_MS (5000U)
+#endif
+
+/**
+ * [EDS#218] Maximum diagnostic frames dispatched on one TCP connection
+ * before the server forces a disconnect, freeing the single serial slot
+ * (DOIP_MAX_CONNECTIONS is a listen() backlog, not a concurrency limit —
+ * see eds_doip_server_run()) for the next client. This is also the
+ * mechanism that bounds total connection lifetime: this file has no
+ * direct RTOS clock access — all platform interaction is ops-only (see
+ * file header) — so, exactly like DOIP_MAX_FRAME_READ_ATTEMPTS above
+ * (EDS#193), a bounded count stands in for a wall-clock deadline. A
+ * client sending valid traffic slowly enough to stay under
+ * DOIP_TCP_RECV_TIMEOUT_MS on every read, and so never trip the
+ * per-frame read-attempt bound, would otherwise be able to hold the
+ * single active connection indefinitely.
+ */
+#ifndef DOIP_MAX_CONNECTION_FRAMES
+#define DOIP_MAX_CONNECTION_FRAMES (500U)
+#endif
+
+/**
+ * [EDS#218] Consecutive connections that dispatch zero diagnostic frames
+ * (connect, then close/error/timeout before a single DiagnosticMessage is
+ * handled — e.g. malformed header, no routing activation, or an
+ * immediate disconnect) before the server treats accept-cycling as
+ * abusive and starts rejecting new connections outright. Resets to 0 the
+ * moment any connection dispatches at least one frame. Mitigates
+ * repeated connect/disconnect cycling used to keep re-acquiring the
+ * single serial connection slot without ever doing real work on it.
+ */
+#ifndef DOIP_RAPID_RECONNECT_THRESHOLD
+#define DOIP_RAPID_RECONNECT_THRESHOLD (8U)
+#endif
+
+/**
+ * [EDS#218] Number of subsequent connection attempts rejected outright
+ * (accepted, then immediately closed with no processing) once
+ * DOIP_RAPID_RECONNECT_THRESHOLD is hit. Counts down per rejected
+ * attempt rather than a wall-clock cooldown, for the same "no direct
+ * RTOS clock" reason as DOIP_MAX_CONNECTION_FRAMES above.
+ */
+#ifndef DOIP_RECONNECT_BACKOFF_REJECTS
+#define DOIP_RECONNECT_BACKOFF_REJECTS (4U)
+#endif
+
 /* ============================================================================
  * Platform operations — implement one set per RTOS/IP-stack combination.
  *
@@ -226,6 +275,12 @@ typedef struct doip_server_state {
     uds_msg_buf_t uds_resp;       /**< Static UDS response buffer — never on task stack. */
     uint32_t frames_received;    /**< Diagnostic counter: total frames received. */
     uint32_t frames_sent;        /**< Diagnostic counter: total frames sent. */
+    /** [EDS#218] Resource-accounting counters — connections force-closed
+     * for hitting DOIP_MAX_CONNECTION_FRAMES, and connection attempts
+     * rejected outright during a DOIP_RECONNECT_BACKOFF_REJECTS window.
+     * Diagnostic/telemetry only; never reset except at server init. */
+    uint32_t connections_lifetime_capped;
+    uint32_t connections_rate_rejected;
 } doip_server_state_t;
 
 /* ============================================================================


### PR DESCRIPTION
## Summary

Consolidates two hardening issues from the 2026-09-02 Software Integrator feedback batch into one PR — both are FreeRTOS/transport hardening in the same "fail-closed on missing production config" spirit, kept separate from the mechanical fixes in #219.

### Closes #215 — compile-time production guard for FreeRTOS RAM flash/NVM stubs + platform support matrix

- **`platform/freertos/freertos_flash_ops.c`**: when `EDS_BUILD_IS_PRODUCTION` is true (and not a host unit test), compiling the RAM-backed stub flash backend (neither `STM32H7xx` nor `STM32H743xx` defined) is now a hard `#error`, citing EDS#215 — mirrors `core/uds_security_algo.c`'s existing `SEC-KEY-GATE-01` / CRIT-4 gate.
- **`platform/freertos/freertos_platform_api.c`**: `eds_platform_init()` now fails closed (`UDS_STATUS_ERR_INVALID_PARAM`) instead of silently activating the non-persistent RAM NVM stub when `EDS_BUILD_IS_PRODUCTION` is true and the customer didn't supply real NVM ops. This one is a *runtime* gate rather than a `#error` — unlike the flash backend (chosen entirely by preprocessor macros), which NVM backend runs is a runtime decision driven by `eds_platform_cfg_t`.
- Both reuse the existing `EDS_BUILD_IS_PRODUCTION` primitive (`SEC-BUILD-MODE-01`, `core/uds_security_algo.h`) rather than inventing a second, competing "is this production" macro — the grep in the issue found no `EDS_PRODUCTION` symbol, but this shared primitive already exists under a different name and is the correct one to reuse (the class of bug issue #84 already fixed once).
- **`build_tests.sh`**: new EDS#215 negative-compile test (mirrors the existing CRIT-4 negative-compile test) proves the flash gate is actually reachable in a production build, plus a regression check that it does *not* fire on the real STM32H7xx HAL backend.
- **`docs/ARCHITECTURE.md`**: new §14.5 FreeRTOS vs Zephyr platform support matrix — transport/flash/NVM/security backend and CI validation depth side by side, distinct in scope from the broader hardware-qualification work tracked in #155.

### Closes #218 — DoIP connection-lifetime cap + request/connection rate limiting

`transport/doip/doip_server.c` cannot call an RTOS clock directly (all platform interaction is ops-only — the same constraint EDS#193's read-attempt bound already works around), so the new limits use the same bounded-count-as-clock-proxy approach instead of a wall-clock deadline:

- **`DOIP_MAX_CONNECTION_FRAMES`**: forces a disconnect after that many frames on one connection, bounding both total connection lifetime and in-connection request rate — a slow-but-valid client can no longer hold the single serial connection slot indefinitely.
- **`DOIP_RAPID_RECONNECT_THRESHOLD` / `DOIP_RECONNECT_BACKOFF_REJECTS`**: after a run of connections that never dispatched a single frame, the server starts rejecting new connections outright for a while — mitigates connect/disconnect cycling used to keep re-acquiring the slot without doing real work.
- New `doip_server_state_t` counters (`connections_lifetime_capped`, `connections_rate_rejected`) for resource-accounting/telemetry, per the issue's ask.
- `DOIP_ACCEPT_POLL_TIMEOUT_MS` names the previously-inline 5000ms accept poll literal, reused by the new backoff logic.

All new limits are configurable compile-time constants (`#ifndef`-guarded), consistent with every other `DOIP_*` tunable in `doip_server.h`.

## Testing

- `bash build_tests.sh`: **915/915 unit test cases pass, 0 failed** (0 regressions), including the new EDS#215 negative-compile test and its STM32H7xx-backend regression check.
- Manually verified both `eds_platform_init()` branches (dev/production) compile cleanly via a standalone syntax check against a real FreeRTOS example's generated headers (no host-test harness exists for `platform/freertos/*.c` today, so this isn't part of `build_tests.sh`).
- `misra_analysis.py --gcc-only` over `transport/doip` and `platform/freertos`: 0 new findings (the 4 pre-existing findings are all in files this PR doesn't touch).
- The DoIP connection-loop changes (lifetime cap, rapid-reconnect backoff) live inside `eds_doip_server_run()`'s blocking loop, which — like the existing EDS#193 read-attempt bound in the same loop — has no direct unit-test harness (it never returns in normal operation); `doip_handle_frame()` and header parsing, which the existing 30-case `test_doip_server` suite exercises, are unchanged and still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTiWQPZe6NL5y6ma8S9bXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTiWQPZe6NL5y6ma8S9bXQ)_