### PR TITLE
native_sim_realcan.conf/.overlay: real vcan0 bridge for native_sim CAN, closes EDS#231

### DIFF
--- a/boards/native_sim/native_sim_realcan.conf
+++ b/boards/native_sim/native_sim_realcan.conf
@@ -1,0 +1,61 @@
+# =============================================================================
+# Xaloqi EDS
+# boards/native_sim/native_sim_realcan.conf
+#
+# EDS#231: alternative to native_sim.conf for connecting a native_sim ECU
+# to a REAL host SocketCAN interface (e.g. vcan0), instead of Zephyr's
+# in-process can_loopback0 device. native_sim.conf's CONFIG_CAN_LOOPBACK=y
+# is correct for EDS's own self-contained CI/unit-test use (no external
+# CAN peer needed) but structurally cannot be reached by an external UDS
+# tester -- the loopback device only ever talks to itself.
+#
+# Use together with Zephyr's own official snippet, which wires the
+# devicetree side (enables the native_sim board's existing `can0` node,
+# bound to the can_native_linux driver, and sets it as the chosen
+# zephyr,canbus):
+#
+#   west build -b native_sim examples/basic_ecu -S socketcan-native-sim \
+#     -- -DEXTRA_CONF_FILE=<path-to-this-file>/native_sim_realcan.conf ...
+#
+# The native_sim board's can0 node defaults to host interface "zcan0"
+# (boards/native/native_sim/native_sim.dts). To use a real vcan0 interface
+# without renaming it, add zcan0 as an alternate name (see Zephyr's
+# snippets/socketcan-native-sim/README.rst):
+#
+#   sudo modprobe vcan
+#   sudo ip link add dev vcan0 type vcan
+#   sudo ip link property add dev vcan0 altname zcan0
+#   sudo ip link set vcan0 up
+#
+# This file is everything native_sim.conf provides EXCEPT
+# CONFIG_CAN_LOOPBACK -- the snippet's own .conf sets CONFIG_CAN=y, and
+# its overlay enables the real can0 device, so the loopback override must
+# not be present here (it would define a second, conflicting canbus
+# chosen node).
+# =============================================================================
+
+# --- POSIX API (required for native_sim threading and timers) ---
+CONFIG_POSIX_API=y
+
+# --- FIX W1: STACK_CANARIES (no entropy source on native_sim) ---
+CONFIG_STACK_CANARIES=n
+
+# --- FIX W2: CAN_STATS (STATS subsystem not enabled on native_sim) ---
+CONFIG_CAN_STATS=n
+
+# --- FIX W3: LOG_BUFFER_SIZE requires LOG_MODE_DEFERRED ---
+CONFIG_LOG_MODE_DEFERRED=y
+
+# --- FIX W4: LOG_BACKEND_UART (no UART on native_sim, use POSIX stdout) ---
+CONFIG_LOG_BACKEND_UART=n
+CONFIG_LOG_BACKEND_NATIVE_POSIX=y
+
+# --- FIX W5: NEWLIB_LIBC choice conflict (force newlib over picolibc default) ---
+CONFIG_NEWLIB_LIBC=y
+
+# --- Reboot subsystem (required for zephyr_port_ecu_reset / sys_reboot) ---
+CONFIG_REBOOT=y
+
+# --- Platform adjustments ---
+CONFIG_LOG_DEFAULT_LEVEL=2
+CONFIG_WATCHDOG=n

--- a/boards/native_sim/native_sim_realcan.overlay
+++ b/boards/native_sim/native_sim_realcan.overlay
@@ -7,8 +7,8 @@
  * ECU to a REAL host SocketCAN interface (e.g. vcan0), instead of
  * Zephyr's in-process can_loopback0 device.
  *
- * native_sim.overlay unconditionally maps the `can0` alias (used by
- * examples/*/src/main.c's DEVICE_DT_GET(DT_ALIAS(can0))) to
+ * native_sim.overlay unconditionally maps the `can0` alias (used by every
+ * example's src/main.c, via DEVICE_DT_GET(DT_ALIAS(can0))) to
  * &can_loopback0 -- so simply removing CONFIG_CAN_LOOPBACK from the
  * Kconfig side (see native_sim_realcan.conf) is not enough on its own;
  * the alias itself must be redirected too, to the board's own `can0`

--- a/boards/native_sim/native_sim_realcan.overlay
+++ b/boards/native_sim/native_sim_realcan.overlay
@@ -1,0 +1,47 @@
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * boards/native_sim/native_sim_realcan.overlay
+ *
+ * EDS#231: alternative to native_sim.overlay for connecting a native_sim
+ * ECU to a REAL host SocketCAN interface (e.g. vcan0), instead of
+ * Zephyr's in-process can_loopback0 device.
+ *
+ * native_sim.overlay unconditionally maps the `can0` alias (used by
+ * examples/*/src/main.c's DEVICE_DT_GET(DT_ALIAS(can0))) to
+ * &can_loopback0 -- so simply removing CONFIG_CAN_LOOPBACK from the
+ * Kconfig side (see native_sim_realcan.conf) is not enough on its own;
+ * the alias itself must be redirected too, to the board's own `can0`
+ * devicetree node (compatible "zephyr,native-linux-can", disabled by
+ * default -- boards/native/native_sim/native_sim.dts), which this
+ * overlay enables.
+ *
+ * That node defaults to host interface "zcan0". To reach it via a real
+ * vcan0 without renaming your interface, add zcan0 as an alternate name
+ * (see Zephyr's own snippets/socketcan-native-sim/README.rst):
+ *
+ *   sudo modprobe vcan
+ *   sudo ip link add dev vcan0 type vcan
+ *   sudo ip link property add dev vcan0 altname zcan0
+ *   sudo ip link set vcan0 up
+ *
+ * Use together with native_sim_realcan.conf:
+ *
+ *   west build -b native_sim examples/basic_ecu \
+ *     -- -DEXTRA_CONF_FILE=.../native_sim_realcan.conf \
+ *        -DDTC_OVERLAY_FILE=.../native_sim_realcan.overlay
+ * =============================================================================
+ */
+
+/ {
+	aliases {
+		/* Map the 'can0' alias used in main.c to the REAL native_linux CAN
+		 * device (bound to a real host SocketCAN interface), instead of
+		 * native_sim.overlay's in-process loopback device. */
+		can0 = &can0;
+	};
+};
+
+&can0 {
+	status = "okay";
+};


### PR DESCRIPTION
## What
Two new, purely additive files — no change to any existing file, no change to EDS's own CI or default example behavior:

- `boards/native_sim/native_sim_realcan.conf` — `native_sim.conf` minus `CONFIG_CAN_LOOPBACK`.
- `boards/native_sim/native_sim_realcan.overlay` — redirects the `can0` devicetree alias (used by every example's `DEVICE_DT_GET(DT_ALIAS(can0))`) to the native_sim board's own `can0` node (`compatible = "zephyr,native-linux-can"`, disabled by default), instead of `native_sim.overlay`'s `&can_loopback0`.

## Why
`native_sim.conf`/`.overlay` are correct for EDS's own self-contained CI and unit tests, but the resulting `can_loopback0` device only ever talks to itself — no external tester, on any transport, can ever reach a `native_sim` ECU built this way. Confirmed nobody had verified real `vcan0` connectivity for any EDS example, anywhere, before this.

## Verification — real, not assumed
No Zephyr SDK / root available in this session's own environment, so verified via a temporary cross-branch dispatch of `xaloqi-compatibility-tests`' real CI (which has both) — branch created, tested, and **deleted** afterward, nothing left committed there:

1. First attempt failed at devicetree parse: my own overlay's doc comment contained a literal `examples/*/src/main.c`, whose `*/` closed the C-style comment early. Fixed (this branch's 2nd commit).
2. Second attempt: **`Full matrix (basic_ecu)` job — genuine success**, not masked by `continue-on-error`:
   ```
   [00:00:00.000,000] <inf> zephyr_can: CAN: Transport initialized (device: can).
   ```
   (was `can_loopback0` before this fix)
   ```
   [01/08] tester_present         → OK (2 ms)
   [02/08] session(extended)      → OK (2 ms)
   [03/08] security_access(level=1) → OK (44 ms)
   [04/08] read_did(0xF190)       → OK (6 ms)
   [05/08] read_dtc               → OK (2 ms)
   [06/08] clear_dtc              → OK (2 ms)
   [07/08] read_dtc               → OK (2 ms)
   [08/08] session(default)       → OK (2 ms)
   Result:  PASS
   ```
   Real round-trip timing (2–44ms), not the 0ms in-process instant results the loopback/virtual paths show — genuine SocketCAN traffic over a real `vcan0` interface, confirmed end to end for the first time in this project's history.

Also confirmed the explicit `-DDTC_OVERLAY_FILE=` correctly overrides Zephyr's auto-included per-example overlay (`examples/basic_ecu/boards/native_sim.overlay`) rather than conflicting with it — resolves an open question from the design, not assumed.

`build_tests.sh` unaffected: 923/923, 0 failed (these new files aren't referenced by any existing build path).

## Follow-up needed elsewhere (not in this PR)
Once merged, `xaloqi-compatibility-tests`' `full-matrix` workflow needs updating to actually use these files for its `basic_ecu` target (currently still uses `native_sim.conf`/the auto-included loopback overlay) — a compat-tests-side change, tracked on [xaloqi-compatibility-tests#2](https://github.com/Xaloqi/xaloqi-compatibility-tests/issues/2), not done here.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
