### PR TITLE
Commit generated dtc_config.h for all examples; fail loudly without it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **`examples/*/generated/dtc_config.h` is now committed for all 12
+  examples** (#249). `codegen.py` has rendered this file since #176, but no
+  example committed it, so the repo's committed `generated/` did not match
+  what the generator produces. The Professional harness consumes it via
+  `#if __has_include("dtc_config.h")` and falls back to registering
+  `basic_ecu`'s two DTCs when absent — correct for the basic_ecu family,
+  silently wrong for any other example (`bms_ecu` declares 10, `ardep_ecu`
+  19). Delivery ZIPs were never affected: `build_release.sh` regenerates
+  `generated/` at staging, verified against the shipped v1.13.4 artifacts.
+  Committing the file makes a repo checkout behave like the ZIP.
+- `build_harness.sh` now **fails** if the selected example has no
+  `generated/dtc_config.h`, instead of building something quietly
+  incorrect. Since codegen emits the file unconditionally — including for a
+  config with an empty `dtcs:` list, verified — its absence always means
+  `generated/` predates #176 rather than "this ECU has no DTCs".
+
+  Scope note: this is correctness hygiene, not a fix for a failing test.
+  The 68 harness assertions are hardcoded to `basic_ecu`'s DID/routine
+  fixture, so no DTC assertion existed that the missing file could have
+  broken — see #252.
+
 ## [1.13.4] — 2026-09-04
 
 ### Security

--- a/build_harness.sh
+++ b/build_harness.sh
@@ -92,6 +92,31 @@ if [[ ! -f "${EXAMPLE_GENERATED}/did_handlers.c" ]]; then
     exit 1
 fi
 
+# EDS#249: harness_ecu.c pulls in this example's DTCs via
+#   #if __has_include("dtc_config.h")
+# and falls back to registering basic_ecu's two DTCs when the file is absent.
+# That fallback is correct for the basic_ecu family and silently WRONG for any
+# other example -- bms_ecu declares 10 DTCs, ardep_ecu 19 -- with no warning,
+# so DTC assertions would run against the wrong data.
+#
+# Since codegen renders dtc_config.h unconditionally (it is emitted even for a
+# config with an empty dtcs: list), its absence always means generated/ predates
+# that change rather than "this ECU has no DTCs". So fail loudly instead of
+# building something quietly incorrect.
+if [[ ! -f "${EXAMPLE_GENERATED}/dtc_config.h" ]]; then
+    echo "ERROR: ${EXAMPLE_GENERATED}/dtc_config.h not found." >&2
+    echo "" >&2
+    echo "  Without it the harness would silently register basic_ecu's DTCs" >&2
+    echo "  instead of ${EXAMPLE}'s, and any DTC assertion would test the" >&2
+    echo "  wrong data (EDS#249)." >&2
+    echo "" >&2
+    echo "Regenerate it with:" >&2
+    echo "  python3 tools/codegen.py \\" >&2
+    echo "             --config examples/${EXAMPLE}/diagnostics_config.yaml \\" >&2
+    echo "             --out examples/${EXAMPLE}/generated/ --safety-wrappers --asil-level B --no-manifest" >&2
+    exit 1
+fi
+
 OUTPUT="${OUTPUT:-/tmp/harness_ecu_test_${EXAMPLE}}"
 
 # ---------------------------------------------------------------------------

--- a/examples/ardep_ecu/generated/dtc_config.h
+++ b/examples/ardep_ecu/generated/dtc_config.h
@@ -1,0 +1,77 @@
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: GENERATED — dtc_config.h
+ *
+ * ECU       : ARDEP_IOController
+ * Version   : 1.0.0
+ * Generated : 2026-09-04T13:51:27Z
+ *
+ * PURPOSE: Per-example DTC table, exposed as an X-macro list so any
+ *          translation unit that already links against this example's
+ *          generated/ sources (e.g. harness/harness_ecu.c) can register
+ *          this example's DTCs without a per-example switch statement —
+ *          the same "compile against examples/<name>/generated/" mechanism
+ *          did_handlers.c and routine_handlers.c already use (issue #158).
+ *
+ *          Architecture:
+ *            diagnostics_config.yaml (dtcs section)
+ *              -> tools/codegen.py (build_dtc_config_context)
+ *                -> tools/templates/dtc_config.h.j2
+ *                  -> generated/dtc_config.h  (this file)
+ *
+ *          NOTE: codegen.py's RENDER_PLAN lives in the public EDS repo.
+ *          Wiring this template into that RENDER_PLAN is tracked as a
+ *          follow-up there; until then this file is kept in sync by hand
+ *          from each example's own generated/uds_init.c Step 5 block (the
+ *          canonical, already-codegen-produced source of truth for that
+ *          example's DTCs) — same content, just re-exposed as an X-macro
+ *          list so harness_ecu.c can consume it generically.
+ *
+ * USAGE:
+ *   #define REGISTER_ONE_DTC(code, severity, desc) \
+ *       (void)dtc_database_register((uint32_t)(code), (uint8_t)(severity), (desc));
+ *   GEN_DTC_TABLE(REGISTER_ONE_DTC)
+ *   #undef REGISTER_ONE_DTC
+ *
+ * WARNING: DO NOT EDIT MANUALLY once codegen.py renders this template.
+ *          Until then, regenerate by hand from this example's
+ *          generated/uds_init.c Step 5 block if diagnostics_config.yaml's
+ *          dtcs: section changes.
+ *
+ * SAFETY  : DTC codes and severities govern SID 0x19 (ReadDTCInformation)
+ *           and SID 0x14 (ClearDiagnosticInformation) responses.
+ * STANDARD: MISRA C:2012 alignment intended.
+ * =============================================================================
+ */
+
+#ifndef DTC_CONFIG_H
+#define DTC_CONFIG_H
+
+/*
+ * X-macro list of this example's DTCs: (code, severity byte, description).
+ * Severity encoding (SAE J2012-DA): 0x20 = check_at_next_halt, 0x40 = other.
+ * Invoke as GEN_DTC_TABLE(X) with X(code, severity, desc) defined by the
+ * caller; #undef X immediately after use.
+ */
+#define GEN_DTC_TABLE(X) \
+    X((uint32_t)12583168UL, (uint8_t)0x20U, "CAN bus communication loss — no frames received > 500ms") \
+    X((uint32_t)12583424UL, (uint8_t)0x20U, "CAN bus error passive — TX/RX error counters exceeded 127") \
+    X((uint32_t)12583680UL, (uint8_t)0x20U, "CAN bus off — transmitter disabled by bus-off recovery") \
+    X((uint32_t)12587008UL, (uint8_t)0x40U, "LIN bus no response — no slave response within timeout") \
+    X((uint32_t)12587264UL, (uint8_t)0x40U, "LIN bus framing error — break field or sync byte invalid") \
+    X((uint32_t)11534592UL, (uint8_t)0x20U, "Output 1 overcurrent — load current exceeded threshold") \
+    X((uint32_t)11534848UL, (uint8_t)0x20U, "Output 2 overcurrent — load current exceeded threshold") \
+    X((uint32_t)11535104UL, (uint8_t)0x20U, "Output 3 overcurrent — load current exceeded threshold") \
+    X((uint32_t)11535360UL, (uint8_t)0x20U, "Output 4 overcurrent — load current exceeded threshold") \
+    X((uint32_t)11535616UL, (uint8_t)0x20U, "Output 5 overcurrent — load current exceeded threshold") \
+    X((uint32_t)11535872UL, (uint8_t)0x20U, "Output 6 overcurrent — load current exceeded threshold") \
+    X((uint32_t)11538432UL, (uint8_t)0x40U, "PowerIO open load — output commanded ON but no current detected") \
+    X((uint32_t)12648192UL, (uint8_t)0x20U, "Supply voltage low — below 9.0V for > 500ms") \
+    X((uint32_t)12648208UL, (uint8_t)0x20U, "Supply voltage high — above 16.0V for > 100ms") \
+    X((uint32_t)12648224UL, (uint8_t)0x20U, "ECU overtemperature — internal junction > 125°C") \
+    X((uint32_t)12648240UL, (uint8_t)0x40U, "Watchdog reset event — firmware failed to service watchdog") \
+    X((uint32_t)12648256UL, (uint8_t)0x40U, "NVM write failure — diagnostic session statistics not persisted") \
+    X((uint32_t)12647936UL, (uint8_t)0x20U, "Firmware image verification failed — CRC mismatch") \
+    X((uint32_t)12647952UL, (uint8_t)0x40U, "Firmware download incomplete — transfer interrupted")
+#endif /* DTC_CONFIG_H */

--- a/examples/basic_ecu/generated/dtc_config.h
+++ b/examples/basic_ecu/generated/dtc_config.h
@@ -1,0 +1,60 @@
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: GENERATED — dtc_config.h
+ *
+ * ECU       : BasicECU
+ * Version   : 0.1.0
+ * Generated : 2026-09-04T13:51:27Z
+ *
+ * PURPOSE: Per-example DTC table, exposed as an X-macro list so any
+ *          translation unit that already links against this example's
+ *          generated/ sources (e.g. harness/harness_ecu.c) can register
+ *          this example's DTCs without a per-example switch statement —
+ *          the same "compile against examples/<name>/generated/" mechanism
+ *          did_handlers.c and routine_handlers.c already use (issue #158).
+ *
+ *          Architecture:
+ *            diagnostics_config.yaml (dtcs section)
+ *              -> tools/codegen.py (build_dtc_config_context)
+ *                -> tools/templates/dtc_config.h.j2
+ *                  -> generated/dtc_config.h  (this file)
+ *
+ *          NOTE: codegen.py's RENDER_PLAN lives in the public EDS repo.
+ *          Wiring this template into that RENDER_PLAN is tracked as a
+ *          follow-up there; until then this file is kept in sync by hand
+ *          from each example's own generated/uds_init.c Step 5 block (the
+ *          canonical, already-codegen-produced source of truth for that
+ *          example's DTCs) — same content, just re-exposed as an X-macro
+ *          list so harness_ecu.c can consume it generically.
+ *
+ * USAGE:
+ *   #define REGISTER_ONE_DTC(code, severity, desc) \
+ *       (void)dtc_database_register((uint32_t)(code), (uint8_t)(severity), (desc));
+ *   GEN_DTC_TABLE(REGISTER_ONE_DTC)
+ *   #undef REGISTER_ONE_DTC
+ *
+ * WARNING: DO NOT EDIT MANUALLY once codegen.py renders this template.
+ *          Until then, regenerate by hand from this example's
+ *          generated/uds_init.c Step 5 block if diagnostics_config.yaml's
+ *          dtcs: section changes.
+ *
+ * SAFETY  : DTC codes and severities govern SID 0x19 (ReadDTCInformation)
+ *           and SID 0x14 (ClearDiagnosticInformation) responses.
+ * STANDARD: MISRA C:2012 alignment intended.
+ * =============================================================================
+ */
+
+#ifndef DTC_CONFIG_H
+#define DTC_CONFIG_H
+
+/*
+ * X-macro list of this example's DTCs: (code, severity byte, description).
+ * Severity encoding (SAE J2012-DA): 0x20 = check_at_next_halt, 0x40 = other.
+ * Invoke as GEN_DTC_TABLE(X) with X(code, severity, desc) defined by the
+ * caller; #undef X immediately after use.
+ */
+#define GEN_DTC_TABLE(X) \
+    X((uint32_t)12583168UL, (uint8_t)0x20U, "CAN bus communication loss") \
+    X((uint32_t)12583424UL, (uint8_t)0x40U, "Diagnostic transport layer timeout")
+#endif /* DTC_CONFIG_H */

--- a/examples/basic_ecu_doip/generated/dtc_config.h
+++ b/examples/basic_ecu_doip/generated/dtc_config.h
@@ -1,0 +1,60 @@
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: GENERATED — dtc_config.h
+ *
+ * ECU       : BasicECU_DoIP
+ * Version   : 1.6.0
+ * Generated : 2026-09-04T13:51:27Z
+ *
+ * PURPOSE: Per-example DTC table, exposed as an X-macro list so any
+ *          translation unit that already links against this example's
+ *          generated/ sources (e.g. harness/harness_ecu.c) can register
+ *          this example's DTCs without a per-example switch statement —
+ *          the same "compile against examples/<name>/generated/" mechanism
+ *          did_handlers.c and routine_handlers.c already use (issue #158).
+ *
+ *          Architecture:
+ *            diagnostics_config.yaml (dtcs section)
+ *              -> tools/codegen.py (build_dtc_config_context)
+ *                -> tools/templates/dtc_config.h.j2
+ *                  -> generated/dtc_config.h  (this file)
+ *
+ *          NOTE: codegen.py's RENDER_PLAN lives in the public EDS repo.
+ *          Wiring this template into that RENDER_PLAN is tracked as a
+ *          follow-up there; until then this file is kept in sync by hand
+ *          from each example's own generated/uds_init.c Step 5 block (the
+ *          canonical, already-codegen-produced source of truth for that
+ *          example's DTCs) — same content, just re-exposed as an X-macro
+ *          list so harness_ecu.c can consume it generically.
+ *
+ * USAGE:
+ *   #define REGISTER_ONE_DTC(code, severity, desc) \
+ *       (void)dtc_database_register((uint32_t)(code), (uint8_t)(severity), (desc));
+ *   GEN_DTC_TABLE(REGISTER_ONE_DTC)
+ *   #undef REGISTER_ONE_DTC
+ *
+ * WARNING: DO NOT EDIT MANUALLY once codegen.py renders this template.
+ *          Until then, regenerate by hand from this example's
+ *          generated/uds_init.c Step 5 block if diagnostics_config.yaml's
+ *          dtcs: section changes.
+ *
+ * SAFETY  : DTC codes and severities govern SID 0x19 (ReadDTCInformation)
+ *           and SID 0x14 (ClearDiagnosticInformation) responses.
+ * STANDARD: MISRA C:2012 alignment intended.
+ * =============================================================================
+ */
+
+#ifndef DTC_CONFIG_H
+#define DTC_CONFIG_H
+
+/*
+ * X-macro list of this example's DTCs: (code, severity byte, description).
+ * Severity encoding (SAE J2012-DA): 0x20 = check_at_next_halt, 0x40 = other.
+ * Invoke as GEN_DTC_TABLE(X) with X(code, severity, desc) defined by the
+ * caller; #undef X immediately after use.
+ */
+#define GEN_DTC_TABLE(X) \
+    X((uint32_t)12583168UL, (uint8_t)0x20U, "CAN bus communication loss") \
+    X((uint32_t)12583424UL, (uint8_t)0x40U, "Diagnostic transport layer timeout")
+#endif /* DTC_CONFIG_H */

--- a/examples/basic_ecu_doip_freertos/generated/dtc_config.h
+++ b/examples/basic_ecu_doip_freertos/generated/dtc_config.h
@@ -1,0 +1,60 @@
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: GENERATED — dtc_config.h
+ *
+ * ECU       : BasicECU_DoIP_FreeRTOS
+ * Version   : 1.6.0
+ * Generated : 2026-09-04T13:51:28Z
+ *
+ * PURPOSE: Per-example DTC table, exposed as an X-macro list so any
+ *          translation unit that already links against this example's
+ *          generated/ sources (e.g. harness/harness_ecu.c) can register
+ *          this example's DTCs without a per-example switch statement —
+ *          the same "compile against examples/<name>/generated/" mechanism
+ *          did_handlers.c and routine_handlers.c already use (issue #158).
+ *
+ *          Architecture:
+ *            diagnostics_config.yaml (dtcs section)
+ *              -> tools/codegen.py (build_dtc_config_context)
+ *                -> tools/templates/dtc_config.h.j2
+ *                  -> generated/dtc_config.h  (this file)
+ *
+ *          NOTE: codegen.py's RENDER_PLAN lives in the public EDS repo.
+ *          Wiring this template into that RENDER_PLAN is tracked as a
+ *          follow-up there; until then this file is kept in sync by hand
+ *          from each example's own generated/uds_init.c Step 5 block (the
+ *          canonical, already-codegen-produced source of truth for that
+ *          example's DTCs) — same content, just re-exposed as an X-macro
+ *          list so harness_ecu.c can consume it generically.
+ *
+ * USAGE:
+ *   #define REGISTER_ONE_DTC(code, severity, desc) \
+ *       (void)dtc_database_register((uint32_t)(code), (uint8_t)(severity), (desc));
+ *   GEN_DTC_TABLE(REGISTER_ONE_DTC)
+ *   #undef REGISTER_ONE_DTC
+ *
+ * WARNING: DO NOT EDIT MANUALLY once codegen.py renders this template.
+ *          Until then, regenerate by hand from this example's
+ *          generated/uds_init.c Step 5 block if diagnostics_config.yaml's
+ *          dtcs: section changes.
+ *
+ * SAFETY  : DTC codes and severities govern SID 0x19 (ReadDTCInformation)
+ *           and SID 0x14 (ClearDiagnosticInformation) responses.
+ * STANDARD: MISRA C:2012 alignment intended.
+ * =============================================================================
+ */
+
+#ifndef DTC_CONFIG_H
+#define DTC_CONFIG_H
+
+/*
+ * X-macro list of this example's DTCs: (code, severity byte, description).
+ * Severity encoding (SAE J2012-DA): 0x20 = check_at_next_halt, 0x40 = other.
+ * Invoke as GEN_DTC_TABLE(X) with X(code, severity, desc) defined by the
+ * caller; #undef X immediately after use.
+ */
+#define GEN_DTC_TABLE(X) \
+    X((uint32_t)12583168UL, (uint8_t)0x20U, "CAN bus communication loss") \
+    X((uint32_t)12583424UL, (uint8_t)0x40U, "Diagnostic transport layer timeout")
+#endif /* DTC_CONFIG_H */

--- a/examples/basic_ecu_freertos/generated/dtc_config.h
+++ b/examples/basic_ecu_freertos/generated/dtc_config.h
@@ -1,0 +1,60 @@
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: GENERATED — dtc_config.h
+ *
+ * ECU       : BasicECU
+ * Version   : 0.1.0
+ * Generated : 2026-09-04T13:51:28Z
+ *
+ * PURPOSE: Per-example DTC table, exposed as an X-macro list so any
+ *          translation unit that already links against this example's
+ *          generated/ sources (e.g. harness/harness_ecu.c) can register
+ *          this example's DTCs without a per-example switch statement —
+ *          the same "compile against examples/<name>/generated/" mechanism
+ *          did_handlers.c and routine_handlers.c already use (issue #158).
+ *
+ *          Architecture:
+ *            diagnostics_config.yaml (dtcs section)
+ *              -> tools/codegen.py (build_dtc_config_context)
+ *                -> tools/templates/dtc_config.h.j2
+ *                  -> generated/dtc_config.h  (this file)
+ *
+ *          NOTE: codegen.py's RENDER_PLAN lives in the public EDS repo.
+ *          Wiring this template into that RENDER_PLAN is tracked as a
+ *          follow-up there; until then this file is kept in sync by hand
+ *          from each example's own generated/uds_init.c Step 5 block (the
+ *          canonical, already-codegen-produced source of truth for that
+ *          example's DTCs) — same content, just re-exposed as an X-macro
+ *          list so harness_ecu.c can consume it generically.
+ *
+ * USAGE:
+ *   #define REGISTER_ONE_DTC(code, severity, desc) \
+ *       (void)dtc_database_register((uint32_t)(code), (uint8_t)(severity), (desc));
+ *   GEN_DTC_TABLE(REGISTER_ONE_DTC)
+ *   #undef REGISTER_ONE_DTC
+ *
+ * WARNING: DO NOT EDIT MANUALLY once codegen.py renders this template.
+ *          Until then, regenerate by hand from this example's
+ *          generated/uds_init.c Step 5 block if diagnostics_config.yaml's
+ *          dtcs: section changes.
+ *
+ * SAFETY  : DTC codes and severities govern SID 0x19 (ReadDTCInformation)
+ *           and SID 0x14 (ClearDiagnosticInformation) responses.
+ * STANDARD: MISRA C:2012 alignment intended.
+ * =============================================================================
+ */
+
+#ifndef DTC_CONFIG_H
+#define DTC_CONFIG_H
+
+/*
+ * X-macro list of this example's DTCs: (code, severity byte, description).
+ * Severity encoding (SAE J2012-DA): 0x20 = check_at_next_halt, 0x40 = other.
+ * Invoke as GEN_DTC_TABLE(X) with X(code, severity, desc) defined by the
+ * caller; #undef X immediately after use.
+ */
+#define GEN_DTC_TABLE(X) \
+    X((uint32_t)12583168UL, (uint8_t)0x20U, "CAN bus communication loss") \
+    X((uint32_t)12583424UL, (uint8_t)0x40U, "Diagnostic transport layer timeout")
+#endif /* DTC_CONFIG_H */

--- a/examples/bms_ecu/generated/dtc_config.h
+++ b/examples/bms_ecu/generated/dtc_config.h
@@ -1,0 +1,68 @@
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: GENERATED — dtc_config.h
+ *
+ * ECU       : BMS_MainController
+ * Version   : 1.0.0
+ * Generated : 2026-09-04T13:51:28Z
+ *
+ * PURPOSE: Per-example DTC table, exposed as an X-macro list so any
+ *          translation unit that already links against this example's
+ *          generated/ sources (e.g. harness/harness_ecu.c) can register
+ *          this example's DTCs without a per-example switch statement —
+ *          the same "compile against examples/<name>/generated/" mechanism
+ *          did_handlers.c and routine_handlers.c already use (issue #158).
+ *
+ *          Architecture:
+ *            diagnostics_config.yaml (dtcs section)
+ *              -> tools/codegen.py (build_dtc_config_context)
+ *                -> tools/templates/dtc_config.h.j2
+ *                  -> generated/dtc_config.h  (this file)
+ *
+ *          NOTE: codegen.py's RENDER_PLAN lives in the public EDS repo.
+ *          Wiring this template into that RENDER_PLAN is tracked as a
+ *          follow-up there; until then this file is kept in sync by hand
+ *          from each example's own generated/uds_init.c Step 5 block (the
+ *          canonical, already-codegen-produced source of truth for that
+ *          example's DTCs) — same content, just re-exposed as an X-macro
+ *          list so harness_ecu.c can consume it generically.
+ *
+ * USAGE:
+ *   #define REGISTER_ONE_DTC(code, severity, desc) \
+ *       (void)dtc_database_register((uint32_t)(code), (uint8_t)(severity), (desc));
+ *   GEN_DTC_TABLE(REGISTER_ONE_DTC)
+ *   #undef REGISTER_ONE_DTC
+ *
+ * WARNING: DO NOT EDIT MANUALLY once codegen.py renders this template.
+ *          Until then, regenerate by hand from this example's
+ *          generated/uds_init.c Step 5 block if diagnostics_config.yaml's
+ *          dtcs: section changes.
+ *
+ * SAFETY  : DTC codes and severities govern SID 0x19 (ReadDTCInformation)
+ *           and SID 0x14 (ClearDiagnosticInformation) responses.
+ * STANDARD: MISRA C:2012 alignment intended.
+ * =============================================================================
+ */
+
+#ifndef DTC_CONFIG_H
+#define DTC_CONFIG_H
+
+/*
+ * X-macro list of this example's DTCs: (code, severity byte, description).
+ * Severity encoding (SAE J2012-DA): 0x20 = check_at_next_halt, 0x40 = other.
+ * Invoke as GEN_DTC_TABLE(X) with X(code, severity, desc) defined by the
+ * caller; #undef X immediately after use.
+ */
+#define GEN_DTC_TABLE(X) \
+    X((uint32_t)13697280UL, (uint8_t)0x20U, "Cell group overvoltage — at least one cell group exceeded OV threshold") \
+    X((uint32_t)13697536UL, (uint8_t)0x20U, "Cell group undervoltage — at least one cell group dropped below UV threshold") \
+    X((uint32_t)13697792UL, (uint8_t)0x20U, "Cell overtemperature during discharge — cell NTC exceeded OT_discharge threshold") \
+    X((uint32_t)13698048UL, (uint8_t)0x20U, "Cell overtemperature during charge — cell NTC exceeded OT_charge threshold") \
+    X((uint32_t)13698304UL, (uint8_t)0x20U, "Pack overcurrent — pack current exceeded continuous current limit") \
+    X((uint32_t)13698560UL, (uint8_t)0x20U, "Isolation fault — pack-to-chassis isolation resistance below 100 Ohm/V") \
+    X((uint32_t)13698816UL, (uint8_t)0x20U, "Contactor weld detected — contactor failed to open on command") \
+    X((uint32_t)13699072UL, (uint8_t)0x20U, "Current sensor fault — sensor output out of plausibility range or open circuit") \
+    X((uint32_t)12583168UL, (uint8_t)0x20U, "CAN communication loss — no frames received from VSC/BCM for > 500 ms") \
+    X((uint32_t)13699328UL, (uint8_t)0x20U, "BMS internal MCU fault — watchdog reset or RAM check failure on startup")
+#endif /* DTC_CONFIG_H */

--- a/examples/motor_controller_ecu/generated/dtc_config.h
+++ b/examples/motor_controller_ecu/generated/dtc_config.h
@@ -1,0 +1,68 @@
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: GENERATED — dtc_config.h
+ *
+ * ECU       : MotorController_Inverter
+ * Version   : 1.0.0
+ * Generated : 2026-09-04T13:51:28Z
+ *
+ * PURPOSE: Per-example DTC table, exposed as an X-macro list so any
+ *          translation unit that already links against this example's
+ *          generated/ sources (e.g. harness/harness_ecu.c) can register
+ *          this example's DTCs without a per-example switch statement —
+ *          the same "compile against examples/<name>/generated/" mechanism
+ *          did_handlers.c and routine_handlers.c already use (issue #158).
+ *
+ *          Architecture:
+ *            diagnostics_config.yaml (dtcs section)
+ *              -> tools/codegen.py (build_dtc_config_context)
+ *                -> tools/templates/dtc_config.h.j2
+ *                  -> generated/dtc_config.h  (this file)
+ *
+ *          NOTE: codegen.py's RENDER_PLAN lives in the public EDS repo.
+ *          Wiring this template into that RENDER_PLAN is tracked as a
+ *          follow-up there; until then this file is kept in sync by hand
+ *          from each example's own generated/uds_init.c Step 5 block (the
+ *          canonical, already-codegen-produced source of truth for that
+ *          example's DTCs) — same content, just re-exposed as an X-macro
+ *          list so harness_ecu.c can consume it generically.
+ *
+ * USAGE:
+ *   #define REGISTER_ONE_DTC(code, severity, desc) \
+ *       (void)dtc_database_register((uint32_t)(code), (uint8_t)(severity), (desc));
+ *   GEN_DTC_TABLE(REGISTER_ONE_DTC)
+ *   #undef REGISTER_ONE_DTC
+ *
+ * WARNING: DO NOT EDIT MANUALLY once codegen.py renders this template.
+ *          Until then, regenerate by hand from this example's
+ *          generated/uds_init.c Step 5 block if diagnostics_config.yaml's
+ *          dtcs: section changes.
+ *
+ * SAFETY  : DTC codes and severities govern SID 0x19 (ReadDTCInformation)
+ *           and SID 0x14 (ClearDiagnosticInformation) responses.
+ * STANDARD: MISRA C:2012 alignment intended.
+ * =============================================================================
+ */
+
+#ifndef DTC_CONFIG_H
+#define DTC_CONFIG_H
+
+/*
+ * X-macro list of this example's DTCs: (code, severity byte, description).
+ * Severity encoding (SAE J2012-DA): 0x20 = check_at_next_halt, 0x40 = other.
+ * Invoke as GEN_DTC_TABLE(X) with X(code, severity, desc) defined by the
+ * caller; #undef X immediately after use.
+ */
+#define GEN_DTC_TABLE(X) \
+    X((uint32_t)13762816UL, (uint8_t)0x20U, "Phase overcurrent — at least one phase current exceeded peak current limit") \
+    X((uint32_t)13763072UL, (uint8_t)0x20U, "Gate driver desaturation — IGBT/SiC short-circuit detected by DESAT circuit") \
+    X((uint32_t)13763328UL, (uint8_t)0x20U, "DC-link overvoltage — bus voltage exceeded maximum continuous rating") \
+    X((uint32_t)13763584UL, (uint8_t)0x20U, "DC-link undervoltage — bus voltage dropped below minimum operating threshold") \
+    X((uint32_t)13763840UL, (uint8_t)0x20U, "IGBT overtemperature — estimated junction temperature exceeded protection threshold") \
+    X((uint32_t)13764096UL, (uint8_t)0x20U, "Motor stator overtemperature — winding NTC exceeded Class F insulation limit") \
+    X((uint32_t)13764352UL, (uint8_t)0x20U, "Resolver signal loss — sin/cos amplitude below minimum or plausibility check failed") \
+    X((uint32_t)13764608UL, (uint8_t)0x20U, "Current sensor fault — phase current out of plausibility range at zero torque") \
+    X((uint32_t)12583168UL, (uint8_t)0x20U, "CAN communication loss — no torque demand frames from VSC for > 100 ms") \
+    X((uint32_t)13764864UL, (uint8_t)0x20U, "MCU watchdog reset — firmware failed to service watchdog within timeout")
+#endif /* DTC_CONFIG_H */

--- a/examples/robot_joint_controller_ecu/generated/dtc_config.h
+++ b/examples/robot_joint_controller_ecu/generated/dtc_config.h
@@ -1,0 +1,63 @@
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: GENERATED — dtc_config.h
+ *
+ * ECU       : RobotJointController
+ * Version   : 1.0.0
+ * Generated : 2026-09-04T13:51:29Z
+ *
+ * PURPOSE: Per-example DTC table, exposed as an X-macro list so any
+ *          translation unit that already links against this example's
+ *          generated/ sources (e.g. harness/harness_ecu.c) can register
+ *          this example's DTCs without a per-example switch statement —
+ *          the same "compile against examples/<name>/generated/" mechanism
+ *          did_handlers.c and routine_handlers.c already use (issue #158).
+ *
+ *          Architecture:
+ *            diagnostics_config.yaml (dtcs section)
+ *              -> tools/codegen.py (build_dtc_config_context)
+ *                -> tools/templates/dtc_config.h.j2
+ *                  -> generated/dtc_config.h  (this file)
+ *
+ *          NOTE: codegen.py's RENDER_PLAN lives in the public EDS repo.
+ *          Wiring this template into that RENDER_PLAN is tracked as a
+ *          follow-up there; until then this file is kept in sync by hand
+ *          from each example's own generated/uds_init.c Step 5 block (the
+ *          canonical, already-codegen-produced source of truth for that
+ *          example's DTCs) — same content, just re-exposed as an X-macro
+ *          list so harness_ecu.c can consume it generically.
+ *
+ * USAGE:
+ *   #define REGISTER_ONE_DTC(code, severity, desc) \
+ *       (void)dtc_database_register((uint32_t)(code), (uint8_t)(severity), (desc));
+ *   GEN_DTC_TABLE(REGISTER_ONE_DTC)
+ *   #undef REGISTER_ONE_DTC
+ *
+ * WARNING: DO NOT EDIT MANUALLY once codegen.py renders this template.
+ *          Until then, regenerate by hand from this example's
+ *          generated/uds_init.c Step 5 block if diagnostics_config.yaml's
+ *          dtcs: section changes.
+ *
+ * SAFETY  : DTC codes and severities govern SID 0x19 (ReadDTCInformation)
+ *           and SID 0x14 (ClearDiagnosticInformation) responses.
+ * STANDARD: MISRA C:2012 alignment intended.
+ * =============================================================================
+ */
+
+#ifndef DTC_CONFIG_H
+#define DTC_CONFIG_H
+
+/*
+ * X-macro list of this example's DTCs: (code, severity byte, description).
+ * Severity encoding (SAE J2012-DA): 0x20 = check_at_next_halt, 0x40 = other.
+ * Invoke as GEN_DTC_TABLE(X) with X(code, severity, desc) defined by the
+ * caller; #undef X immediately after use.
+ */
+#define GEN_DTC_TABLE(X) \
+    X((uint32_t)10486017UL, (uint8_t)0x40U, "Axis 0 motor over-temperature (> 85 °C)") \
+    X((uint32_t)10486273UL, (uint8_t)0x40U, "Axis 0 drive over-current (> rated peak)") \
+    X((uint32_t)10486019UL, (uint8_t)0x40U, "Axis 0 encoder signal loss (no valid position update > 50 ms)") \
+    X((uint32_t)10486529UL, (uint8_t)0x20U, "Axis 0 positive soft limit exceeded") \
+    X((uint32_t)10486530UL, (uint8_t)0x20U, "Axis 0 negative soft limit exceeded")
+#endif /* DTC_CONFIG_H */

--- a/examples/safeboot_ecu/generated/dtc_config.h
+++ b/examples/safeboot_ecu/generated/dtc_config.h
@@ -1,0 +1,61 @@
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: GENERATED — dtc_config.h
+ *
+ * ECU       : SafeBootECU
+ * Version   : 1.0.0
+ * Generated : 2026-09-04T13:51:29Z
+ *
+ * PURPOSE: Per-example DTC table, exposed as an X-macro list so any
+ *          translation unit that already links against this example's
+ *          generated/ sources (e.g. harness/harness_ecu.c) can register
+ *          this example's DTCs without a per-example switch statement —
+ *          the same "compile against examples/<name>/generated/" mechanism
+ *          did_handlers.c and routine_handlers.c already use (issue #158).
+ *
+ *          Architecture:
+ *            diagnostics_config.yaml (dtcs section)
+ *              -> tools/codegen.py (build_dtc_config_context)
+ *                -> tools/templates/dtc_config.h.j2
+ *                  -> generated/dtc_config.h  (this file)
+ *
+ *          NOTE: codegen.py's RENDER_PLAN lives in the public EDS repo.
+ *          Wiring this template into that RENDER_PLAN is tracked as a
+ *          follow-up there; until then this file is kept in sync by hand
+ *          from each example's own generated/uds_init.c Step 5 block (the
+ *          canonical, already-codegen-produced source of truth for that
+ *          example's DTCs) — same content, just re-exposed as an X-macro
+ *          list so harness_ecu.c can consume it generically.
+ *
+ * USAGE:
+ *   #define REGISTER_ONE_DTC(code, severity, desc) \
+ *       (void)dtc_database_register((uint32_t)(code), (uint8_t)(severity), (desc));
+ *   GEN_DTC_TABLE(REGISTER_ONE_DTC)
+ *   #undef REGISTER_ONE_DTC
+ *
+ * WARNING: DO NOT EDIT MANUALLY once codegen.py renders this template.
+ *          Until then, regenerate by hand from this example's
+ *          generated/uds_init.c Step 5 block if diagnostics_config.yaml's
+ *          dtcs: section changes.
+ *
+ * SAFETY  : DTC codes and severities govern SID 0x19 (ReadDTCInformation)
+ *           and SID 0x14 (ClearDiagnosticInformation) responses.
+ * STANDARD: MISRA C:2012 alignment intended.
+ * =============================================================================
+ */
+
+#ifndef DTC_CONFIG_H
+#define DTC_CONFIG_H
+
+/*
+ * X-macro list of this example's DTCs: (code, severity byte, description).
+ * Severity encoding (SAE J2012-DA): 0x20 = check_at_next_halt, 0x40 = other.
+ * Invoke as GEN_DTC_TABLE(X) with X(code, severity, desc) defined by the
+ * caller; #undef X immediately after use.
+ */
+#define GEN_DTC_TABLE(X) \
+    X((uint32_t)15728641UL, (uint8_t)0x40U, "DFU transfer CRC mismatch — image rejected (REQ-FLASH-003)") \
+    X((uint32_t)15728642UL, (uint8_t)0x40U, "DFU flash erase failure") \
+    X((uint32_t)15728643UL, (uint8_t)0x40U, "DFU flash write failure")
+#endif /* DTC_CONFIG_H */

--- a/examples/safeboot_freertos_ecu/generated/dtc_config.h
+++ b/examples/safeboot_freertos_ecu/generated/dtc_config.h
@@ -1,0 +1,61 @@
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: GENERATED — dtc_config.h
+ *
+ * ECU       : SafeBootFreeRTOSECU
+ * Version   : 1.0.0
+ * Generated : 2026-09-04T13:51:29Z
+ *
+ * PURPOSE: Per-example DTC table, exposed as an X-macro list so any
+ *          translation unit that already links against this example's
+ *          generated/ sources (e.g. harness/harness_ecu.c) can register
+ *          this example's DTCs without a per-example switch statement —
+ *          the same "compile against examples/<name>/generated/" mechanism
+ *          did_handlers.c and routine_handlers.c already use (issue #158).
+ *
+ *          Architecture:
+ *            diagnostics_config.yaml (dtcs section)
+ *              -> tools/codegen.py (build_dtc_config_context)
+ *                -> tools/templates/dtc_config.h.j2
+ *                  -> generated/dtc_config.h  (this file)
+ *
+ *          NOTE: codegen.py's RENDER_PLAN lives in the public EDS repo.
+ *          Wiring this template into that RENDER_PLAN is tracked as a
+ *          follow-up there; until then this file is kept in sync by hand
+ *          from each example's own generated/uds_init.c Step 5 block (the
+ *          canonical, already-codegen-produced source of truth for that
+ *          example's DTCs) — same content, just re-exposed as an X-macro
+ *          list so harness_ecu.c can consume it generically.
+ *
+ * USAGE:
+ *   #define REGISTER_ONE_DTC(code, severity, desc) \
+ *       (void)dtc_database_register((uint32_t)(code), (uint8_t)(severity), (desc));
+ *   GEN_DTC_TABLE(REGISTER_ONE_DTC)
+ *   #undef REGISTER_ONE_DTC
+ *
+ * WARNING: DO NOT EDIT MANUALLY once codegen.py renders this template.
+ *          Until then, regenerate by hand from this example's
+ *          generated/uds_init.c Step 5 block if diagnostics_config.yaml's
+ *          dtcs: section changes.
+ *
+ * SAFETY  : DTC codes and severities govern SID 0x19 (ReadDTCInformation)
+ *           and SID 0x14 (ClearDiagnosticInformation) responses.
+ * STANDARD: MISRA C:2012 alignment intended.
+ * =============================================================================
+ */
+
+#ifndef DTC_CONFIG_H
+#define DTC_CONFIG_H
+
+/*
+ * X-macro list of this example's DTCs: (code, severity byte, description).
+ * Severity encoding (SAE J2012-DA): 0x20 = check_at_next_halt, 0x40 = other.
+ * Invoke as GEN_DTC_TABLE(X) with X(code, severity, desc) defined by the
+ * caller; #undef X immediately after use.
+ */
+#define GEN_DTC_TABLE(X) \
+    X((uint32_t)15728641UL, (uint8_t)0x40U, "DFU transfer CRC mismatch — image rejected (REQ-FLASH-003)") \
+    X((uint32_t)15728642UL, (uint8_t)0x40U, "DFU flash erase failure") \
+    X((uint32_t)15728643UL, (uint8_t)0x40U, "DFU flash write failure")
+#endif /* DTC_CONFIG_H */

--- a/examples/sensor_ecu/generated/dtc_config.h
+++ b/examples/sensor_ecu/generated/dtc_config.h
@@ -1,0 +1,62 @@
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: GENERATED — dtc_config.h
+ *
+ * ECU       : SensorECU
+ * Version   : 1.0.0
+ * Generated : 2026-09-04T13:51:29Z
+ *
+ * PURPOSE: Per-example DTC table, exposed as an X-macro list so any
+ *          translation unit that already links against this example's
+ *          generated/ sources (e.g. harness/harness_ecu.c) can register
+ *          this example's DTCs without a per-example switch statement —
+ *          the same "compile against examples/<name>/generated/" mechanism
+ *          did_handlers.c and routine_handlers.c already use (issue #158).
+ *
+ *          Architecture:
+ *            diagnostics_config.yaml (dtcs section)
+ *              -> tools/codegen.py (build_dtc_config_context)
+ *                -> tools/templates/dtc_config.h.j2
+ *                  -> generated/dtc_config.h  (this file)
+ *
+ *          NOTE: codegen.py's RENDER_PLAN lives in the public EDS repo.
+ *          Wiring this template into that RENDER_PLAN is tracked as a
+ *          follow-up there; until then this file is kept in sync by hand
+ *          from each example's own generated/uds_init.c Step 5 block (the
+ *          canonical, already-codegen-produced source of truth for that
+ *          example's DTCs) — same content, just re-exposed as an X-macro
+ *          list so harness_ecu.c can consume it generically.
+ *
+ * USAGE:
+ *   #define REGISTER_ONE_DTC(code, severity, desc) \
+ *       (void)dtc_database_register((uint32_t)(code), (uint8_t)(severity), (desc));
+ *   GEN_DTC_TABLE(REGISTER_ONE_DTC)
+ *   #undef REGISTER_ONE_DTC
+ *
+ * WARNING: DO NOT EDIT MANUALLY once codegen.py renders this template.
+ *          Until then, regenerate by hand from this example's
+ *          generated/uds_init.c Step 5 block if diagnostics_config.yaml's
+ *          dtcs: section changes.
+ *
+ * SAFETY  : DTC codes and severities govern SID 0x19 (ReadDTCInformation)
+ *           and SID 0x14 (ClearDiagnosticInformation) responses.
+ * STANDARD: MISRA C:2012 alignment intended.
+ * =============================================================================
+ */
+
+#ifndef DTC_CONFIG_H
+#define DTC_CONFIG_H
+
+/*
+ * X-macro list of this example's DTCs: (code, severity byte, description).
+ * Severity encoding (SAE J2012-DA): 0x20 = check_at_next_halt, 0x40 = other.
+ * Invoke as GEN_DTC_TABLE(X) with X(code, severity, desc) defined by the
+ * caller; #undef X immediately after use.
+ */
+#define GEN_DTC_TABLE(X) \
+    X((uint32_t)13631745UL, (uint8_t)0x20U, "Ambient temperature sensor — over-range (> threshold high)") \
+    X((uint32_t)13631746UL, (uint8_t)0x20U, "Ambient temperature sensor — under-range (< threshold low)") \
+    X((uint32_t)13632001UL, (uint8_t)0x40U, "Supply voltage — over-range (> 16.0 V)") \
+    X((uint32_t)13632002UL, (uint8_t)0x40U, "Supply voltage — under-range (< 9.0 V)")
+#endif /* DTC_CONFIG_H */

--- a/examples/sensor_ecu_freertos/generated/dtc_config.h
+++ b/examples/sensor_ecu_freertos/generated/dtc_config.h
@@ -1,0 +1,62 @@
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: GENERATED — dtc_config.h
+ *
+ * ECU       : SensorECU
+ * Version   : 1.0.0
+ * Generated : 2026-09-04T13:51:29Z
+ *
+ * PURPOSE: Per-example DTC table, exposed as an X-macro list so any
+ *          translation unit that already links against this example's
+ *          generated/ sources (e.g. harness/harness_ecu.c) can register
+ *          this example's DTCs without a per-example switch statement —
+ *          the same "compile against examples/<name>/generated/" mechanism
+ *          did_handlers.c and routine_handlers.c already use (issue #158).
+ *
+ *          Architecture:
+ *            diagnostics_config.yaml (dtcs section)
+ *              -> tools/codegen.py (build_dtc_config_context)
+ *                -> tools/templates/dtc_config.h.j2
+ *                  -> generated/dtc_config.h  (this file)
+ *
+ *          NOTE: codegen.py's RENDER_PLAN lives in the public EDS repo.
+ *          Wiring this template into that RENDER_PLAN is tracked as a
+ *          follow-up there; until then this file is kept in sync by hand
+ *          from each example's own generated/uds_init.c Step 5 block (the
+ *          canonical, already-codegen-produced source of truth for that
+ *          example's DTCs) — same content, just re-exposed as an X-macro
+ *          list so harness_ecu.c can consume it generically.
+ *
+ * USAGE:
+ *   #define REGISTER_ONE_DTC(code, severity, desc) \
+ *       (void)dtc_database_register((uint32_t)(code), (uint8_t)(severity), (desc));
+ *   GEN_DTC_TABLE(REGISTER_ONE_DTC)
+ *   #undef REGISTER_ONE_DTC
+ *
+ * WARNING: DO NOT EDIT MANUALLY once codegen.py renders this template.
+ *          Until then, regenerate by hand from this example's
+ *          generated/uds_init.c Step 5 block if diagnostics_config.yaml's
+ *          dtcs: section changes.
+ *
+ * SAFETY  : DTC codes and severities govern SID 0x19 (ReadDTCInformation)
+ *           and SID 0x14 (ClearDiagnosticInformation) responses.
+ * STANDARD: MISRA C:2012 alignment intended.
+ * =============================================================================
+ */
+
+#ifndef DTC_CONFIG_H
+#define DTC_CONFIG_H
+
+/*
+ * X-macro list of this example's DTCs: (code, severity byte, description).
+ * Severity encoding (SAE J2012-DA): 0x20 = check_at_next_halt, 0x40 = other.
+ * Invoke as GEN_DTC_TABLE(X) with X(code, severity, desc) defined by the
+ * caller; #undef X immediately after use.
+ */
+#define GEN_DTC_TABLE(X) \
+    X((uint32_t)13631745UL, (uint8_t)0x20U, "Ambient temperature sensor — over-range (> threshold high)") \
+    X((uint32_t)13631746UL, (uint8_t)0x20U, "Ambient temperature sensor — under-range (< threshold low)") \
+    X((uint32_t)13632001UL, (uint8_t)0x40U, "Supply voltage — over-range (> 16.0 V)") \
+    X((uint32_t)13632002UL, (uint8_t)0x40U, "Supply voltage — under-range (< 9.0 V)")
+#endif /* DTC_CONFIG_H */


### PR DESCRIPTION
Closes #249. Implements the agreed **A + C**.

## First — correcting my own report

I filed #249 saying *"nothing `#include`s it"*. **That was wrong.** I grepped only this repo; the consumer is `harness/harness_ecu.c:72` in EDS-toolchain's Professional harness, which isn't public:

```c
#if __has_include("dtc_config.h")
#include "dtc_config.h"
#define HARNESS_HAVE_DTC_CONFIG
#endif
```

The "generator shipped without its consumer" framing was incorrect, and my originally-proposed option 2 (drop it from `RENDER_PLAN`) would have been a **regression** — it would strip real DTCs from customer ZIPs.

## What was actually wrong

`codegen.py` has rendered `dtc_config.h` since #176, but no example committed it. When absent, the harness falls back to registering `basic_ecu`'s two DTCs — correct for the basic_ecu family, silently wrong for any other (`bms_ecu` declares 10, `ardep_ecu` 19).

**Delivery ZIPs were never affected.** `build_release.sh` regenerates `generated/` at staging, confirmed against the shipped artifacts — 9 `dtc_config.h` entries in both v1.13.4 ZIPs. This makes a repo checkout behave like the ZIP.

## A — committed for all 12 examples

Only that file was added; no existing file rewritten, so no timestamp churn. Each verified against its own YAML — **DTC counts match 12/12**:

```
ardep_ecu 19 · bms_ecu 10 · motor_controller_ecu 10 · robot_joint_controller_ecu 5
sensor_ecu 4 · sensor_ecu_freertos 4 · safeboot_ecu 3 · safeboot_freertos_ecu 3
basic_ecu 2 · basic_ecu_doip 2 · basic_ecu_freertos 2 · basic_ecu_doip_freertos 2
```

## C — the fallback is no longer silent

`build_harness.sh` now fails when the selected example lacks the file, naming the consequence rather than building something quietly incorrect:

```
ERROR: examples/bms_ecu/generated/dtc_config.h not found.

  Without it the harness would silently register basic_ecu's DTCs
  instead of bms_ecu's, and any DTC assertion would test the
  wrong data (EDS#249).
```

Safe as a hard **error** rather than a warning: codegen emits `dtc_config.h` unconditionally — I verified it renders even for a config with an empty `dtcs:` list — so absence always means `generated/` predates #176, never "this ECU has no DTCs".

## Impact stated plainly, not overclaimed

Two things I checked that make this smaller than the issue implied, and I'd rather say so than let the changelog imply a bug fix:

- `basic_ecu`'s generated table is **byte-equivalent** to the hardcoded fallback (same codes `12583168`/`12583424`, same severities, same strings), so switching it to the real branch is a behavioural no-op.
- The 68 harness assertions are hardcoded to `basic_ecu`'s DID/routine fixture, so **no DTC assertion existed that the missing file could have broken**. Filed separately as #252.

This is correctness hygiene — the committed tree now matches what the generator produces — not a fix for a failing test.

## Verification

- harness **68/68** with the file present
- the new guard fires with the message above when it's removed
- `--example bms_ecu` gives 10 failures both **before and after** this change (verified by stashing to `origin/main`), all DID/routine fixture mismatches, zero DTC-related — hence #252

A paired change in EDS-toolchain adds the file-set assertion to the cross-repo freshness test, which is what would have caught this in the first place.
