### PR TITLE
examples/basic_ecu_doip: add native_sim_doip_realzeth.conf for a real host DoIP bridge

### DIFF
--- a/examples/basic_ecu_doip/boards/native_sim/native_sim_doip_realzeth.conf
+++ b/examples/basic_ecu_doip/boards/native_sim/native_sim_doip_realzeth.conf
@@ -1,0 +1,80 @@
+# =============================================================================
+# Xaloqi EDS
+# examples/basic_ecu_doip/boards/native_sim/native_sim_doip_realzeth.conf
+#
+# compat-tests#4 / EDS#230: alternative to native_sim_doip.conf for running
+# the DoIP example against a REAL host TCP connection over Zephyr's
+# native_posix Ethernet driver + a host-side "zeth" TAP bridge, instead of
+# only ever being reachable from inside the same native_sim process.
+#
+# Root cause (found by reading Zephyr's own Kconfig source directly,
+# v3.7.0 -- zephyr/drivers/ethernet/Kconfig +
+# zephyr/boards/native/native_sim/Kconfig.defconfig): CONFIG_ETH_NATIVE_POSIX
+# lives inside `if ETH_DRIVER`, and ETH_DRIVER's only default is
+# `y if NET_L2_ETHERNET` -- whose own default is `y if !NET_LOOPBACK &&
+# !NET_TEST`. native_sim_doip.conf sets CONFIG_NET_LOOPBACK=y, which blocks
+# NET_L2_ETHERNET's default, leaving the entire ETH_DRIVER subtree
+# (including CONFIG_ETH_NATIVE_POSIX=y) invisible -- silently dropped, no
+# build error. On top of that, CONFIG_NET_LOOPBACK=y also creates a SEPARATE
+# Zephyr-internal loopback net_if; even after forcing NET_L2_ETHERNET=y,
+# net_config's auto-init assigned the static IP to that competing interface
+# instead of the real eth_native_posix one -- ARP for the configured address
+# stayed INCOMPLETE on the host's zeth device until CONFIG_NET_LOOPBACK was
+# disabled entirely. Verified end-to-end against real CI before this became
+# permanent (8 iterations of a throwaway cross-repo branch, since deleted):
+# real ARP resolution ("192.0.2.1 lladdr ... REACHABLE"), 8/8 UDS ops over
+# real DoIP/TCP through the zeth bridge, real 102-204ms timings.
+#
+# Host-side setup this conf expects (see Zephyr's own
+# snippets/socketcan-native-sim/ pattern for the analogous CAN case, and
+# net-tools' own README for this one):
+#
+#   git clone https://github.com/zephyrproject-rtos/net-tools /tmp/net-tools
+#   cd /tmp/net-tools && sudo ./net-setup.sh start
+#
+# That creates the "zeth" TAP interface with net-tools' own default pairing
+# (host 192.0.2.2 / native_sim-side 192.0.2.1), matched below.
+#
+# Use together with native_sim.conf (for CONFIG_REBOOT and friends, same as
+# native_sim_doip.conf) and IN PLACE OF native_sim_doip.conf, not alongside
+# it -- native_sim_doip.conf's CONFIG_NET_LOOPBACK=y is exactly what this
+# file needs to override:
+#
+#   west build -b native_sim examples/basic_ecu_doip \
+#     -- -DEXTRA_CONF_FILE="boards/native_sim/native_sim.conf;\
+#         examples/basic_ecu_doip/boards/native_sim/native_sim_doip_realzeth.conf"
+# =============================================================================
+
+# --- POSIX API required for native_sim networking ---
+CONFIG_POSIX_API=y
+
+# --- Real host bridge, not Zephyr's internal loopback net_if ---
+CONFIG_NET_LOOPBACK=n
+CONFIG_NET_NATIVE=y
+CONFIG_NET_L2_ETHERNET=y
+CONFIG_NET_DRIVERS=y
+CONFIG_ETH_NATIVE_POSIX=y
+
+# --- Static IPv4, matching net-tools' own default zeth pairing ---
+CONFIG_NET_CONFIG_SETTINGS=y
+CONFIG_NET_CONFIG_NEED_IPV4=y
+CONFIG_NET_CONFIG_MY_IPV4_ADDR="192.0.2.1"
+CONFIG_NET_CONFIG_MY_IPV4_GW="192.0.2.2"
+CONFIG_NET_CONFIG_MY_IPV4_NETMASK="255.255.255.0"
+
+# --- Log via POSIX stdout (no UART on native_sim) ---
+CONFIG_LOG_MODE_DEFERRED=y
+CONFIG_LOG_BACKEND_UART=n
+CONFIG_LOG_BACKEND_NATIVE_POSIX=y
+
+# --- No stack canaries on native_sim (no entropy) ---
+CONFIG_STACK_CANARIES=n
+
+# --- Force newlib (consistent with rest of EDS) ---
+CONFIG_NEWLIB_LIBC=y
+
+# --- Reduce log noise in CI ---
+CONFIG_LOG_DEFAULT_LEVEL=2
+
+# --- No watchdog on simulator ---
+CONFIG_WATCHDOG=n


### PR DESCRIPTION
## What
New file, additive only: `examples/basic_ecu_doip/boards/native_sim/native_sim_doip_realzeth.conf` — an alternative to `native_sim_doip.conf` that makes the DoIP example reachable from a real host TCP connection over a `zeth` TAP bridge, instead of only ever being reachable from inside the same native_sim process. Doesn't touch `native_sim_doip.conf`, any existing example, or any CI job.

## Why
[EDS#230](https://github.com/Xaloqi/EDS/issues/230): this repo's own DoIP Integration CI job has been silently skipping its real connection test (TestLab not found → 0 tests collected, reported as pass) since inception — the existing `native_sim_doip.conf` has never actually been confirmed to work against a real host connection anywhere, not just in this repo's own CI. `xaloqi-compatibility-tests#4` surfaced the exact same unknown independently.

## Root cause (why the existing conf never worked for this)
Found by reading Zephyr's own Kconfig source directly (v3.7.0):

- `CONFIG_ETH_NATIVE_POSIX` lives inside `if ETH_DRIVER`
- `ETH_DRIVER`'s only default is `y if NET_L2_ETHERNET`
- `NET_L2_ETHERNET`'s own default is `y if !NET_LOOPBACK && !NET_TEST`

`native_sim_doip.conf` sets `CONFIG_NET_LOOPBACK=y`, which blocks `NET_L2_ETHERNET`'s default — silently dropping the entire Ethernet driver subtree, including the file's own `CONFIG_ETH_NATIVE_POSIX=y`. No build error, no warning — the symbol just never appears in `.config`.

Forcing `NET_L2_ETHERNET=y` explicitly fixes that half, but `CONFIG_NET_LOOPBACK=y` *also* creates a competing Zephyr-internal loopback net interface — `net_config`'s auto-init assigned the static IP there instead of the real Ethernet interface, even with the Kconfig chain now correct (confirmed: TAP fd attached, `zeth` carrier up, but ARP for the configured address stayed `INCOMPLETE`). Disabling `CONFIG_NET_LOOPBACK` entirely in the new file fixed both problems together.

## Verification
Not guessed — root-caused via 9 throwaway cross-repo CI iterations against `xaloqi-compatibility-tests` (since deleted), each one checked against real evidence (`.config` dumps, generated devicetree, `ip addr`/`ip neigh` on the host, process fd inspection) rather than assumption:
- Real ARP resolution: `192.0.2.1 lladdr 02:00:5e:00:53:31 REACHABLE`
- 8/8 UDS ops passed over real DoIP/TCP through the zeth bridge
- Real timings (102–204ms), not synthetic

Final pass re-confirmed against the exact committed file in this PR (not just the inline-generated version used while iterating).

## Status
Not merging — permanent wiring into `xaloqi-compatibility-tests`' CI is tracked in a companion PR there ([xaloqi-compatibility-tests#8](https://github.com/Xaloqi/xaloqi-compatibility-tests/pull/8)), which needs this PR merged first to go green.