### PR TITLE
activate.py: make the public file the single canonical implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **`tools/activate.py` had diverged into two incompatible
+  implementations, and every paying customer ran the one the docs were
+  not written against** (EDS-toolchain#99). EDS-toolchain kept a
+  separately-written `tools/activate.py` (`--key`/`--status`/`--quiet`)
+  that `build_release.sh` staged into the license ZIPs; INSTALL.md Step 2
+  tells customers to `unzip -o` the ZIP over their clone of this repo, so
+  that copy silently overwrote this repo's (`--key`/`--check`/
+  `--deactivate`) for every real Developer/Professional install. INSTALL.md
+  then documented `python3 tools/activate.py --check`, which the
+  overwritten file rejected — a customer following the documented step
+  order hit `error: unrecognized arguments: --check` on their first
+  activation command. This file is now the single canonical
+  implementation (EDS-toolchain stages it straight from here and no
+  longer keeps its own), with the ZIP-only features folded in so nothing
+  regresses: `--status` is accepted as an alias for `--check`, and
+  `--quiet` suppresses output on successful activation for CI/automation.
+  Also dropped a dead `_license.check.__wrapped__` probe whose result was
+  assigned and never read. Reported by an external evaluator mid-review
+  of v1.13.3.
+- `INSTALL.md`'s "Expected output" block for activation showed the
+  *other* implementation's format (`License: ACTIVE` / `Product:`), so it
+  was wrong for both files even before the flag mismatch. Replaced with
+  the real output, captured from a run against the shipped `_license.py`.
+
 ### Security
 
 - **`core/uds_services/service_0x23.c`, `service_0x34.c`, `service_0x35.c`,

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -154,14 +154,24 @@ Verify activation:
 python3 tools/activate.py --check
 ```
 
+`--status` is accepted as an alias for `--check`, and
+`--key ... --quiet` installs a key without printing anything (for CI and
+automation).
+
 Expected output:
 
 ```
-License: ACTIVE
-  Tier   : developer          (or: professional)
-  Email  : engineer@yourcompany.com
-  Expires: 2027-04-21
-  Product: xaloqi-eds v1
+License source: /home/you/.xaloqi/license.key
+
+============================================================
+  Xaloqi EDS — License Status
+============================================================
+  Status   : OK
+  Email    : engineer@yourcompany.com
+  Tier     : Developer          (or: Professional)
+  Expires  : 2027-04-21
+  Days left: 365
+============================================================
 ```
 
 ---

--- a/tools/activate.py
+++ b/tools/activate.py
@@ -14,12 +14,24 @@ PURPOSE: License key activation for Xaloqi EDS.
          It can validate and install keys but cannot generate them
          (the Ed25519 private key is never distributed).
 
+         THIS IS THE SINGLE CANONICAL IMPLEMENTATION. The Developer and
+         Professional license ZIPs ship this exact file (EDS-toolchain's
+         build_release.sh stages it straight from this repo), so the
+         `unzip -o` step in INSTALL.md overwrites it with an identical
+         copy rather than a second, separately-drifted one. Do not fork a
+         parallel activate.py into EDS-toolchain — that divergence was
+         EDS-toolchain#99. tests/test_activate_single_implementation.py
+         (EDS-toolchain) enforces this.
+
 USAGE:
     python3 tools/activate.py --key <YOUR_LICENSE_KEY>
 
+    # Silent install, for CI/automation:
+    python3 tools/activate.py --key <YOUR_LICENSE_KEY> --quiet
+
     # Or via environment variable (CI, Docker):
     export XALOQI_LICENSE_KEY=<YOUR_LICENSE_KEY>
-    python3 tools/activate.py --check
+    python3 tools/activate.py --check        # --status is an accepted alias
 
 EXIT CODES:
     0  Activation successful (or --check with a valid key).
@@ -63,7 +75,7 @@ def _require_license_module() -> None:
         sys.exit(1)
 
 
-def cmd_activate(key: str) -> None:
+def cmd_activate(key: str, quiet: bool = False) -> None:
     """Validate and install a license key."""
     _require_license_module()
 
@@ -72,9 +84,8 @@ def cmd_activate(key: str) -> None:
         print("ERROR: License key cannot be empty.", file=sys.stderr)
         sys.exit(1)
 
-    print("Validating license key...")
-
-    result = _license.check.__wrapped__(key) if hasattr(_license.check, "__wrapped__") else None
+    if not quiet:
+        print("Validating license key...")
 
     # Use the internal _verify_jwt directly for activation — we need to
     # validate the key before writing it, including expired keys (they
@@ -108,32 +119,33 @@ def cmd_activate(key: str) -> None:
     except OSError:
         pass  # Windows — ignore
 
-    print()
-    print("=" * 60)
-    print("  Xaloqi EDS — License Activated")
-    print("=" * 60)
-    print(f"  Email    : {email}")
-    print(f"  Tier     : {tier.capitalize()}")
-    print(f"  Expires  : {exp_str}", end="")
+    if not quiet:
+        print()
+        print("=" * 60)
+        print("  Xaloqi EDS — License Activated")
+        print("=" * 60)
+        print(f"  Email    : {email}")
+        print(f"  Tier     : {tier.capitalize()}")
+        print(f"  Expires  : {exp_str}", end="")
 
-    if days_left < 0:
-        days_expired = abs(days_left)
-        grace_left   = _license.GRACE_PERIOD_DAYS - days_expired
-        if grace_left > 0:
-            print(f"  ⚠  EXPIRED {days_expired}d ago — {grace_left}d grace period remains")
+        if days_left < 0:
+            days_expired = abs(days_left)
+            grace_left   = _license.GRACE_PERIOD_DAYS - days_expired
+            if grace_left > 0:
+                print(f"  ⚠  EXPIRED {days_expired}d ago — {grace_left}d grace period remains")
+            else:
+                print(f"  ✗  EXPIRED — grace period over. Renew at {_license.PURCHASE_URL}")
+        elif days_left <= 30:
+            print(f"  ({days_left} days remaining — renewal recommended)")
         else:
-            print(f"  ✗  EXPIRED — grace period over. Renew at {_license.PURCHASE_URL}")
-    elif days_left <= 30:
-        print(f"  ({days_left} days remaining — renewal recommended)")
-    else:
-        print(f"  ({days_left} days remaining)")
+            print(f"  ({days_left} days remaining)")
 
-    print(f"  Saved to : {_license.LICENSE_FILE_PATH}")
-    print("=" * 60)
-    print()
-    print("  Run codegen to confirm activation:")
-    print("    python3 tools/codegen.py --config diagnostics_config.yaml --out generated/")
-    print()
+        print(f"  Saved to : {_license.LICENSE_FILE_PATH}")
+        print("=" * 60)
+        print()
+        print("  Run codegen to confirm activation:")
+        print("    python3 tools/codegen.py --config diagnostics_config.yaml --out generated/")
+        print()
 
 
 def cmd_check() -> None:
@@ -212,6 +224,12 @@ def main() -> None:
             "  # Check the currently installed key:\n"
             "  python3 tools/activate.py --check\n"
             "\n"
+            "  # Check using the alias accepted for ZIP compatibility:\n"
+            "  python3 tools/activate.py --status\n"
+            "\n"
+            "  # Silent install for CI/automation:\n"
+            "  python3 tools/activate.py --key eyJhbGciOiJFZERTQSJ9... --quiet\n"
+            "\n"
             "  # Remove the locally stored key:\n"
             "  python3 tools/activate.py --deactivate\n"
             "\n"
@@ -228,8 +246,13 @@ def main() -> None:
         help="License key JWT string to activate.",
     )
     group.add_argument(
-        "--check", "-c",
+        # --status is an accepted alias: the license ZIPs used to ship a
+        # separate activate.py whose only status flag was --status
+        # (EDS-toolchain#99). Keeping it means customers who learned that
+        # flag are not broken by the consolidation.
+        "--check", "--status", "-c",
         action="store_true",
+        dest="check",
         help="Check the currently installed license key and exit.",
     )
     group.add_argument(
@@ -238,10 +261,16 @@ def main() -> None:
         help="Remove the locally stored license key file.",
     )
 
+    parser.add_argument(
+        "--quiet", "-q",
+        action="store_true",
+        help="Suppress output on successful activation (for CI/automation).",
+    )
+
     args = parser.parse_args()
 
     if args.key:
-        cmd_activate(args.key)
+        cmd_activate(args.key, quiet=args.quiet)
     elif args.check:
         cmd_check()
     elif args.deactivate:


### PR DESCRIPTION
Half of the fix for Xaloqi/EDS-toolchain#99. **Depends-on: Xaloqi/EDS-toolchain#102** — merge this one first; the toolchain PR stages this file into the ZIPs and deletes its own copy.

## The bug

There were two independently-written `tools/activate.py` files:

| | flags | shipped to |
|---|---|---|
| this repo | `--key` / `--check` / `--deactivate` | free / trial / evaluator users who clone |
| EDS-toolchain | `--key` / `--status` / `--quiet` | every Developer & Professional customer, via the ZIP |

`build_release.sh:225` staged the toolchain's copy into the ZIP, and INSTALL.md Step 2 tells customers to `unzip -o` the ZIP over their clone of this repo. So the ZIP's copy silently overwrote this one on disk for every paying customer — and INSTALL.md:154 then told them to run `--check`, which that copy rejects.

**A customer following INSTALL.md's own step order fails on their first activation command.** Reported by an external evaluator mid-review of v1.13.3.

## The fix

This file becomes the single canonical implementation. Rather than pick a winner and drop features, the two ZIP-only behaviours are folded in so no customer regresses:

- `--status` is accepted as an alias for `--check` (`dest="check"`), so anyone who learned the flag from the ZIP is not broken.
- `--quiet` suppresses output on successful `--key` activation, for CI/automation.

Kept from this file: `--deactivate` (the toolchain copy had no equivalent), and the graceful `_HAS_LICENSE_MODULE` degradation, which the toolchain copy lacked — it hard-exits with *"This file should be present in your license ZIP"*, the wrong message for a public-repo user who has no ZIP. That alone settles which file should be canonical.

Also removed a dead `_license.check.__wrapped__` probe whose result was assigned and never read.

## INSTALL.md was wrong for *both* files

Its "Expected output" block showed `License: ACTIVE / Tier / Email / Expires / Product` — the **toolchain** file's format — while documenting `--check`, **this** file's flag. So the doc matched neither implementation end to end. Replaced with real captured output.

## Verification

Ran all four flag forms against the actually-shipped `_license.py` (patching `_verify_jwt`/`_load_raw_key` the way `tests/test_license_feature_gate.py` does), rather than transcribing expected output by hand:

- `--key` → activation banner, key written
- `--key --quiet` → no stdout, exit 0
- `--check` → status banner
- `--status` → byte-identical to `--check`

Confirmed first that the shipped `_license.py` exposes everything this file needs (`_verify_jwt`, `LICENSE_FILE_PATH`, `GRACE_PERIOD_DAYS`, `PURCHASE_URL`, `LICENSE_ENV_VAR`, `LicenseStatus`, `is_usable`) — the toolchain copy used a narrower surface, so this had to be checked before making the public file canonical.

Closing keyword deliberately omitted: the issue lives in EDS-toolchain and only the paired PR completes the fix (lessons/run-029).
