### PR TITLE
codegen: ASIL builds must declare CAN IDs explicitly, not inherit defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+### Changed
+
+- **ASIL builds now *fail* rather than warn when CAN diagnostic addressing
+  is not declared explicitly** (#226). `validate_safety_config()`'s check 5
+  was the only one of its five ASIL checks that merely warned — checks 3
+  (write-security) and 4 (P2 timing) were already fatal. Silently falling
+  back to `rx=0x7DF` / `tx=0x7E8` is not a benign default: `0x7DF` is the
+  ISO 15765-4 *functional* (broadcast) request ID, so a defaulted ECU
+  services requests addressed to every ECU on the bus, and any second
+  defaulted ECU answers on the same `0x7E8`. Neither is visible in the
+  generated code — it surfaces as bus misbehaviour during integration.
+  Gated on the new `ASIL_B_REQUIRE_EXPLICIT_CAN_IDS` constant, mirroring
+  `ASIL_B_REQUIRE_WRITE_SECURITY`'s documented ISO 26262-8 §7 deviation
+  override. The check also now catches a `can:` section that declares only
+  one of the two IDs, which previously passed while still inheriting the
+  other default. **Only affects ASIL builds** — `validate_safety_config()`
+  runs solely under `--safety-wrappers`; non-safety generation is
+  unchanged.
+- The 10 example configs that relied on the implicit defaults now declare
+  `can.rx_can_id` / `can.tx_can_id` explicitly, matching the block already
+  present in `robot_joint_controller_ecu` and `sensor_ecu_freertos`. The
+  declared values are the previous effective defaults, so **generated
+  output is byte-identical** — verified by regenerating against
+  `origin/main`'s `codegen.py` and diffing (timestamps excluded).
+
 ### Security
 
 - **`core/uds_services/service_0x23.c`, `service_0x34.c`, `service_0x35.c`,

--- a/examples/ardep_ecu/diagnostics_config.yaml
+++ b/examples/ardep_ecu/diagnostics_config.yaml
@@ -51,6 +51,10 @@ metadata:
 # ISO 14229-1 §7.2 / ARDEP default timing configuration
 # P2_server_max is intentionally conservative for prototyping use
 # -----------------------------------------------------------------------------
+can:
+  rx_can_id: "0x7DF"  # ISO 15765-4 functional addressing (request)
+  tx_can_id: "0x7E8"  # ISO 15765-4 physical response (ECU address 0)
+
 timing:
   p2_server_max_ms:       25     # Max ECU response time (ISO default: 50ms)
   p2_star_server_max_ms:  5000   # Extended response pending window

--- a/examples/basic_ecu/diagnostics_config.yaml
+++ b/examples/basic_ecu/diagnostics_config.yaml
@@ -27,6 +27,10 @@ metadata:
   version:  "0.1.0"
   description: "Example ECU for Xaloqi EDS demonstration"
 
+can:
+  rx_can_id: "0x7DF"  # ISO 15765-4 functional addressing (request)
+  tx_can_id: "0x7E8"  # ISO 15765-4 physical response (ECU address 0)
+
 timing:
   p2_server_max_ms:       25
   p2_star_server_max_ms:  5000

--- a/examples/basic_ecu_doip/diagnostics_config.yaml
+++ b/examples/basic_ecu_doip/diagnostics_config.yaml
@@ -34,6 +34,10 @@ ecu:
     source_address:  "0x0E00"   # Expected tester address (xaloqi-tester default)
     port:            13400       # Standard DoIP TCP port (ISO 13400)
 
+can:
+  rx_can_id: "0x7DF"  # ISO 15765-4 functional addressing (request)
+  tx_can_id: "0x7E8"  # ISO 15765-4 physical response (ECU address 0)
+
 timing:
   p2_server_max_ms:       25
   p2_star_server_max_ms:  5000

--- a/examples/basic_ecu_doip_freertos/diagnostics_config.yaml
+++ b/examples/basic_ecu_doip_freertos/diagnostics_config.yaml
@@ -34,6 +34,10 @@ ecu:
     source_address:  "0x0E00"   # Expected tester address (xaloqi-tester default)
     port:            13400       # Standard DoIP TCP port (ISO 13400)
 
+can:
+  rx_can_id: "0x7DF"  # ISO 15765-4 functional addressing (request)
+  tx_can_id: "0x7E8"  # ISO 15765-4 physical response (ECU address 0)
+
 timing:
   p2_server_max_ms:       25
   p2_star_server_max_ms:  5000

--- a/examples/basic_ecu_freertos/diagnostics_config.yaml
+++ b/examples/basic_ecu_freertos/diagnostics_config.yaml
@@ -27,6 +27,10 @@ metadata:
   version:  "0.1.0"
   description: "Example ECU for Xaloqi EDS demonstration"
 
+can:
+  rx_can_id: "0x7DF"  # ISO 15765-4 functional addressing (request)
+  tx_can_id: "0x7E8"  # ISO 15765-4 physical response (ECU address 0)
+
 timing:
   p2_server_max_ms:       25
   p2_star_server_max_ms:  5000

--- a/examples/bms_ecu/diagnostics_config.yaml
+++ b/examples/bms_ecu/diagnostics_config.yaml
@@ -56,6 +56,10 @@ metadata:
 # P2_server_max is 50 ms (ISO default) — BMS computations can be slow due to
 # Kalman filter / SoC estimation algorithms running in extended session.
 # -----------------------------------------------------------------------------
+can:
+  rx_can_id: "0x7DF"  # ISO 15765-4 functional addressing (request)
+  tx_can_id: "0x7E8"  # ISO 15765-4 physical response (ECU address 0)
+
 timing:
   p2_server_max_ms:       50     # Max ECU response time (ISO 14229 default)
   p2_star_server_max_ms:  5000   # Extended response pending window

--- a/examples/motor_controller_ecu/diagnostics_config.yaml
+++ b/examples/motor_controller_ecu/diagnostics_config.yaml
@@ -62,6 +62,10 @@ metadata:
 # embedded system; 25 ms is achievable for all read-only DIDs. FOC runs at
 # ≥ 10 kHz; DID reads are background priority and non-blocking.
 # -----------------------------------------------------------------------------
+can:
+  rx_can_id: "0x7DF"  # ISO 15765-4 functional addressing (request)
+  tx_can_id: "0x7E8"  # ISO 15765-4 physical response (ECU address 0)
+
 timing:
   p2_server_max_ms:       25
   p2_star_server_max_ms:  5000

--- a/examples/safeboot_ecu/diagnostics_config.yaml
+++ b/examples/safeboot_ecu/diagnostics_config.yaml
@@ -47,6 +47,10 @@ metadata:
     automatically so 0x34/0x36/0x37 accept firmware downloads without manual
     flash ops registration.
 
+can:
+  rx_can_id: "0x7DF"  # ISO 15765-4 functional addressing (request)
+  tx_can_id: "0x7E8"  # ISO 15765-4 physical response (ECU address 0)
+
 timing:
   p2_server_max_ms:       50     # Extended for flash erase (0x78 pending used)
   p2_star_server_max_ms:  5000

--- a/examples/safeboot_freertos_ecu/diagnostics_config.yaml
+++ b/examples/safeboot_freertos_ecu/diagnostics_config.yaml
@@ -40,6 +40,10 @@ metadata:
     Uses STM32H743 dual-bank flash: Bank 2 is the OTA staging area.
     safeboot.platform: freertos wires freertos_flash_ops_init() automatically.
 
+can:
+  rx_can_id: "0x7DF"  # ISO 15765-4 functional addressing (request)
+  tx_can_id: "0x7E8"  # ISO 15765-4 physical response (ECU address 0)
+
 timing:
   p2_server_max_ms:       50     # Extended for flash erase (0x78 pending used)
   p2_star_server_max_ms:  5000

--- a/examples/sensor_ecu/diagnostics_config.yaml
+++ b/examples/sensor_ecu/diagnostics_config.yaml
@@ -60,6 +60,10 @@ metadata:
     Reads ambient temperature and supply voltage via the Zephyr sensor API,
     exposes measurements as UDS DIDs, and raises DTCs on out-of-range conditions.
 
+can:
+  rx_can_id: "0x7DF"  # ISO 15765-4 functional addressing (request)
+  tx_can_id: "0x7E8"  # ISO 15765-4 physical response (ECU address 0)
+
 timing:
   p2_server_max_ms:       25
   p2_star_server_max_ms:  5000

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -185,6 +185,29 @@ ASIL_B_REQUIRE_EXPLICIT_SESSION: bool = True
 #:   Do NOT set it False globally without per-DID justification.
 ASIL_B_REQUIRE_WRITE_SECURITY: bool = True  # [HIGH-1 FIX] Hard error, not advisory.
 
+#: ASIL-B requires the CAN addressing section to be declared explicitly.
+#:
+#: [#226 FIX] Set to True — an ASIL build with no explicit rx_can_id/tx_can_id
+#: is now a hard fatal error, not an advisory warning. This aligns check 5 with
+#: checks 3 and 4 in validate_safety_config(), which were already fatal; it was
+#: the only ASIL check that merely warned.
+#:
+#: RATIONALE: the fallback is rx=0x7DF, the ISO 15765-4 *functional* (broadcast)
+#: request ID, answered on tx=0x7E8 (physical response, ECU address 0). Silently
+#: defaulting a safety-relevant ECU to those means (a) it services diagnostic
+#: requests broadcast to every ECU on the bus rather than ones physically
+#: addressed to it, and (b) any second ECU that also defaulted answers on the
+#: same 0x7E8, so two ECUs collide on one response ID. Neither is detectable
+#: from the generated code — it surfaces as bus misbehaviour during
+#: integration. An ASIL-B ECU's diagnostic addressing must be a deliberate,
+#: reviewed decision, not a fallback nobody chose.
+#:
+#: TO OVERRIDE (requires formal safety deviation record):
+#:   Declare can.rx_can_id and can.tx_can_id in the YAML, OR set
+#:   ASIL_B_REQUIRE_EXPLICIT_CAN_IDS = False here with a documented deviation
+#:   record justifying reliance on the defaults per ISO 26262-8 §7.
+ASIL_B_REQUIRE_EXPLICIT_CAN_IDS: bool = True  # [#226 FIX] Hard error, not advisory.
+
 _DID_PATTERN = re.compile(r"^0[xX][0-9A-Fa-f]{4}$")
 _DTC_PATTERN = re.compile(r"^0[xX][0-9A-Fa-f]{6}$")
 _RID_PATTERN = re.compile(r"^0[xX][0-9A-Fa-f]{4}$")  # RID is 16-bit like DID
@@ -1054,7 +1077,9 @@ def validate_safety_config(cfg: Dict[str, Any], asil_level: str = "B") -> None:
          (Advisory: ASIL_B_REQUIRE_WRITE_SECURITY controls whether this is fatal.)
       4. Timing constraints must meet minimum ASIL-B response headroom:
          p2_server_max_ms >= 10 ms (below 10 ms is unrealistic for ASIL-B).
-      5. CAN addressing section must be present in ASIL builds (no defaults).
+      5. CAN addressing (rx_can_id + tx_can_id) must be declared explicitly
+         in ASIL builds — no silent fallback to 0x7DF / 0x7E8.
+         (ASIL_B_REQUIRE_EXPLICIT_CAN_IDS controls whether this is fatal.)
 
     Args:
         cfg:        Validated configuration dictionary (validate_config passed).
@@ -1127,12 +1152,37 @@ def validate_safety_config(cfg: Dict[str, Any], asil_level: str = "B") -> None:
         )
 
     # ── 5. CAN section must be explicit in ASIL builds ───────────────────────
-    if not cfg.get("can"):
-        _warn(
-            "SAFETY ADVISORY: No 'can' section found in config. "
-            "ASIL builds should explicitly declare rx_can_id and tx_can_id "
-            "rather than relying on defaults (0x7DF / 0x7E8)."
-        )
+    # Both IDs must be declared, not merely the section: a config carrying only
+    # rx_can_id still silently inherits tx=0x7E8, which is the half that makes
+    # two defaulted ECUs collide on one response ID.
+    can_cfg = cfg.get("can") or {}
+    missing_ids = [k for k in ("rx_can_id", "tx_can_id") if not can_cfg.get(k)]
+    if missing_ids:
+        if not can_cfg:
+            what = "No 'can' section found in config"
+        else:
+            what = f"'can' section does not declare {' and '.join(missing_ids)}"
+
+        if ASIL_B_REQUIRE_EXPLICIT_CAN_IDS:
+            _fatal(
+                f"SAFETY [#226]: {what}.  "
+                "ASIL builds must declare CAN diagnostic addressing explicitly "
+                "rather than inheriting the defaults (rx=0x7DF, tx=0x7E8).  "
+                "0x7DF is the ISO 15765-4 functional (broadcast) request ID, so "
+                "a defaulted ECU answers requests addressed to every ECU on the "
+                "bus, and any second defaulted ECU responds on the same 0x7E8.  "
+                "FIX: set can.rx_can_id and can.tx_can_id in "
+                "diagnostics_config.yaml for this ECU.  "
+                "OVERRIDE (requires formal deviation record per ISO 26262-8 §7): "
+                "set ASIL_B_REQUIRE_EXPLICIT_CAN_IDS = False in tools/codegen.py "
+                "with a documented justification for relying on the defaults."
+            )
+        else:
+            _warn(
+                f"SAFETY ADVISORY: {what}. "
+                "ASIL builds should explicitly declare rx_can_id and tx_can_id "
+                "rather than relying on defaults (0x7DF / 0x7E8)."
+            )
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #226.

## The call this issue was waiting on

The codebase had already answered it. `validate_safety_config()` runs five ASIL checks; checks 3 (write-security) and 4 (P2 timing) are **fatal**, and check 3 is fatal *behind a documented, overridable constant* with an ISO 26262-8 §7 deviation path. Check 5 was the only one that merely warned. So this isn't a new policy — it's the existing policy applied consistently.

## Why the default isn't benign

`_build_can_context()` falls back to `rx=0x7DF`, `tx=0x7E8`. `0x7DF` is the ISO 15765-4 **functional (broadcast)** request ID. A safety-relevant ECU that inherits it:

- services diagnostic requests broadcast to *every* ECU on the bus, rather than ones physically addressed to it, and
- collides with any second defaulted ECU, since both answer on `0x7E8`.

Neither is detectable from the generated code — it surfaces as bus misbehaviour during integration, which is the worst place to find it.

## Change

- New `ASIL_B_REQUIRE_EXPLICIT_CAN_IDS: bool = True`, documented in the same shape as `ASIL_B_REQUIRE_WRITE_SECURITY`, with the same "set it False *with a formal deviation record*" override.
- Check 5 now also catches a `can:` section declaring only **one** of the two IDs. That previously passed validation while still silently inheriting the other default — the half that makes two ECUs collide.
- The 10 example configs that relied on the defaults now declare them, matching the block already in `robot_joint_controller_ecu` and `sensor_ecu_freertos`.

**Blast radius is ASIL-only.** `validate_safety_config()` is called solely under `--safety-wrappers` (codegen.py:2381), so non-safety generation is untouched.

## Verification

The risk here was breaking the release gate, since `build_harness.sh` and the gate's codegen smoke both run ASIL generation over these examples.

- **Generated output is byte-identical.** The declared values equal the previous effective defaults. Regenerated `basic_ecu` with `origin/main`'s `codegen.py` as a true pre-fix baseline and diffed against the new run: identical except timestamps. Committed `examples/*/generated/` therefore needed no regeneration.
- **The gate fires, and correctly**, verified against the unfixed state rather than assumed:
  - no `can:` section → fatal, `SAFETY [#226]: No 'can' section found in config.`
  - `can:` with `rx_can_id` only → fatal, naming `tx_can_id` specifically
  - no `--safety-wrappers` → generation completes, unaffected
- Gate's codegen smoke target (`bms_ecu`) generates clean.
- 426 generated-test cases pass.
- The toolchain's cross-repo `test_example_freshness.py` — which regenerates every specialist example and diffs against this repo's committed output — still passes 8/8.

## Not changed on purpose

Every example now declares `0x7DF`/`0x7E8`, i.e. its previous effective addressing. Giving the specialist examples *distinct physical* IDs would be more realistic for a multi-ECU bus, but it would change generated output and could break harness expectations and TestLab campaigns that assume those IDs. That's a separate, deliberate decision rather than something to slip into a safety-gate fix.

## Filed while here

`codegen` emits `generated/dtc_config.h`, which no example commits and nothing `#include`s — the generator half of #175/#176 shipped without its consumer. Pre-existing (reproduced against `origin/main`), filed as #249.
