### PR TITLE
docs: correct the CI job count, document the harness fixture limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   catch it — its count patterns do not cover this phrasing, so the drift was
   invisible to the release sweep (the `docs/`-goes-unswept shape of
   lessons/run-010, one layer down).
+- `docs/ARCHITECTURE.md:182` described the generator as having **8
+  templates**; it has **18**. Found by widening the release sweep's count
+  patterns after the CI-job miss below, then re-running it across both
+  repos rather than only re-checking the one case that prompted it
+  (lessons/run-020).
 - Documented that the 68 harness assertions target `basic_ecu`'s DID/routine
   fixture, so `build_harness.sh --example <specialist>` builds and runs but
   does **not** go green — it reports fixture mismatches, not defects (#252).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+### Documentation
+
+- `docs/TESTING_STRATEGY.md`'s status line claimed **21/21 CI jobs**; `ci.yml`
+  has **23**. Stale since two jobs were added. `check_release_docs.py` did not
+  catch it — its count patterns do not cover this phrasing, so the drift was
+  invisible to the release sweep (the `docs/`-goes-unswept shape of
+  lessons/run-010, one layer down).
+- Documented that the 68 harness assertions target `basic_ecu`'s DID/routine
+  fixture, so `build_harness.sh --example <specialist>` builds and runs but
+  does **not** go green — it reports fixture mismatches, not defects (#252).
+  Added to `TESTING_STRATEGY.md` and to `build_harness.sh`'s own help text,
+  which advertised the flag with no such caveat. Figures verified by running
+  it: `bms_ecu` 58 pass / 10 fail, `basic_ecu` 68/68.
+
 ### Added
 
 - **`examples/*/generated/dtc_config.h` is now committed for all 12

--- a/build_harness.sh
+++ b/build_harness.sh
@@ -14,6 +14,12 @@
 #   ./build_harness.sh --run --hw             # Build for AF_CAN hardware (vcan0)
 #   ./build_harness.sh --fast                 # Build without Wpedantic (faster CI)
 #   ./build_harness.sh --example sensor_ecu   # Build against examples/sensor_ecu/generated
+#
+#   NOTE: the 68 assertions target basic_ecu's DIDs and routines, so
+#   --example <specialist> builds and runs but does NOT go green -- it
+#   reports fixture mismatches, not defects. Use it to check an example's
+#   generated sources compile and link. See docs/TESTING_STRATEGY.md "The 68
+#   assertions target basic_ecu" and issue #252.
 #                                              # instead of the default (basic_ecu). The
 #                                              # EXAMPLE env var works the same way.
 #

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -179,7 +179,7 @@ embedded-diagnostics-suite/
 │   └── safety_config.h         # Generated ASIL compile-time assertions
 │
 ├── tools/
-│   ├── codegen.py              # Main generator: YAML → C/H (8 templates)
+│   ├── codegen.py              # Main generator: YAML → C/H (18 templates)
 │   ├── testgen.py              # Test generator: YAML → pytest + CANoe CAPL (v1.1.0)
 │   ├── config_parser.py        # YAML validation and parsing helpers
 │   └── templates/              # Jinja2 templates for all generated files

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -1,7 +1,7 @@
 # Testing Strategy — Xaloqi EDS
 
 **Version:** v1.13.4  
-**Status:** 45/45 unit test modules passing. 68/68 harness tests passing. 21/21 CI jobs green. FreeRTOS, SafeBoot (Zephyr + FreeRTOS), DoIP, and sensor examples all covered.
+**Status:** 45/45 unit test modules passing. 68/68 harness tests passing. 23/23 CI jobs green. FreeRTOS, SafeBoot (Zephyr + FreeRTOS), DoIP, and sensor examples all covered.
 
 ---
 
@@ -279,6 +279,34 @@ bash build_harness.sh
 Harness tests cover scenarios that are difficult to isolate in pure unit tests: multi-module
 interaction, end-to-end NRC generation, and the full ISO-TP → UDS → safety wrapper →
 handler call chain.
+
+### The 68 assertions target `basic_ecu` (#252)
+
+`build_harness.sh --example <name>` builds the harness against another
+example's `generated/` sources, which is useful for checking that an
+example's generated code compiles and links. **It is not expected to
+produce a green run.**
+
+The 68 assertions are written against `basic_ecu`'s specific DIDs and
+routines, so against a specialist example they report fixture mismatches
+rather than defects:
+
+```bash
+bash build_harness.sh --example bms_ecu --run
+# 58 pass, 10 fail — all DID/routine fixture mismatches
+```
+
+Those ten failures are the correct protocol behaviour. `bms_ecu` does not
+declare DIDs `0x0C00`/`0x0500` or routines `0xFF00`/`0xFF01`, so NRC `0x31`
+(`requestOutOfRange`) is the right response; the tests simply assume
+`basic_ecu`'s fixture. Making the assertions fixture-aware — deriving the
+expected DIDs and routines from the selected example's
+`diagnostics_config.yaml` — is tracked in #252 and is a considerably larger
+change than it looks.
+
+`--example` does still enforce one thing: the selected example must have a
+`generated/dtc_config.h`, or the build fails. Without it the harness would
+silently register `basic_ecu`'s DTCs instead of the example's own (#249).
 
 ---
 


### PR DESCRIPTION
Closes #252, via its **option 1** — document the limitation.

## Two gaps found auditing whether today's work left the docs current

**1. Stale CI job count.** `docs/TESTING_STRATEGY.md:4` claimed *"21/21 CI jobs green"*; `ci.yml` has **23**.

Worth noting *why* it survived: `check_release_docs.py` — the mandatory release docs sweep — reports clean on this repo. Its count patterns don't cover that phrasing, so the drift was invisible to the sweep that exists to catch exactly this. That's the `lessons/run-010` shape one layer down: the sweep covers `docs/`, but not every claim in it.

**2. The `--example` trap.** `build_harness.sh` advertises this in its own help:

```
#   ./build_harness.sh --example sensor_ecu   # Build against examples/sensor_ecu/generated
```

with no caveat. But the 68 assertions target `basic_ecu`'s DIDs and routines, so against a specialist example it reports fixture mismatches:

```
bash build_harness.sh --example bms_ecu --run
# 58 pass, 10 fail
```

Someone following the documented usage gets ten red lines and nothing telling them this was never a passing configuration. Now documented in `TESTING_STRATEGY.md` and in the script's own help, including *why* the failures are correct: `bms_ecu` doesn't declare DIDs `0x0C00`/`0x0500` or routines `0xFF00`/`0xFF01`, so NRC `0x31` (`requestOutOfRange`) is the right response.

The new section also records what `--example` *does* still enforce — the selected example must have `generated/dtc_config.h` or the build fails, from #249.

## Scope

This is #252 option 1. **Option 3** — making assertions fixture-aware by deriving expected DIDs and routines from the selected example's `diagnostics_config.yaml` — stays unbuilt. It's a real project, and nothing currently needs per-example harness runs to go green. If that changes, #252's discussion has the analysis.

## Verified

Figures were run, not transcribed: `bms_ecu` **58 pass / 10 fail**, `basic_ecu` **68/68**.
