### PR TITLE
ci: add commit-message-lint job for closing-keyword syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,27 @@ env:
 
 jobs:
 
+  # ── Job 0: Commit message lint ──────────────────────────────────────────────
+  # Mechanical, unconditional gate for a mistake that already happened twice
+  # in one day despite being documented both times (xaloqi-knowledge
+  # lessons/run-030, run-031): a commit saying "closes EDS#N" instead of
+  # bare "closes #N" isn't recognized by GitHub's auto-close parser at all --
+  # no error, no warning, the issue just silently never closes. Cheap and
+  # fast (no build), runs on every PR so it also catches direct human
+  # commits, not just agent sessions.
+  commit-message-lint:
+    name: "Commit message lint (closing-keyword syntax)"
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify closing-keyword syntax
+        run: |
+          bash scripts/verify_closing_keyword_syntax.sh "${{ github.event.pull_request.base.sha }}"
+
   # ── Job 1: Host unit tests ─────────────────────────────────────────────────
   unit-tests:
     name: "Unit Tests"

--- a/scripts/verify_closing_keyword_syntax.sh
+++ b/scripts/verify_closing_keyword_syntax.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Xaloqi EDS
+# scripts/verify_closing_keyword_syntax.sh
+#
+# PURPOSE: Catch invalid GitHub issue-closing references BEFORE merge,
+#          mechanically -- not by an agent or human remembering to check.
+#
+#          GitHub's auto-close keyword parser (close(s|d)/fix(es|ed)/
+#          resolve(s|d)) only recognizes two reference forms: bare `#123`
+#          (same-repo) or `owner/repo#123` (cross-repo). `EDS#123` (repo
+#          name, no owner, directly before `#`) matches neither -- it is
+#          not malformed enough to error or warn, it just silently isn't
+#          recognized as an issue reference at all. Four issues went
+#          unclosed this way in one PR with zero signal anything was
+#          wrong (xaloqi-knowledge lessons/run-030); the documented
+#          mitigation ("remember the correct syntax") demonstrably failed
+#          to prevent an immediate recurrence in the very next PR
+#          (lessons/run-031's sibling note). This script is the actual
+#          fix: a mechanical, unconditional gate, not a reminder.
+#
+# USAGE:
+#   bash scripts/verify_closing_keyword_syntax.sh [base-ref]
+#
+#   base-ref defaults to origin/main. Checks every commit in
+#   base-ref..HEAD. In CI, the checkout must have enough history to reach
+#   base-ref (fetch-depth: 0, or at least deep enough to cover the PR).
+#
+# EXIT CODES:
+#   0  No repo-prefixed closing-keyword references found.
+#   1  At least one commit uses the invalid REPO#N form.
+# =============================================================================
+
+set -euo pipefail
+
+BASE="${1:-origin/main}"
+
+if ! git rev-parse --verify "${BASE}" >/dev/null 2>&1; then
+    echo "SKIP: base ref '${BASE}' not reachable (shallow clone or first commit on this branch) -- nothing to compare against."
+    exit 0
+fi
+
+RANGE="${BASE}..HEAD"
+bad_found=0
+
+# %H then a NUL-safe body would be nicer, but commit messages here are
+# plain text without embedded NULs in practice; %B per-commit via a
+# second git log call keeps this simple and readable.
+for commit in $(git rev-list "${RANGE}"); do
+    msg="$(git log -1 --format=%B "${commit}")"
+
+    # Capture whatever comes between a closing keyword and '#N'.
+    matches="$(grep -oP '(?i)\b(close[sd]?|fix(es|ed)?|resolve[sd]?)\s+\K[A-Za-z][A-Za-z0-9._/-]*#[0-9]+' <<< "${msg}" || true)"
+    [ -z "${matches}" ] && continue
+
+    while IFS= read -r m; do
+        [ -z "${m}" ] && continue
+        prefix="${m%%#*}"
+        # Bare '#N' never matches the pattern above (it requires a
+        # leading letter before '#'), so prefix is never empty here.
+        # 'owner/repo#N' contains a '/' -- valid, skip. Anything else
+        # (a bare repo name directly before '#') is the bug.
+        if [[ "${prefix}" != */* ]]; then
+            short="${commit:0:9}"
+            echo "::error::Commit ${short}: '${m}' is not valid GitHub closing-keyword syntax -- '${prefix}#N' (repo name, no owner) is never recognized as an issue reference. Use bare '#N' for a same-repo issue, or 'owner/${prefix}#N' for cross-repo. See xaloqi-knowledge lessons/run-030."
+            bad_found=1
+        fi
+    done <<< "${matches}"
+done
+
+if [ "${bad_found}" -ne 0 ]; then
+    exit 1
+fi
+
+echo "OK: no repo-prefixed closing-keyword references found in ${RANGE}."


### PR DESCRIPTION
New `commit-message-lint` job runs `scripts/verify_closing_keyword_syntax.sh` against every commit in a PR, catching the "closes REPO#N" mistake mechanically (GitHub's auto-close parser only recognizes bare `#N` or `owner/repo#N`). This happened twice in one day despite being documented both times — a checklist reminder alone didn't hold, so this replaces it with a real gate, not a sharper reminder. Fast, no build required. Tested locally against good/bad/mixed/edge cases before wiring into CI (see commit message). Optional follow-up for you to consider separately: whether to add this job to the branch-protection ruleset as a required check — that's a repo-settings change outside what I'll do unilaterally. Not merging — CI running, will confirm green.