### PR TITLE
release: bump version 1.13.2 -> 1.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+## [1.13.3] — 2026-09-02
+
 ### Security
 
 - **SecurityAccess lockout NVM persistence was two independent,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@
 #
 # SAFETY CONTEXT : Contains ASIL-B candidate modules (ISO 26262 Part 6).
 # CODING STANDARD: MISRA C:2012 alignment intended.
-# VERSION        : 1.13.2
+# VERSION        : 1.13.3
 # SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 
@@ -74,7 +74,7 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(zephyr_diagnostics_suite
-    VERSION     1.13.2
+    VERSION     1.13.3
     LANGUAGES   C
     DESCRIPTION "Production-grade UDS/ISO-TP diagnostics stack for Zephyr RTOS"
 )

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 > repo. Community users cloning the public repo can ignore this file.
 
 **Product:** Xaloqi EDS (Xaloqi Embedded Diagnostic Suite)  
-**Version:** v1.13.2  
+**Version:** v1.13.3  
 **Support:** contact@xaloqi.com
 
 ---
@@ -50,7 +50,7 @@ cd EDS
 Verify you are on the correct version:
 
 ```bash
-git checkout v1.13.2
+git checkout v1.13.3
 ```
 
 ---
@@ -59,10 +59,10 @@ git checkout v1.13.2
 
 ```bash
 # From the EDS repo root:
-unzip -o /path/to/xaloqi-eds-developer-v1.13.2.zip
+unzip -o /path/to/xaloqi-eds-developer-v1.13.3.zip
 
 # Or for Professional:
-unzip -o /path/to/xaloqi-eds-professional-v1.13.2.zip
+unzip -o /path/to/xaloqi-eds-professional-v1.13.3.zip
 ```
 
 The `-o` flag overwrites existing files without prompting — required when updating an existing installation.
@@ -75,7 +75,7 @@ The `-o` flag overwrites existing files without prompting — required when upda
 >
 > ```bash
 > rm -f tools/templates tools/testgen.py tools/_license.py harness
-> unzip -o /path/to/xaloqi-eds-developer-v1.13.2.zip
+> unzip -o /path/to/xaloqi-eds-developer-v1.13.3.zip
 > ```
 
 This extracts the toolchain files directly into the repo tree. No separate directory. After extraction you will have:
@@ -185,7 +185,7 @@ Expected output:
 
 ```
 ========================================================================
-  Xaloqi EDS — Code Generator v1.13.2
+  Xaloqi EDS — Code Generator v1.13.3
 ========================================================================
   Config   : examples/bms_ecu/diagnostics_config.yaml
   ...

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Xaloqi Embedded Diagnostics Suite
 
 [![CI](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml/badge.svg)](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-v1.13.2-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.13.2)
+[![Version](https://img.shields.io/badge/version-v1.13.3-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.13.3)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](LICENSE)
 [![Zephyr](https://img.shields.io/badge/Zephyr-v3.7%2B-brightgreen)](https://zephyrproject.org)
 
@@ -157,7 +157,7 @@ manifest:
   projects:
     - name: EDS
       remote: xaloqi
-      revision: v1.13.2
+      revision: v1.13.3
       path: modules/eds
 ```
 
@@ -181,7 +181,7 @@ The `ZEPHYR_EDS_MODULE_DIR` variable is set automatically by west when the modul
 
 ```bash
 pip install west
-west init -m https://github.com/Xaloqi/EDS --mr v1.13.2 eds-workspace
+west init -m https://github.com/Xaloqi/EDS --mr v1.13.3 eds-workspace
 cd eds-workspace && west update
 pip install -r tools/requirements.txt
 ```

--- a/core/uds_types.h
+++ b/core/uds_types.h
@@ -36,10 +36,10 @@ extern "C" {
  * -------------------------------------------------------------------------- */
 #define UDS_SUITE_VERSION_MAJOR  (1U)
 #define UDS_SUITE_VERSION_MINOR  (13U)
-#define UDS_SUITE_VERSION_PATCH  (2U)
+#define UDS_SUITE_VERSION_PATCH  (3U)
 
 /** Compile-time version string — matches UDS_STACK_VERSION in safety_config.h. */
-#define UDS_SUITE_VERSION_STRING "1.13.2"
+#define UDS_SUITE_VERSION_STRING "1.13.3"
 
 /* --------------------------------------------------------------------------
  * Buffer and protocol sizing constants

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -13,7 +13,7 @@ ISO 15765-2 (ISO-TP) diagnostics stack for embedded RTOS targets. It is YAML-dri
 describe your DIDs, DTCs, and routines in YAML, run the code generator, and receive
 ASIL-B safety-wrapped C code ready to compile into your ECU firmware.
 
-**Version:** v1.13.2
+**Version:** v1.13.3
 **Target RTOS:** Zephyr v3.7+ · FreeRTOS (any version with static allocation support)
 **Target boards:** native_sim (CI/dev) · STM32 Nucleo-H743ZI2 (Cortex-M7) · NXP FRDM-MCX-N947 (MCX N947, Cortex-M33) · NXP MR-CANHUBK3 (S32K344, Cortex-M7) · QEMU ARM Cortex-M4 (FreeRTOS CI)
 **Transport:** ISO-TP over CAN (default) · DoIP over Ethernet/TCP (v1.6.0+)
@@ -1033,5 +1033,5 @@ tooling and lives in EDS-toolchain — it is not part of this repo's public CI.)
 
 ---
 
-*EDS v1.13.2 — Developer €690/yr · Professional €1,990/yr — xaloqi.com*
+*EDS v1.13.3 — Developer €690/yr · Professional €1,990/yr — xaloqi.com*
 *Runtime: GPL v2 · Examples: Apache 2.0 · Tools + IDE + GUI: Commercial*

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture — Xaloqi EDS
 
-**Version:** v1.13.2  
+**Version:** v1.13.3  
 **Status:** Production-ready. All CI jobs passing.
 
 ---

--- a/docs/CODEGEN_ARCHITECTURE.md
+++ b/docs/CODEGEN_ARCHITECTURE.md
@@ -559,7 +559,7 @@ SDV tooling, OEM SOVD clients, or any tool that understands the OpenSOVD
 ```json
 {
   "sovdVersion": "1.0.0",
-  "generatedBy":  "Xaloqi EDS codegen v1.6.0",
+  "generatedBy":  "Xaloqi EDS codegen v1.13.3",
   "generatedAt":  "<ISO 8601 UTC>",
   "ecuIdentification": {
     "name":    "<ecu_name>",

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -61,7 +61,7 @@ west --version   # must print 1.2 or newer
 mkdir eds-workspace && cd eds-workspace
 
 # Initialise the workspace from the EDS repository
-west init -m https://github.com/Xaloqi/EDS --mr v1.13.2 .
+west init -m https://github.com/Xaloqi/EDS --mr v1.13.3 .
 
 # Pull Zephyr and all dependencies (this downloads ~500 MB, takes 2-4 min)
 west update

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -1,10 +1,10 @@
 # Integration Guide
 
-## Xaloqi EDS — Zephyr RTOS, FreeRTOS, DoIP, and SOVD (v1.13.2)
+## Xaloqi EDS — Zephyr RTOS, FreeRTOS, DoIP, and SOVD (v1.13.3)
 
 | Field | Value |
 |---|---|
-| Stack version | 1.13.2 |
+| Stack version | 1.13.3 |
 | Zephyr version | v3.7.0 (pinned in `west.yml`) |
 | FreeRTOS version | FreeRTOS-Kernel (any recent release; tested with HEAD) |
 | ISO standard | ISO 14229-1:2020 (UDS), ISO 15765-2:2016 (ISO-TP), ISO 13400-2 (DoIP) |
@@ -185,7 +185,7 @@ manifest:
 
     - name: embedded-diagnostics-suite
       url: https://github.com/your-org/embedded-diagnostics-suite
-      revision: v1.13.2            # pin to a release tag
+      revision: v1.13.3            # pin to a release tag
       path: eds
 ```
 
@@ -1255,7 +1255,7 @@ The flag is opt-in — omitting it leaves all existing behaviour unchanged.
 ```json
 {
   "sovdVersion": "1.0.0",
-  "generatedBy": "Xaloqi EDS codegen v1.13.2",
+  "generatedBy": "Xaloqi EDS codegen v1.13.3",
   "generatedAt": "2026-05-20T10:00:00Z",
   "ecuIdentification": {
     "name": "BasicECU",

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -1,6 +1,6 @@
 # Testing Strategy — Xaloqi EDS
 
-**Version:** v1.13.2  
+**Version:** v1.13.3  
 **Status:** 45/45 unit test modules passing. 68/68 harness tests passing. 21/21 CI jobs green. FreeRTOS, SafeBoot (Zephyr + FreeRTOS), DoIP, and sensor examples all covered.
 
 ---
@@ -10,7 +10,7 @@
 EDS uses a four-layer testing strategy: unit tests, harness tests, integration tests, and system
 tests. All four layers run automatically in CI on every push and pull request.
 
-**Current test counts (v1.13.2):**
+**Current test counts (v1.13.3):**
 
 | Layer | Count | Framework | Status |
 |---|---|---|---|
@@ -30,7 +30,7 @@ tests. All four layers run automatically in CI on every push and pull request.
 ### What "the generated pytest suite" (row above) actually runs on a clean checkout
 
 `cd examples/basic_ecu/generated/tests && pytest --collect-only -q` reports **632 tests
-collected** for `basic_ecu` (v1.13.2). That is a *collection* count, not a claim that
+collected** for `basic_ecu` (v1.13.3). That is a *collection* count, not a claim that
 632 tests execute — and pass — right after `pip install -r tools/requirements.txt`. A
 meaningful share need TestLab (the commercial `xaloqi-tester` package), the
 (not-publicly-included) `firmware_bus` harness, or the commercial `tools/templates/`

--- a/examples/ardep_ecu/generated/safety_config.h
+++ b/examples/ardep_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.2"
+#define UDS_STACK_VERSION "1.13.3"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu/generated/safety_config.h
+++ b/examples/basic_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.2"
+#define UDS_STACK_VERSION "1.13.3"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu_doip/generated/safety_config.h
+++ b/examples/basic_ecu_doip/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.2"
+#define UDS_STACK_VERSION "1.13.3"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu_doip_freertos/generated/safety_config.h
+++ b/examples/basic_ecu_doip_freertos/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.2"
+#define UDS_STACK_VERSION "1.13.3"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu_freertos/generated/safety_config.h
+++ b/examples/basic_ecu_freertos/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.2"
+#define UDS_STACK_VERSION "1.13.3"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/bms_ecu/generated/safety_config.h
+++ b/examples/bms_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.2"
+#define UDS_STACK_VERSION "1.13.3"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/motor_controller_ecu/generated/safety_config.h
+++ b/examples/motor_controller_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.2"
+#define UDS_STACK_VERSION "1.13.3"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/robot_joint_controller_ecu/generated/safety_config.h
+++ b/examples/robot_joint_controller_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.2"
+#define UDS_STACK_VERSION "1.13.3"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/safeboot_ecu/generated/safety_config.h
+++ b/examples/safeboot_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.2"
+#define UDS_STACK_VERSION "1.13.3"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/safeboot_freertos_ecu/generated/safety_config.h
+++ b/examples/safeboot_freertos_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.2"
+#define UDS_STACK_VERSION "1.13.3"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/sensor_ecu/generated/safety_config.h
+++ b/examples/sensor_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.2"
+#define UDS_STACK_VERSION "1.13.3"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/sensor_ecu_freertos/generated/safety_config.h
+++ b/examples/sensor_ecu_freertos/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.2"
+#define UDS_STACK_VERSION "1.13.3"
 
 /* =============================================================================
  * ASIL level identification

--- a/sbom.json
+++ b/sbom.json
@@ -14,9 +14,9 @@
     ],
     "component": {
       "type": "firmware",
-      "bom-ref": "xaloqi-eds@1.13.2",
+      "bom-ref": "xaloqi-eds@1.13.3",
       "name": "Xaloqi EDS",
-      "version": "1.13.2",
+      "version": "1.13.3",
       "description": "Production-grade UDS/ISO-TP/DoIP diagnostics stack for automotive ECUs (ASIL-B candidate, ISO 14229 / ISO 15765-2 / ISO 13400-2)",
       "licenses": [
         {

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -100,7 +100,7 @@ except ImportError:
     print("ERROR: Jinja2 is required.  pip install jinja2", file=sys.stderr)
     sys.exit(2)
 
-__version__ = "1.13.2"
+__version__ = "1.13.3"
 
 # =============================================================================
 # Constants


### PR DESCRIPTION
## Summary

Version bump for the v1.13.3 release, per `xaloqi-knowledge/ops/release-runbook.md` step 1+3 — bundles #211-218 (already merged via #219, #220, #221).

Rolls `CHANGELOG.md` (`[Unreleased]` → `[1.13.3] — 2026-09-02`) and bumps every known version-bearing literal via `xaloqi-knowledge/scripts/bump_release_version.py`:
- `tools/codegen.py` `__version__`
- `core/uds_types.h`'s 4 `UDS_SUITE_VERSION_*` macros
- `CMakeLists.txt` (header comment + `project()` VERSION)
- `README.md` badges, `INSTALL.md` (6 occurrences)
- `sbom.json`'s own-component version/bom-ref/timestamp
- `docs/{AI_CONTEXT,ARCHITECTURE,GETTING_STARTED,INTEGRATION_GUIDE,TESTING_STRATEGY}.md` current-version claims
- 12 committed `examples/*/generated/safety_config.h` `UDS_STACK_VERSION` lines

Also fixes 2 stale spots the bump script's `doc_patterns` list didn't yet cover (script itself fixed separately, see below):
- `docs/INTEGRATION_GUIDE.md`'s table row + `generatedBy` JSON example — still at 1.13.2, the exact two spots #212 added detection patterns for one release ago, but the bump script wasn't updated to match at the time.
- `docs/CODEGEN_ARCHITECTURE.md`'s `generatedBy` JSON example — found stuck at v1.6.0, a third, previously-unknown stale spot the new checker pattern also caught.

## Testing

- `python3 scripts/check_release_docs.py --expected-version 1.13.3`: **0 hard failures** after the two manual doc fixes above. 1 pre-existing non-blocking warning (a historical "37 → 45 jobrunner tests" mention in EDS-toolchain's README.md — correctly not a current-state claim).
- `bash build_tests.sh`: **919/919 unit test cases pass, 0 regressions.**
- Spot-check regen: `codegen.py --template-dir <eds-toolchain>/tools/templates` against `basic_ecu`'s real config, diffed against the committed `generated/` output — every file present in both is a timestamp-only diff, confirming the version bump matches what real codegen produces.
- `sbom.json` validated as well-formed JSON with the new version.

**Noted, not fixed here (pre-existing, unrelated to this bump):** a real codegen run also emits `dtc_config.h`, which no currently-committed example includes — a gap between the toolchain's template set and EDS's committed examples that predates this release.

**Not touched (out of scope for this session):** `automation/agents/delivery.py`'s `EDS_VERSION` — that repo isn't attached to this session; needs a separate founder pass before this version should ship to a real paying customer.

## Next steps (after merge, per the release runbook)

1. Tag `v1.13.3` on post-merge `main` and push.
2. Verify the public GitHub Release auto-published (`.github/workflows/release.yml`).
3. `bash build_release.sh` (needs `../EDS` + `../EDS-Safety` siblings) — release gate + `delivery-v1.13.3` in EDS-toolchain.
4. Founder: Polar sandbox test purchase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTiWQPZe6NL5y6ma8S9bXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTiWQPZe6NL5y6ma8S9bXQ)_