### PR TITLE
docs: point Developer/Professional customers to INSTALL.md from GETTING_STARTED.md

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -135,6 +135,11 @@ that implement your DID and DTC tables, safety wrappers, and init sequence.
 > part of this public repo) — see [COMMERCIAL_NOTICE.md](../COMMERCIAL_NOTICE.md).
 > **No license? Skip this step.** `basic_ecu`'s `generated/` output is already
 > committed to the repo, so Steps 6–8 (`west build` and run) work without it.
+> **Developer/Professional customer?** Don't skip it — but follow
+> [`INSTALL.md`](../INSTALL.md) (shipped at the top level of your ZIP) instead of
+> continuing from here: it covers unzipping your package into this clone and
+> activating your license before this step will produce real output. Come back to
+> this guide's Step 6 once `codegen.py` has run successfully.
 
 ```bash
 # From the eds repo root


### PR DESCRIPTION
## Summary

The licensed-step callout at the codegen step only said "no license? skip this step" — it never told a customer who *does* have a license where to actually go. A paying customer landing here (e.g. via the welcome email's "Full guide" link) would read "skip this step" as applying to them too, or would run `codegen.py` here without ever unzipping their ZIP or activating their license first — this file's own `west init` flow never merges the commercial ZIP into the workspace it creates; that's `INSTALL.md`'s job, a separate document this file never mentioned.

Adds one line: Developer/Professional customers should follow `INSTALL.md` (shipped at the top level of their ZIP) instead of continuing past this step here, then come back to Step 6 once codegen has actually produced output.

Companion fix: [Xaloqi/automation#13](https://github.com/Xaloqi/automation/pull/13) (welcome email Quick Start sections, which had the same disconnect plus a stale `--mr v1.7.0` reference).

## Testing

- `python3 scripts/check_release_docs.py --expected-version 1.13.3` (xaloqi-knowledge, paths adapted for this session): 0 hard failures, same 1 pre-existing unrelated warning as before this change.
- `../INSTALL.md` resolves correctly from `docs/GETTING_STARTED.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTiWQPZe6NL5y6ma8S9bXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTiWQPZe6NL5y6ma8S9bXQ)_