### PR TITLE
fix: lwip_stub sockets.h struct/typedef tag mismatch broke DoIP FreeRTOS build

### DIFF
--- a/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/lwip_stub/lwip/sockets.h
+++ b/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/lwip_stub/lwip/sockets.h
@@ -23,7 +23,13 @@ struct sockaddr_in {
     uint8_t        sin_zero[8];
 };
 
-typedef struct { long tv_sec; long tv_usec; } struct_timeval;
+/* `#define timeval struct_timeval` below rewrites every `struct timeval`
+ * in the including source to `struct struct_timeval` — so the type here
+ * must be a tagged struct (`struct struct_timeval { ... }`), not a
+ * `typedef struct { ... } struct_timeval` (that only creates a typedef
+ * *name*, not a `struct struct_timeval` tag, leaving `struct timeval`
+ * references as an incomplete type: "storage size of 'tv' isn't known"). */
+struct struct_timeval { long tv_sec; long tv_usec; };
 #define timeval struct_timeval
 
 typedef struct { unsigned long fds_bits[1]; } fd_set;


### PR DESCRIPTION
## What
One-line-equivalent fix in `examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/lwip_stub/lwip/sockets.h`.

## Why
`#define timeval struct_timeval` rewrites every `struct timeval` reference to `struct struct_timeval`. The stub defined `struct_timeval` as `typedef struct { ... } struct_timeval;` — a typedef *name*, not a `struct struct_timeval` *tag* — so every `struct timeval tv;` in `transport/doip/freertos_lwip.c` was an incomplete type:

```
freertos_lwip.c:120:20: error: storage size of 'tv' isn't known
    struct timeval tv;
                   ^~
```

## How found
`xaloqi-compatibility-tests`' `full-matrix` CI job (`basic_ecu_doip_freertos` target) — the only place this build path is actually exercised. Filed as [xaloqi-compatibility-tests#2](https://github.com/Xaloqi/xaloqi-compatibility-tests/issues/2).

## Verification
Reproduced the exact failing compile command locally with the real `arm-none-eabi-gcc` and the real `transport/doip/freertos_lwip.c` (same defines, include paths, flags) — fails without this fix, compiles clean (object file produced, zero errors/warnings related to this) with it.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
