### PR TITLE
README: DIAG_SKIP_CODEGEN fix + 2 stale v1.13.2 refs (stranded from feature/gtm-readme-rewrite)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Zephyr's `native_sim`. No CAN hardware, no commercial license:
 
 ```bash
 pip install west
-west init -m https://github.com/Xaloqi/EDS --mr v1.13.2 eds-workspace
+west init -m https://github.com/Xaloqi/EDS --mr v1.13.3 eds-workspace
 cd eds-workspace && west update
 pip install -r tools/requirements.txt
 
@@ -492,7 +492,7 @@ Unlike alternatives that use PolyForm Noncommercial (which prohibits production 
 **Just want to see an ECU run?**
 
 ```bash
-west init -m https://github.com/Xaloqi/EDS --mr v1.13.2 eds-workspace
+west init -m https://github.com/Xaloqi/EDS --mr v1.13.3 eds-workspace
 cd eds-workspace && west update
 west build -b native_sim examples/basic_ecu \
   -- -DDTC_OVERLAY_FILE=boards/native_sim/native_sim.overlay \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ cd eds-workspace && west update
 pip install -r tools/requirements.txt
 
 west build -b native_sim examples/basic_ecu \
-  -- -DDTC_OVERLAY_FILE=boards/native_sim/native_sim.overlay
+  -- -DDTC_OVERLAY_FILE=boards/native_sim/native_sim.overlay \
+     -DDIAG_SKIP_CODEGEN=ON
 west build -t run
 ```
 
@@ -37,6 +38,12 @@ the licensed step, not evaluating the runtime — see
 [Open-core: what's free, what's licensed](#open-core-whats-free-whats-licensed)
 below. More boards (STM32 Nucleo, NXP FRDM/S32K) and the full generator
 walkthrough: [Quick start](#quick-start).
+
+`-DDIAG_SKIP_CODEGEN=ON` tells the build to use the committed `generated/`
+output as-is instead of trying to regenerate it — required here, since a
+fresh checkout has no commercial templates. Without it the build fails
+outright rather than silently falling back (confirmed against a real CI
+checkout — [EDS#198](https://github.com/Xaloqi/EDS/issues/198)).
 
 > **Want to test UDS without writing an ECU first?** →
 > [Xaloqi TestLab Core](https://github.com/Xaloqi/xaloqi-testlab-core) — a
@@ -119,7 +126,8 @@ python3 tools/codegen.py \
 ```bash
 # Simulator (CI, no hardware)
 west build -b native_sim examples/basic_ecu \
-  -- -DDTC_OVERLAY_FILE=boards/native_sim/native_sim.overlay
+  -- -DDTC_OVERLAY_FILE=boards/native_sim/native_sim.overlay \
+     -DDIAG_SKIP_CODEGEN=ON
 west build -t run
 
 # STM32 Nucleo-H743ZI2
@@ -217,7 +225,7 @@ pip install -r tools/requirements.txt
 
 ### Run the basic ECU example
 
-> **No license? Skip the codegen step.** This example's generated code is committed under `examples/basic_ecu/generated/`, so `west build` works out of the box on the GPL runtime. The `codegen.py` step below regenerates it and **requires a Developer/Professional license** (templates are commercial — see [COMMERCIAL_NOTICE.md](COMMERCIAL_NOTICE.md)).
+> **No license? Skip the codegen step.** This example's generated code is committed under `examples/basic_ecu/generated/` — pass `-DDIAG_SKIP_CODEGEN=ON` to `west build` (below) to use it as-is on the GPL runtime, no commercial templates needed. The `codegen.py` step below regenerates it and **requires a Developer/Professional license** (templates are commercial — see [COMMERCIAL_NOTICE.md](COMMERCIAL_NOTICE.md)).
 
 ```bash
 # Generate code from the bundled example config  (licensed step — see note above)
@@ -228,7 +236,8 @@ python3 tools/codegen.py \
 
 # Build and run in simulator  (works without a license — generated/ is committed)
 west build -b native_sim examples/basic_ecu \
-  -- -DDTC_OVERLAY_FILE=boards/native_sim/native_sim.overlay
+  -- -DDTC_OVERLAY_FILE=boards/native_sim/native_sim.overlay \
+     -DDIAG_SKIP_CODEGEN=ON
 west build -t run
 ```
 
@@ -486,7 +495,8 @@ Unlike alternatives that use PolyForm Noncommercial (which prohibits production 
 west init -m https://github.com/Xaloqi/EDS --mr v1.13.2 eds-workspace
 cd eds-workspace && west update
 west build -b native_sim examples/basic_ecu \
-  -- -DDTC_OVERLAY_FILE=boards/native_sim/native_sim.overlay
+  -- -DDTC_OVERLAY_FILE=boards/native_sim/native_sim.overlay \
+     -DDIAG_SKIP_CODEGEN=ON
 west build -t run
 ```
 


### PR DESCRIPTION
## What
Recovers one commit that got stranded on `feature/gtm-readme-rewrite`
after its first commit merged as #228 but a second, later commit
(pushed after the merge) never got its own PR — plus a real, live bug
found while rebasing that branch onto `main`.

## Commit 1 — `-DIAG_SKIP_CODEGEN=ON`
Adds `-DIAG_SKIP_CODEGEN=ON` to every no-license `west build` command in
the README. Confirmed via real CI (`xaloqi-compatibility-tests`, see
[EDS#198](https://github.com/Xaloqi/EDS/issues/198)) that a genuine
`actions/checkout@v4` + `west build` does **not** skip codegen via mtime
staleness the way a plain local `git clone` appears to — without this
flag, the documented "no license needed" build path fails outright with
"Code generator templates not found" in any GitHub Actions-based CI.

## Commit 2 — stale version references
`main`'s README currently has two stale `--mr v1.13.2` west-init commands
(lines 25 and 486 before this PR) in the "See it run" and "Start here"
sections. Root cause: #228 was based on pre-version-bump content and
merged *after* #222 (the 1.13.2→1.13.3 bump) had already landed on
`main`, so its new sections silently carried the old version string back
in. Verified live on `main` before filing this fix; `check_versions.py`
confirms EDS's authoritative version is v1.13.3.

## Origin
Recovered from `feature/gtm-readme-rewrite` (cherry-picked the one
unmerged commit onto fresh `main`, since that branch's other commit is
already merged via #228 and the branch itself is now several commits
behind).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
