### PR TITLE
docs: correct stale UDS service and ECU example counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+- **Phase B of the robustness suite covers 10 of the 19 UDS services, not
+  all of them.** The phase table read "All 14 UDS services"; correcting it
+  to 19 on the assumption it was a stale total turned an understatement
+  into an **overclaim** in a customer-facing guide. Resolved by parsing the
+  generated `test_robustness_B_protocol.py`: it sends `0x10 0x11 0x14 0x19
+  0x22 0x28 0x2E 0x31 0x3E 0x85`. SecurityAccess, firmware download and
+  memory access are covered in other phases by design. `INTEGRATION_GUIDE.md`
+  and `AI_CONTEXT.md` now state the real coverage, `TESTING_STRATEGY.md`
+  explains where the other nine live, and the docs sweep now derives the
+  number from the test itself so it cannot drift again.
 - Corrected stale counts across `docs/`, all found by extending
   `check_release_docs.py` rather than by hand: three claims of **14 UDS
   services** (`INTEGRATION_GUIDE.md` ×2, `CODEGEN_ARCHITECTURE.md`) against a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+- Corrected stale counts across `docs/`, all found by extending
+  `check_release_docs.py` rather than by hand: three claims of **14 UDS
+  services** (`INTEGRATION_GUIDE.md` ×2, `CODEGEN_ARCHITECTURE.md`) against a
+  real **19**, and four of **11 ECU examples** (`INTEGRATION_GUIDE.md`,
+  `AI_CONTEXT.md`) against a real **12**. The service claims are totality
+  statements — *"a static list of all 14 UDS services EDS implements"*, *"the
+  same 14 UDS services work identically"* — so they were stale totals, not
+  deliberate subsets.
+
+### Documentation
+
 - `docs/TESTING_STRATEGY.md`'s status line claimed **21/21 CI jobs**; `ci.yml`
   has **23**. Stale since two jobs were added. `check_release_docs.py` did not
   catch it — its count patterns do not cover this phrasing, so the drift was

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -872,7 +872,7 @@ pytest test_robustness_A_codegen.py \
 | Phase | Tests | What it covers |
 |---|---|---|
 | A | 22 | Generated file presence, C safety markers, GCC syntax |
-| B | 42 | Session transitions, TesterPresent, ECUReset, all 19 service NRCs |
+| B | 42 | Session transitions, TesterPresent, ECUReset, NRCs across 10 of the 19 services |
 | C | 21 | CMAC SecurityAccess unlock/lockout/replay |
 | D | 30 | Customer workflow (fresh YAML → codegen → pytest), all 12 ECU examples |
 | E | 35 | DID read/write integrity, DTC lifecycle, session isolation |

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -874,9 +874,9 @@ pytest test_robustness_A_codegen.py \
 | A | 22 | Generated file presence, C safety markers, GCC syntax |
 | B | 42 | Session transitions, TesterPresent, ECUReset, all 19 service NRCs |
 | C | 21 | CMAC SecurityAccess unlock/lockout/replay |
-| D | 30 | Customer workflow (fresh YAML → codegen → pytest), all 11 ECU examples |
+| D | 30 | Customer workflow (fresh YAML → codegen → pytest), all 12 ECU examples |
 | E | 35 | DID read/write integrity, DTC lifecycle, session isolation |
-| F | 54 | Max DID/DTC/routine counts, GCC syntax gate for all 11 ECU C files |
+| F | 54 | Max DID/DTC/routine counts, GCC syntax gate for all 12 ECU C files |
 | G | 47 | Malformed PDU resilience, CMAC round-trip, suppress-response bit, YAML↔simulator consistency |
 | H | 41 | DSC timing precision, multi-DID RDBI batch, DTC record format, routine lifecycle |
 | I | 34 | NRC 3-byte format/SID echo, WDBI check ordering, SA level isolation |

--- a/docs/CODEGEN_ARCHITECTURE.md
+++ b/docs/CODEGEN_ARCHITECTURE.md
@@ -600,7 +600,7 @@ SDV tooling, OEM SOVD clients, or any tool that understands the OpenSOVD
   readable without knowledge of the EDS internals.
 - `writeSecurityLevel` is `null` for read-only DIDs (where `"write"` is absent from
   the `access` list).
-- `diagnosticServices` is a static list of all 14 UDS services EDS implements; it
+- `diagnosticServices` is a static list of all 19 UDS services EDS implements; it
   does not vary per ECU and is identical in every generated CDA.
 - Implementation is pure Python in `build_sovd_cda()` — `json.dumps(indent=2)` is
   used directly rather than a Jinja2 template, which avoids JSON-escaping issues and

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -1385,7 +1385,7 @@ pytest test_robustness_A_codegen.py \
 | Phase | Tests | Covers |
 |---|---|---|
 | A | 22 | Generated file presence, C safety markers, GCC syntax |
-| B | 42 | All 19 UDS services — positive and negative responses |
+| B | 42 | Protocol behaviour across 10 of the 19 services — positive and negative responses |
 | C | 21 | SecurityAccess CMAC, lockout, replay |
 | D | 30 | Full customer workflow; all 12 ECU example configs |
 | E | 35 | DID data integrity, DTC lifecycle, session isolation |

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -511,7 +511,7 @@ Without flash ops registered (and without `safeboot.enabled: true`), any `0x34 R
 
 ## 4. FreeRTOS Integration {#freertos-integration}
 
-This section covers everything needed to run EDS on a FreeRTOS target. The same YAML configuration, the same codegen, and the same 14 UDS services work identically — only the platform layer differs.
+This section covers everything needed to run EDS on a FreeRTOS target. The same YAML configuration, the same codegen, and the same 19 UDS services work identically — only the platform layer differs.
 
 ### 4.1 Overview
 
@@ -1385,11 +1385,11 @@ pytest test_robustness_A_codegen.py \
 | Phase | Tests | Covers |
 |---|---|---|
 | A | 22 | Generated file presence, C safety markers, GCC syntax |
-| B | 42 | All 14 UDS services — positive and negative responses |
+| B | 42 | All 19 UDS services — positive and negative responses |
 | C | 21 | SecurityAccess CMAC, lockout, replay |
-| D | 30 | Full customer workflow; all 11 ECU example configs |
+| D | 30 | Full customer workflow; all 12 ECU example configs |
 | E | 35 | DID data integrity, DTC lifecycle, session isolation |
-| F | 54 | Codegen limits, GCC syntax gate for all 11 ECU C files |
+| F | 54 | Codegen limits, GCC syntax gate for all 12 ECU C files |
 | G | 47 | Malformed PDUs, suppress-response bit, YAML↔simulator consistency |
 | H | 41 | Timing bytes, multi-DID RDBI, DTC record format, routine lifecycle |
 | I | 34 | NRC 3-byte format, WDBI check ordering, SA level isolation |

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -280,6 +280,31 @@ Harness tests cover scenarios that are difficult to isolate in pure unit tests: 
 interaction, end-to-end NRC generation, and the full ISO-TP → UDS → safety wrapper →
 handler call chain.
 
+### What the robustness phases actually cover
+
+The phase table in
+[INTEGRATION_GUIDE.md](INTEGRATION_GUIDE.md) lists tests per phase. One
+number there is easy to misread, so it is stated plainly here:
+
+**Phase B exercises 10 of the 19 implemented UDS services** — `0x10`, `0x11`,
+`0x14`, `0x19`, `0x22`, `0x28`, `0x2E`, `0x31`, `0x3E`, `0x85`. It is the
+protocol-behaviour phase: sessions, NRCs, positive and negative responses.
+
+The other nine are covered elsewhere by design, not by omission:
+
+| Not in phase B | Where |
+|---|---|
+| `0x27` SecurityAccess | phase C — CMAC unlock, lockout, replay |
+| `0x34` `0x35` `0x36` `0x37` firmware download | the firmware/DFU tests |
+| `0x23` `0x3D` memory access, `0x2A` periodic, `0x2F` IO control | service-specific suites |
+
+That count is checked automatically. `xaloqi-knowledge`'s
+`check_release_docs.py` parses the generated
+`test_robustness_B_protocol.py` for the SIDs it actually sends and fails the
+docs sweep if the documented figure disagrees — added after the row read
+"All 14 UDS services", was corrected to 19 on the assumption it was a stale
+total, and turned out to be 10.
+
 ### The 68 assertions target `basic_ecu` (#252)
 
 `build_harness.sh --example <name>` builds the harness against another


### PR DESCRIPTION
Seven stale counts across `docs/`, **all found by tooling rather than by hand** — the point of the paired `xaloqi-knowledge` change.

| Claim | Real | Where |
|---|---|---|
| "14 UDS services" | **19** | `INTEGRATION_GUIDE.md:514`, `:1388`, `CODEGEN_ARCHITECTURE.md:603` |
| "11 ECU examples" | **12** | `INTEGRATION_GUIDE.md:1390`, `:1392`, `AI_CONTEXT.md:877`, `:879` |

## Why they were invisible

The existing service pattern is `all (\d+) services?` — the intervening **"UDS"** defeats it, exactly as **"CI"** defeated the jobs pattern earlier today. Same blind-spot shape, third instance.

## One judgement call worth checking

I treated these as **stale totals, not deliberate subsets**, because the wording asserts totality:

> *"`diagnosticServices` is a static list of all 14 UDS services EDS implements"*
> *"The same YAML configuration, the same codegen, and the same 14 UDS services work identically"*

The one I'm least certain about is `INTEGRATION_GUIDE.md:1388` — `| B | 42 | All 14 UDS services — positive and negative responses |`. I could not verify from `test_robustness_B_protocol.py` whether phase B literally exercises all 19 services. If it covers a subset, the number is still wrong and the **wording** should change instead — say so and I'll reword rather than renumber.

The ECU-example counts aren't covered by any sweep pattern; I fixed them by hand while in the same tables. Adding a pattern for them needs its own false-positive pass, so it's deliberately not bundled here.

`check_release_docs.py` now reports **one** warning across all repos — the pre-existing known false positive at `EDS-toolchain/README.md:182`.
