### PR TITLE
W-eval quick batch: reproducible codegen, INSTALL.md tier caveat, pytest collection fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,45 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   in fallback mode (#236).
 - `platform/freertos/lwip_stub`'s `sockets.h` shim had a struct/typedef
   tag mismatch that broke the DoIP FreeRTOS compile-only CI build (#229).
+- `tools/codegen.py`'s `_now_utc()` (the single choke point for every
+  "Generated :"/`generated`/`generatedAt` timestamp written into `.c`,
+  `.h`, generated pytest files, `sovd_cda.json`, and the manifest) always
+  used wall-clock time — generating the same config twice, a second
+  apart, produced byte-different output even though the only real
+  difference was the timestamp. Now honours `SOURCE_DATE_EPOCH`
+  ([reproducible-builds.org convention](https://reproducible-builds.org/specs/source-date-epoch/))
+  when set, falling back to wall-clock time with a warning on an invalid
+  value (#224). Verified locally: same epoch → byte-identical timestamp
+  across repeated calls; invalid epoch → warns and falls back correctly.
+- `tests/test_license_expiry.py` was a standalone `unittest`-style
+  script (`if __name__ == "__main__":` runner block only, no
+  pytest-discoverable `test_*` functions or `TestCase`) — `pytest
+  tests/test_license_expiry.py` silently collected zero tests whenever
+  `tools/_license.py` was actually importable (a real commercial
+  checkout), giving silent zero-coverage on license-expiry regression
+  via the canonical `pytest tests/` sweep. Converted to real
+  `test_*` functions with real assertions; direct invocation
+  (`python3 tests/test_license_expiry.py`) still works. Verified with a
+  temporary mock `_license` module (this public checkout has no real
+  one to test against): pytest now collects and passes all 3 scenarios,
+  and a deliberately broken grace-period case correctly fails with a
+  clear assertion message before being reverted (#227).
 
 ### Documentation
+
+- `INSTALL.md` Step 6 told every customer "All tests should pass"
+  running the generated suite with no tier caveat — a Developer-only
+  install (no `xaloqi-tester`/TestLab) correctly generates the tests but
+  has nothing installed to execute them against a CAN interface, so
+  pytest collects and skips rather than fails. Added an explicit note:
+  what Step 6 verifies standalone at the Developer tier (codegen
+  succeeded, generated C compiles, suite is collectible) vs. what needs
+  TestLab installed (#225).
+- `docs/CODEGEN_ARCHITECTURE.md` claimed generated output is "fully
+  deterministic... byte-identical" unconditionally — true for content,
+  false for bytes by default (the embedded wall-clock timestamp, #224).
+  Corrected to describe the real, `SOURCE_DATE_EPOCH`-gated behavior
+  instead of the blanket claim.
 
 - `docs/TESTING_STRATEGY.md`: unit module count corrected 42/44 → 45 (3
   places), DoIP ZTEST case count corrected 24 → 30 (7 places, uniformly

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -212,7 +212,23 @@ cd examples/bms_ecu/generated/tests
 pytest . -v --can-interface=simulator
 ```
 
-All tests should pass. This validates the generated code, the license key, and the testgen pipeline in one command.
+**Developer-tier customers: expect most of these tests to *skip*, not
+fail.** The generated suite's `conftest.py` drives the CAN interface via
+the separate `xaloqi-tester` package, which ships with **TestLab**, not
+the Developer/Professional EDS overlay — a Developer-only install
+correctly generates the pytest files (codegen succeeded, the license key
+is valid) but has nothing installed to actually execute them against a
+CAN interface, so pytest collects the suite and reports skips rather
+than failures. That's expected, not broken. What Step 6 *does* verify
+standalone at the Developer tier: codegen completed, the generated C
+compiles, and the test suite itself is well-formed and collectible. To
+see the tests actually run and pass end-to-end, install TestLab
+(`pip install xaloqi-tester`) — Professional-tier customers already have
+this, and it's what "All tests should pass" below assumes.
+
+With `xaloqi-tester` installed: all tests should pass. This validates
+the generated code, the license key, and the testgen pipeline in one
+command.
 
 ---
 

--- a/docs/CODEGEN_ARCHITECTURE.md
+++ b/docs/CODEGEN_ARCHITECTURE.md
@@ -58,7 +58,19 @@ This approach delivers several compounding advantages:
 
 ### Deterministic Output
 
-Generated code is fully deterministic: the same YAML always produces byte-identical output. This is essential for reproducible CI builds and for diff-based code review.
+Generated code's *content* is deterministic: the same YAML, templates,
+and generator version always produce the same DIDs, handlers, and safety
+wrappers. By default, output is **not** byte-identical between runs —
+every generated file embeds a wall-clock `Generated :`/`generated`
+timestamp (`tools/codegen.py`'s `_now_utc()`), so two runs of the same
+config a second apart differ at the byte level even though their
+substantive content is identical (issue #224). Set `SOURCE_DATE_EPOCH`
+(the [reproducible-builds.org convention](https://reproducible-builds.org/specs/source-date-epoch/))
+to a fixed Unix timestamp before running `codegen.py` to get genuinely
+byte-identical output across runs — this is what CI, diff-based code
+review, and qualification/provenance tooling that needs true
+reproducibility should do, rather than relying on wall-clock output
+matching by chance.
 
 ### Safety Integration
 

--- a/tests/test_license_expiry.py
+++ b/tests/test_license_expiry.py
@@ -9,17 +9,21 @@ Three scenarios:
   2. Grace       — 10 days after expiry (within 14-day grace window)
   3. Expired     — 20 days after expiry (grace period over)
 
-Run:
+Collected by the canonical `pytest tests/` sweep (issue #227 — this file
+used to be a standalone unittest-style script with only an
+`if __name__ == "__main__":` runner block, so pytest silently collected
+zero tests from it despite the filename matching its default discovery
+pattern). Direct invocation still works too:
+
     cd /path/to/EDS
     python3 tests/test_license_expiry.py
-
-Exit 0 if all three scenarios produce the expected LicenseStatus.
 """
 import sys
-import time
-import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
 
@@ -43,8 +47,9 @@ except ImportError:
         sys.exit(0)
     # Collected by pytest — turn the import error into a proper SKIP report
     # instead of a collection error.
-    import pytest
     pytest.skip(_ENV_SKIP_REASON, allow_module_level=True)
+
+DAY = 86400
 
 
 def _real_expires_at() -> int:
@@ -59,68 +64,54 @@ def _real_expires_at() -> int:
     return int(claims["exp"])
 
 
-def _run_scenario(label: str, fake_now: int) -> _license.LicenseResult:
+@pytest.fixture(scope="module")
+def expires_at() -> int:
+    """Real expiry timestamp of the installed key.
+
+    Skips (not fails) if no key is activated yet — same "environment
+    setup gap, not a regression" spirit as the _license import guard
+    above, since a fresh commercial checkout with _license.py present
+    but no key activated is a real, expected local-dev state.
+    """
+    try:
+        return _real_expires_at()
+    except RuntimeError as e:
+        pytest.skip(f"[ENV] {e}")
+
+
+def _check_at(fake_now: int) -> "_license.LicenseResult":
     with patch("_license.time") as mock_time:
         mock_time.time.return_value = fake_now
-        result = _license.check()
-    return result
+        return _license.check()
 
 
-def main() -> int:
-    print("=" * 60)
-    print("  Xaloqi EDS — License Expiry Simulation")
-    print("=" * 60)
+def test_valid_license_30_days_before_expiry(expires_at: int) -> None:
+    result = _check_at(expires_at - 30 * DAY)
+    assert result.status == _license.LicenseStatus.OK, (
+        f"expected OK 30 days before expiry, got {result.status.value} "
+        f"(days_left={result.days_left}, msg={result.message!r})"
+    )
 
-    try:
-        exp = _real_expires_at()
-    except RuntimeError as e:
-        print(f"\nERROR: {e}")
-        return 1
 
-    from datetime import datetime, timezone
-    exp_dt = datetime.fromtimestamp(exp, tz=timezone.utc).strftime("%Y-%m-%d")
-    print(f"\n  Real expiry date : {exp_dt}")
-    print(f"  Grace period     : {_license.GRACE_PERIOD_DAYS} days")
-    print()
+def test_grace_period_10_days_after_expiry(expires_at: int) -> None:
+    result = _check_at(expires_at + 10 * DAY)
+    assert result.status == _license.LicenseStatus.GRACE, (
+        f"expected GRACE 10 days after expiry (within the "
+        f"{_license.GRACE_PERIOD_DAYS}-day grace window), got "
+        f"{result.status.value} (days_left={result.days_left}, "
+        f"msg={result.message!r})"
+    )
 
-    DAY = 86400
-    scenarios = [
-        ("SCENARIO 1 — Valid (30 days before expiry)",
-         exp - 30 * DAY,
-         _license.LicenseStatus.OK),
-        ("SCENARIO 2 — Grace period (10 days after expiry)",
-         exp + 10 * DAY,
-         _license.LicenseStatus.GRACE),
-        ("SCENARIO 3 — Expired (20 days after expiry, grace over)",
-         exp + 20 * DAY,
-         _license.LicenseStatus.EXPIRED),
-    ]
 
-    all_pass = True
-    for label, fake_now, expected_status in scenarios:
-        fake_date = datetime.fromtimestamp(fake_now, tz=timezone.utc).strftime("%Y-%m-%d")
-        result = _run_scenario(label, fake_now)
-
-        ok = result.status == expected_status
-        icon = "PASS" if ok else "FAIL"
-        print(f"[{icon}] {label}")
-        print(f"       Simulated date : {fake_date}")
-        print(f"       Expected status: {expected_status.value}")
-        print(f"       Actual status  : {result.status.value}")
-        print(f"       days_left      : {result.days_left}")
-        if result.message:
-            for line in result.message.strip().splitlines():
-                print(f"       msg: {line}")
-        print()
-
-        if not ok:
-            all_pass = False
-
-    print("=" * 60)
-    print(f"  Result: {'ALL PASS' if all_pass else 'FAILURES DETECTED'}")
-    print("=" * 60)
-    return 0 if all_pass else 1
+def test_expired_20_days_after_expiry(expires_at: int) -> None:
+    result = _check_at(expires_at + 20 * DAY)
+    assert result.status == _license.LicenseStatus.EXPIRED, (
+        f"expected EXPIRED 20 days after expiry (past the "
+        f"{_license.GRACE_PERIOD_DAYS}-day grace window), got "
+        f"{result.status.value} (days_left={result.days_left}, "
+        f"msg={result.message!r})"
+    )
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -237,8 +237,28 @@ def _warn(message: str) -> None:
 
 
 def _now_utc() -> str:
-    """Return current time in ISO 8601 UTC format."""
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    """Return current time in ISO 8601 UTC format.
+
+    Honours SOURCE_DATE_EPOCH (https://reproducible-builds.org/specs/source-date-epoch/,
+    the widely-adopted reproducible-builds convention) when set, so that
+    identical (generator version + YAML + templates + flags) input produces
+    byte-identical output -- see issue #224. Every generated-file timestamp
+    ("Generated :", "generated", "generatedAt", "generated_at" fields) flows
+    through this single function.
+    """
+    epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    if epoch:
+        try:
+            when = datetime.fromtimestamp(int(epoch), tz=timezone.utc)
+        except ValueError:
+            _warn(
+                f"SOURCE_DATE_EPOCH={epoch!r} is not a valid integer Unix "
+                "timestamp -- ignoring, using current time instead."
+            )
+            when = datetime.now(timezone.utc)
+    else:
+        when = datetime.now(timezone.utc)
+    return when.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _c_identifier(name: str) -> str:


### PR DESCRIPTION
Fixes #224, #225, #227 — three small, low-risk issues from an external evaluator (W, v1.13.3 Phase 1), all independently re-verified against current `main` before fixing (not taken on the issue's own claims alone). See commit message for the full detail on each, including how each was locally verified (real byte-identical-output test for #224, a temporary mock `_license` module proving real pytest collection + a deliberately-broken-case failure for #227). Also fixed a real false claim in `docs/CODEGEN_ARCHITECTURE.md` ("fully deterministic... byte-identical" unconditionally, which was false by default before #224's fix and still conditional after it) — found while reading that doc for this batch, not previously filed as its own issue. CHANGELOG.md updated in this same branch. #226 (the ASIL warn-vs-fail design question) deliberately not included — needs your decision first, not a fix. Not merging — CI running, will confirm green.