### PR TITLE
release: bump version 1.13.3 -> 1.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+## [1.13.4] — 2026-09-04
+
 ### Security
 
 - **`core/uds_services/service_0x23.c`, `service_0x34.c`, `service_0x35.c`,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@
 #
 # SAFETY CONTEXT : Contains ASIL-B candidate modules (ISO 26262 Part 6).
 # CODING STANDARD: MISRA C:2012 alignment intended.
-# VERSION        : 1.13.3
+# VERSION        : 1.13.4
 # SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 
@@ -74,7 +74,7 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(zephyr_diagnostics_suite
-    VERSION     1.13.3
+    VERSION     1.13.4
     LANGUAGES   C
     DESCRIPTION "Production-grade UDS/ISO-TP diagnostics stack for Zephyr RTOS"
 )

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 > repo. Community users cloning the public repo can ignore this file.
 
 **Product:** Xaloqi EDS (Xaloqi Embedded Diagnostic Suite)  
-**Version:** v1.13.3  
+**Version:** v1.13.4  
 **Support:** contact@xaloqi.com
 
 ---
@@ -50,7 +50,7 @@ cd EDS
 Verify you are on the correct version:
 
 ```bash
-git checkout v1.13.3
+git checkout v1.13.4
 ```
 
 ---
@@ -59,10 +59,10 @@ git checkout v1.13.3
 
 ```bash
 # From the EDS repo root:
-unzip -o /path/to/xaloqi-eds-developer-v1.13.3.zip
+unzip -o /path/to/xaloqi-eds-developer-v1.13.4.zip
 
 # Or for Professional:
-unzip -o /path/to/xaloqi-eds-professional-v1.13.3.zip
+unzip -o /path/to/xaloqi-eds-professional-v1.13.4.zip
 ```
 
 The `-o` flag overwrites existing files without prompting — required when updating an existing installation.
@@ -75,7 +75,7 @@ The `-o` flag overwrites existing files without prompting — required when upda
 >
 > ```bash
 > rm -f tools/templates tools/testgen.py tools/_license.py harness
-> unzip -o /path/to/xaloqi-eds-developer-v1.13.3.zip
+> unzip -o /path/to/xaloqi-eds-developer-v1.13.4.zip
 > ```
 
 This extracts the toolchain files directly into the repo tree. No separate directory. After extraction you will have:
@@ -195,7 +195,7 @@ Expected output:
 
 ```
 ========================================================================
-  Xaloqi EDS — Code Generator v1.13.3
+  Xaloqi EDS — Code Generator v1.13.4
 ========================================================================
   Config   : examples/bms_ecu/diagnostics_config.yaml
   ...

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Xaloqi Embedded Diagnostics Suite
 
 [![CI](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml/badge.svg)](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-v1.13.3-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.13.3)
+[![Version](https://img.shields.io/badge/version-v1.13.4-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.13.4)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](LICENSE)
 [![Zephyr](https://img.shields.io/badge/Zephyr-v3.7%2B-brightgreen)](https://zephyrproject.org)
 
@@ -22,7 +22,7 @@ Zephyr's `native_sim`. No CAN hardware, no commercial license:
 
 ```bash
 pip install west
-west init -m https://github.com/Xaloqi/EDS --mr v1.13.3 eds-workspace
+west init -m https://github.com/Xaloqi/EDS --mr v1.13.4 eds-workspace
 cd eds-workspace && west update
 pip install -r tools/requirements.txt
 
@@ -166,7 +166,7 @@ manifest:
   projects:
     - name: EDS
       remote: xaloqi
-      revision: v1.13.3
+      revision: v1.13.4
       path: modules/eds
 ```
 
@@ -218,7 +218,7 @@ The `ZEPHYR_EDS_MODULE_DIR` variable is set automatically by west when the modul
 
 ```bash
 pip install west
-west init -m https://github.com/Xaloqi/EDS --mr v1.13.3 eds-workspace
+west init -m https://github.com/Xaloqi/EDS --mr v1.13.4 eds-workspace
 cd eds-workspace && west update
 pip install -r tools/requirements.txt
 ```
@@ -497,7 +497,7 @@ Unlike alternatives that use PolyForm Noncommercial (which prohibits production 
 **Just want to see an ECU run?**
 
 ```bash
-west init -m https://github.com/Xaloqi/EDS --mr v1.13.3 eds-workspace
+west init -m https://github.com/Xaloqi/EDS --mr v1.13.4 eds-workspace
 cd eds-workspace && west update
 west build -b native_sim examples/basic_ecu \
   -- -DDTC_OVERLAY_FILE=boards/native_sim/native_sim.overlay \

--- a/core/uds_types.h
+++ b/core/uds_types.h
@@ -36,10 +36,10 @@ extern "C" {
  * -------------------------------------------------------------------------- */
 #define UDS_SUITE_VERSION_MAJOR  (1U)
 #define UDS_SUITE_VERSION_MINOR  (13U)
-#define UDS_SUITE_VERSION_PATCH  (3U)
+#define UDS_SUITE_VERSION_PATCH  (4U)
 
 /** Compile-time version string — matches UDS_STACK_VERSION in safety_config.h. */
-#define UDS_SUITE_VERSION_STRING "1.13.3"
+#define UDS_SUITE_VERSION_STRING "1.13.4"
 
 /* --------------------------------------------------------------------------
  * Buffer and protocol sizing constants

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -13,7 +13,7 @@ ISO 15765-2 (ISO-TP) diagnostics stack for embedded RTOS targets. It is YAML-dri
 describe your DIDs, DTCs, and routines in YAML, run the code generator, and receive
 ASIL-B safety-wrapped C code ready to compile into your ECU firmware.
 
-**Version:** v1.13.3
+**Version:** v1.13.4
 **Target RTOS:** Zephyr v3.7+ · FreeRTOS (any version with static allocation support)
 **Target boards:** native_sim (CI/dev) · STM32 Nucleo-H743ZI2 (Cortex-M7) · NXP FRDM-MCX-N947 (MCX N947, Cortex-M33) · NXP MR-CANHUBK3 (S32K344, Cortex-M7) · QEMU ARM Cortex-M4 (FreeRTOS CI)
 **Transport:** ISO-TP over CAN (default) · DoIP over Ethernet/TCP (v1.6.0+)
@@ -1033,5 +1033,5 @@ tooling and lives in EDS-toolchain — it is not part of this repo's public CI.)
 
 ---
 
-*EDS v1.13.3 — Developer €690/yr · Professional €1,990/yr — xaloqi.com*
+*EDS v1.13.4 — Developer €690/yr · Professional €1,990/yr — xaloqi.com*
 *Runtime: GPL v2 · Examples: Apache 2.0 · Tools + IDE + GUI: Commercial*

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture — Xaloqi EDS
 
-**Version:** v1.13.3  
+**Version:** v1.13.4  
 **Status:** Production-ready. All CI jobs passing.
 
 ---

--- a/docs/CODEGEN_ARCHITECTURE.md
+++ b/docs/CODEGEN_ARCHITECTURE.md
@@ -571,7 +571,7 @@ SDV tooling, OEM SOVD clients, or any tool that understands the OpenSOVD
 ```json
 {
   "sovdVersion": "1.0.0",
-  "generatedBy":  "Xaloqi EDS codegen v1.13.3",
+  "generatedBy":  "Xaloqi EDS codegen v1.13.4",
   "generatedAt":  "<ISO 8601 UTC>",
   "ecuIdentification": {
     "name":    "<ecu_name>",

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -61,7 +61,7 @@ west --version   # must print 1.2 or newer
 mkdir eds-workspace && cd eds-workspace
 
 # Initialise the workspace from the EDS repository
-west init -m https://github.com/Xaloqi/EDS --mr v1.13.3 .
+west init -m https://github.com/Xaloqi/EDS --mr v1.13.4 .
 
 # Pull Zephyr and all dependencies (this downloads ~500 MB, takes 2-4 min)
 west update

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -1,10 +1,10 @@
 # Integration Guide
 
-## Xaloqi EDS — Zephyr RTOS, FreeRTOS, DoIP, and SOVD (v1.13.3)
+## Xaloqi EDS — Zephyr RTOS, FreeRTOS, DoIP, and SOVD (v1.13.4)
 
 | Field | Value |
 |---|---|
-| Stack version | 1.13.3 |
+| Stack version | 1.13.4 |
 | Zephyr version | v3.7.0 (pinned in `west.yml`) |
 | FreeRTOS version | FreeRTOS-Kernel (any recent release; tested with HEAD) |
 | ISO standard | ISO 14229-1:2020 (UDS), ISO 15765-2:2016 (ISO-TP), ISO 13400-2 (DoIP) |
@@ -186,7 +186,7 @@ manifest:
 
     - name: embedded-diagnostics-suite
       url: https://github.com/your-org/embedded-diagnostics-suite
-      revision: v1.13.3            # pin to a release tag
+      revision: v1.13.4            # pin to a release tag
       path: eds
 ```
 
@@ -1256,7 +1256,7 @@ The flag is opt-in — omitting it leaves all existing behaviour unchanged.
 ```json
 {
   "sovdVersion": "1.0.0",
-  "generatedBy": "Xaloqi EDS codegen v1.13.3",
+  "generatedBy": "Xaloqi EDS codegen v1.13.4",
   "generatedAt": "2026-05-20T10:00:00Z",
   "ecuIdentification": {
     "name": "BasicECU",

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -1,6 +1,6 @@
 # Testing Strategy — Xaloqi EDS
 
-**Version:** v1.13.3  
+**Version:** v1.13.4  
 **Status:** 45/45 unit test modules passing. 68/68 harness tests passing. 21/21 CI jobs green. FreeRTOS, SafeBoot (Zephyr + FreeRTOS), DoIP, and sensor examples all covered.
 
 ---
@@ -10,7 +10,7 @@
 EDS uses a four-layer testing strategy: unit tests, harness tests, integration tests, and system
 tests. All four layers run automatically in CI on every push and pull request.
 
-**Current test counts (v1.13.3):**
+**Current test counts (v1.13.4):**
 
 | Layer | Count | Framework | Status |
 |---|---|---|---|
@@ -30,7 +30,7 @@ tests. All four layers run automatically in CI on every push and pull request.
 ### What "the generated pytest suite" (row above) actually runs on a clean checkout
 
 `cd examples/basic_ecu/generated/tests && pytest --collect-only -q` reports **632 tests
-collected** for `basic_ecu` (v1.13.3). That is a *collection* count, not a claim that
+collected** for `basic_ecu` (v1.13.4). That is a *collection* count, not a claim that
 632 tests execute — and pass — right after `pip install -r tools/requirements.txt`. A
 meaningful share need TestLab (the commercial `xaloqi-tester` package), the
 (not-publicly-included) `firmware_bus` harness, or the commercial `tools/templates/`

--- a/examples/ardep_ecu/generated/safety_config.h
+++ b/examples/ardep_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.3"
+#define UDS_STACK_VERSION "1.13.4"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu/generated/safety_config.h
+++ b/examples/basic_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.3"
+#define UDS_STACK_VERSION "1.13.4"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu_doip/generated/safety_config.h
+++ b/examples/basic_ecu_doip/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.3"
+#define UDS_STACK_VERSION "1.13.4"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu_doip_freertos/generated/safety_config.h
+++ b/examples/basic_ecu_doip_freertos/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.3"
+#define UDS_STACK_VERSION "1.13.4"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu_freertos/generated/safety_config.h
+++ b/examples/basic_ecu_freertos/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.3"
+#define UDS_STACK_VERSION "1.13.4"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/bms_ecu/generated/safety_config.h
+++ b/examples/bms_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.3"
+#define UDS_STACK_VERSION "1.13.4"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/motor_controller_ecu/generated/safety_config.h
+++ b/examples/motor_controller_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.3"
+#define UDS_STACK_VERSION "1.13.4"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/robot_joint_controller_ecu/generated/safety_config.h
+++ b/examples/robot_joint_controller_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.3"
+#define UDS_STACK_VERSION "1.13.4"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/safeboot_ecu/generated/safety_config.h
+++ b/examples/safeboot_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.3"
+#define UDS_STACK_VERSION "1.13.4"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/safeboot_freertos_ecu/generated/safety_config.h
+++ b/examples/safeboot_freertos_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.3"
+#define UDS_STACK_VERSION "1.13.4"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/sensor_ecu/generated/safety_config.h
+++ b/examples/sensor_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.3"
+#define UDS_STACK_VERSION "1.13.4"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/sensor_ecu_freertos/generated/safety_config.h
+++ b/examples/sensor_ecu_freertos/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.3"
+#define UDS_STACK_VERSION "1.13.4"
 
 /* =============================================================================
  * ASIL level identification

--- a/sbom.json
+++ b/sbom.json
@@ -4,7 +4,7 @@
   "serialNumber": "urn:uuid:7b3c9a5d-1f2e-4c8b-a6d0-8e4f2b1c5a3d",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-09-02T00:00:00Z",
+    "timestamp": "2026-09-04T00:00:00Z",
     "tools": [
       {
         "vendor": "Xaloqi",
@@ -14,9 +14,9 @@
     ],
     "component": {
       "type": "firmware",
-      "bom-ref": "xaloqi-eds@1.13.3",
+      "bom-ref": "xaloqi-eds@1.13.4",
       "name": "Xaloqi EDS",
-      "version": "1.13.3",
+      "version": "1.13.4",
       "description": "Production-grade UDS/ISO-TP/DoIP diagnostics stack for automotive ECUs (ASIL-B candidate, ISO 14229 / ISO 15765-2 / ISO 13400-2)",
       "licenses": [
         {

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -100,7 +100,7 @@ except ImportError:
     print("ERROR: Jinja2 is required.  pip install jinja2", file=sys.stderr)
     sys.exit(2)
 
-__version__ = "1.13.3"
+__version__ = "1.13.4"
 
 # =============================================================================
 # Constants


### PR DESCRIPTION
Release bump for **v1.13.4**, produced by `xaloqi-knowledge/scripts/bump_release_version.py` (43 files across 3 repos).

**Depends-on: Xaloqi/EDS-toolchain#103** and `Xaloqi/automation`'s `release/v1.13.4` — all three must merge before tagging.

## Why this release matters now

The v1.13.3 delivery ZIP **still ships the broken `activate.py`**. I verified it against the published artifact:

```
flags in delivery-v1.13.3 ZIP: --key --quiet --status
accepts --check (what INSTALL.md tells customers to run)?  NO
```

So EDS-toolchain#99 is fixed on `main` but has never reached anything a customer can download — including the external evaluator who reported it. Every Developer/Professional customer following INSTALL.md's own step order still fails on their first activation command today.

It also carries a **Security** entry: #233's exact-length validation on `0x23`/`0x34`/`0x35`/`0x3D`, from the Tier-1 review. That's been sitting unreleased since 2026-09-02.

14 commits total since the `v1.13.3` tag, including the #226 ASIL CAN-ID gate.

## Verification

- **Runbook step 2 spot-check passed.** A real `codegen.py` regen of `bms_ecu` against the toolchain templates differs from what the bump script wrote **only in the timestamp line**, and `UDS_STACK_VERSION` matches at `"1.13.4"` in both. This is the check that confirms the script's targeted literal edit agrees with what real codegen actually produces (lessons/run-014 spirit).
- **`check_release_docs.py --expected-version 1.13.4`** — no hard version-header/badge drift.
  - Note the flag matters: without it the script derives ground truth from `git describe`, which is still `v1.13.3` pre-tag, and reports all 19 correctly-bumped files as failures. Inverted, not real.
  - Its one remaining warning is a false positive: `EDS-toolchain/README.md:182` reads *"by 4 unit tests (37 → 45 jobrunner tests total)"* — a sentence about jobrunner counts, not a version claim.
- `check_versions.py` now reports EDS v1.13.4 as authoritative.

## Not done in this PR

Tagging and the GitHub Release are runbook steps 4–5, after this merges. The gate (`build_release.sh`) is step 6 and runs against the **tagged ref**, not `main` — the lesson from v1.13.3.
