### PR TITLE
ci: extend commit-message-lint to catch comma-list closes and PR bodies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,13 +242,15 @@ env:
 jobs:
 
   # ── Job 0: Commit message lint ──────────────────────────────────────────────
-  # Mechanical, unconditional gate for a mistake that already happened twice
-  # in one day despite being documented both times (xaloqi-knowledge
-  # lessons/run-030, run-031): a commit saying "closes EDS#N" instead of
-  # bare "closes #N" isn't recognized by GitHub's auto-close parser at all --
-  # no error, no warning, the issue just silently never closes. Cheap and
+  # Mechanical, unconditional gate for two independent GitHub closing-keyword
+  # mistakes that have each bitten this repo for real (xaloqi-knowledge
+  # lessons/run-024, run-030, run-031): "closes EDS#N" instead of bare
+  # "closes #N" (not recognized at all), and "fixes #1, #2, #3" (only the
+  # first-listed issue reliably auto-closes). Checks commit messages AND
+  # the PR body/description -- the comma-list mistake recurred in a PR body
+  # with otherwise-clean commits, proving both need covering. Cheap and
   # fast (no build), runs on every PR so it also catches direct human
-  # commits, not just agent sessions.
+  # edits, not just agent sessions.
   commit-message-lint:
     name: "Commit message lint (closing-keyword syntax)"
     runs-on: ubuntu-22.04
@@ -259,6 +261,11 @@ jobs:
           fetch-depth: 0
 
       - name: Verify closing-keyword syntax
+        env:
+          # Passed via env:, not interpolated into the script -- the PR
+          # body is untrusted, arbitrary text; env-var passing avoids any
+          # shell-injection risk that inlining it into `run:` would carry.
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           bash scripts/verify_closing_keyword_syntax.sh "${{ github.event.pull_request.base.sha }}"
 

--- a/scripts/verify_closing_keyword_syntax.sh
+++ b/scripts/verify_closing_keyword_syntax.sh
@@ -3,73 +3,113 @@
 # Xaloqi EDS
 # scripts/verify_closing_keyword_syntax.sh
 #
-# PURPOSE: Catch invalid GitHub issue-closing references BEFORE merge,
-#          mechanically -- not by an agent or human remembering to check.
+# PURPOSE: Catch invalid/unreliable GitHub issue-closing references BEFORE
+#          merge, mechanically -- not by an agent or human remembering to
+#          check. Checks both commit messages AND the PR body/description
+#          (GitHub parses closing keywords in both places independently --
+#          the second recurrence of this bug class happened purely in a PR
+#          body with clean commit messages, see below).
 #
-#          GitHub's auto-close keyword parser (close(s|d)/fix(es|ed)/
-#          resolve(s|d)) only recognizes two reference forms: bare `#123`
-#          (same-repo) or `owner/repo#123` (cross-repo). `EDS#123` (repo
-#          name, no owner, directly before `#`) matches neither -- it is
-#          not malformed enough to error or warn, it just silently isn't
-#          recognized as an issue reference at all. Four issues went
-#          unclosed this way in one PR with zero signal anything was
-#          wrong (xaloqi-knowledge lessons/run-030); the documented
-#          mitigation ("remember the correct syntax") demonstrably failed
-#          to prevent an immediate recurrence in the very next PR
-#          (lessons/run-031's sibling note). This script is the actual
-#          fix: a mechanical, unconditional gate, not a reminder.
+#          Two independent, unrelated bad patterns, both already bitten us
+#          for real:
+#
+#          1. REPO#N instead of #N or owner/repo#N (xaloqi-knowledge
+#             lessons/run-030). GitHub's auto-close parser only recognizes
+#             bare `#123` (same-repo) or `owner/repo#123` (cross-repo).
+#             `EDS#123` (repo name, no owner, directly before `#`) matches
+#             neither -- not malformed enough to error or warn, it just
+#             silently isn't recognized as an issue reference at all.
+#
+#          2. "Fixes #1, #2, #3" -- a comma-separated list of issue
+#             references after a SINGLE closing keyword (xaloqi-knowledge
+#             lessons/run-024). GitHub only reliably auto-closes the
+#             first-listed issue in a comma-list; the rest silently stay
+#             open. This bit us in a PR *body* (not a commit message) the
+#             same day the repo-prefix check above shipped -- proof this
+#             needed to cover PR bodies too, not just commits.
+#
+#          Fix for #2: repeat the keyword per issue instead of listing
+#          them together, e.g. "Fixes #1. Fixes #2. Fixes #3." rather than
+#          "Fixes #1, #2, #3."
 #
 # USAGE:
 #   bash scripts/verify_closing_keyword_syntax.sh [base-ref]
 #
-#   base-ref defaults to origin/main. Checks every commit in
-#   base-ref..HEAD. In CI, the checkout must have enough history to reach
-#   base-ref (fetch-depth: 0, or at least deep enough to cover the PR).
+#   base-ref defaults to origin/main. Checks every commit message in
+#   base-ref..HEAD, plus $PR_BODY (if set -- CI passes
+#   github.event.pull_request.body here; nothing to check locally outside
+#   a PR context, that's fine). In CI, the checkout must have enough
+#   history to reach base-ref (fetch-depth: 0, or at least deep enough to
+#   cover the PR).
 #
 # EXIT CODES:
-#   0  No repo-prefixed closing-keyword references found.
-#   1  At least one commit uses the invalid REPO#N form.
+#   0  No bad closing-keyword references found.
+#   1  At least one bad reference found (either pattern).
 # =============================================================================
 
 set -euo pipefail
 
 BASE="${1:-origin/main}"
-
-if ! git rev-parse --verify "${BASE}" >/dev/null 2>&1; then
-    echo "SKIP: base ref '${BASE}' not reachable (shallow clone or first commit on this branch) -- nothing to compare against."
-    exit 0
-fi
-
-RANGE="${BASE}..HEAD"
 bad_found=0
 
-# %H then a NUL-safe body would be nicer, but commit messages here are
-# plain text without embedded NULs in practice; %B per-commit via a
-# second git log call keeps this simple and readable.
-for commit in $(git rev-list "${RANGE}"); do
-    msg="$(git log -1 --format=%B "${commit}")"
-
-    # Capture whatever comes between a closing keyword and '#N'.
-    matches="$(grep -oP '(?i)\b(close[sd]?|fix(es|ed)?|resolve[sd]?)\s+\K[A-Za-z][A-Za-z0-9._/-]*#[0-9]+' <<< "${msg}" || true)"
-    [ -z "${matches}" ] && continue
+# --- Pattern 1: repo-prefixed reference (run-030) --------------------------
+check_repo_prefix() {
+    local where="$1" text="$2"
+    local matches
+    matches="$(grep -oP '(?i)\b(close[sd]?|fix(es|ed)?|resolve[sd]?)\s+\K[A-Za-z][A-Za-z0-9._/-]*#[0-9]+' <<< "${text}" || true)"
+    [ -z "${matches}" ] && return 0
 
     while IFS= read -r m; do
         [ -z "${m}" ] && continue
-        prefix="${m%%#*}"
-        # Bare '#N' never matches the pattern above (it requires a
-        # leading letter before '#'), so prefix is never empty here.
-        # 'owner/repo#N' contains a '/' -- valid, skip. Anything else
-        # (a bare repo name directly before '#') is the bug.
+        local prefix="${m%%#*}"
+        # Bare '#N' never matches the pattern above (it requires a leading
+        # letter before '#'), so prefix is never empty here. 'owner/repo#N'
+        # contains a '/' -- valid, skip. Anything else (a bare repo name
+        # directly before '#') is the bug.
         if [[ "${prefix}" != */* ]]; then
-            short="${commit:0:9}"
-            echo "::error::Commit ${short}: '${m}' is not valid GitHub closing-keyword syntax -- '${prefix}#N' (repo name, no owner) is never recognized as an issue reference. Use bare '#N' for a same-repo issue, or 'owner/${prefix}#N' for cross-repo. See xaloqi-knowledge lessons/run-030."
+            echo "::error::${where}: '${m}' is not valid GitHub closing-keyword syntax -- '${prefix}#N' (repo name, no owner) is never recognized as an issue reference. Use bare '#N' for a same-repo issue, or 'owner/${prefix}#N' for cross-repo. See xaloqi-knowledge lessons/run-030."
             bad_found=1
         fi
     done <<< "${matches}"
-done
+}
+
+# --- Pattern 2: comma-list after one keyword (run-024) ----------------------
+check_comma_list() {
+    local where="$1" text="$2"
+    local matches
+    matches="$(grep -ozP '(?i)\b(close[sd]?|fix(es|ed)?|resolve[sd]?)\s+([A-Za-z][A-Za-z0-9._/-]*)?#[0-9]+(\s*,\s*([A-Za-z][A-Za-z0-9._/-]*)?#[0-9]+)+' <<< "${text}" | tr '\0' '\n' || true)"
+    [ -z "${matches}" ] && return 0
+
+    while IFS= read -r m; do
+        [ -z "${m}" ] && continue
+        echo "::error::${where}: '${m}' lists multiple issues after one closing keyword -- GitHub only reliably auto-closes the FIRST one listed, the rest silently stay open. Repeat the keyword instead, e.g. 'Fixes #1. Fixes #2.' not 'Fixes #1, #2.'. See xaloqi-knowledge lessons/run-024."
+        bad_found=1
+    done <<< "${matches}"
+}
+
+check_all() {
+    local where="$1" text="$2"
+    check_repo_prefix "${where}" "${text}"
+    check_comma_list "${where}" "${text}"
+}
+
+# --- Commit messages ---------------------------------------------------------
+if git rev-parse --verify "${BASE}" >/dev/null 2>&1; then
+    for commit in $(git rev-list "${BASE}..HEAD"); do
+        msg="$(git log -1 --format=%B "${commit}")"
+        check_all "Commit ${commit:0:9}" "${msg}"
+    done
+else
+    echo "SKIP (commits): base ref '${BASE}' not reachable (shallow clone or first commit on this branch) -- nothing to compare against."
+fi
+
+# --- PR body (CI passes this via $PR_BODY; no-op locally) -------------------
+if [ -n "${PR_BODY:-}" ]; then
+    check_all "PR description" "${PR_BODY}"
+fi
 
 if [ "${bad_found}" -ne 0 ]; then
     exit 1
 fi
 
-echo "OK: no repo-prefixed closing-keyword references found in ${RANGE}."
+echo "OK: no bad closing-keyword references found."


### PR DESCRIPTION
Real gap found the same day the first version of this job shipped: it only scanned commit messages, but EDS#245's PR description used a closing keyword followed by a comma-separated list of three issue numbers — the exact pattern lessons/run-024 already documented (only the first-listed issue reliably auto-closes) — and slipped through because it lived in the PR body, not any commit. GitHub parses closing keywords in both places independently.

`scripts/verify_closing_keyword_syntax.sh` now checks both patterns (run-030 repo-prefix, run-024 comma-list) against both surfaces (every commit in the PR range, plus the PR body). Tested locally against 7 cases before wiring in, including the exact string that caused today's real miss (see commit message). Not merging — CI running, will confirm green.