### PR TITLE
ci: replace skip-as-pass in harness and DoIP jobs with BLOCKED semantics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1967,14 +1967,32 @@ jobs:
   #
   # Builds basic_ecu_doip on native_sim, runs the 20 DoIP Unity unit tests
   # via build_tests.sh (already covered by the unit-tests job, included here
-  # as a smoke check), then launches the ECU binary and runs the 10 pytest
-  # end-to-end integration tests using xaloqi-tester DoipBus over loopback.
+  # as a smoke check), then boots the ECU binary and confirms the DoIP
+  # server reaches listen state by watching for its own log line
+  # ("DoIP: listening on port 13400", emitted right after zsock_listen()
+  # succeeds) rather than attempting a live host TCP connection.
   #
-  # Requires: Zephyr SDK, xaloqi-tester (TestLab) installed.
+  # Not a live connection because this example's native_sim_doip.conf sets
+  # CONFIG_NET_LOOPBACK=y, which binds the DoIP server to Zephyr's internal
+  # virtual loopback only -- never reachable from the host OS by any
+  # client. A real host-side connection needs a "zeth" TAP bridge (see the
+  # diagnosed-but-not-yet-merged fix/eds230-native-sim-doip-realzeth
+  # branch), which this job deliberately does not set up.
+  #
+  # This job proves build + boot only. It deliberately does NOT attempt a
+  # real DoIP protocol/connection test: xaloqi-tester (TestLab) is a private,
+  # commercial dependency that is never present at ../TestLab in this public
+  # repo's CI (by design — see decisions/ADR-005 and the #230 owner decision).
+  # Giving this repo a credential to install it wouldn't fix fork-originated
+  # PRs (GitHub withholds secrets from forks) and would break the OD-14
+  # reproducible-by-anyone boundary, so none is added. The canonical
+  # real-DoIP verification point is `xaloqi-compatibility-tests`' Robot
+  # Framework `basic_ecu_doip` leg, which runs the real campaign over real
+  # DoIP/TCP and passes on its `main`.
   # ──────────────────────────────────────────────────────────────────────────
   doip-integration:
     runs-on: ubuntu-latest
-    name: "DoIP Integration (native_sim + DoipBus)"
+    name: "DoIP ECU Build + Boot (native_sim)"
 
     steps:
       - name: Checkout EDS
@@ -1989,20 +2007,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install west pyelftools pyyaml jinja2 pytest pytest-asyncio pytest-timeout
-
-      - name: Install xaloqi-tester (TestLab)
-        env:
-          XALOQI_LICENSE_SKIP: "1"
-        run: |
-          # In CI, TestLab is expected to be available as a peer repo or
-          # installed from a pre-built wheel. Adjust path as needed.
-          if [ -d "../TestLab" ]; then
-            pip install -e ../TestLab
-          else
-            echo "WARN: TestLab not found at ../TestLab — skipping xaloqi-tester install"
-            echo "      DoipBus tests will be skipped automatically."
-          fi
+          pip install west pyelftools pyyaml jinja2
 
       - name: Install Zephyr SDK
         run: |
@@ -2049,20 +2054,58 @@ jobs:
         run: |
           bash build_tests.sh --verbose 2>&1 | grep -E "test_doip|PASS|FAIL|Summary"
 
-      - name: Run DoIP integration tests
-        env:
-          XALOQI_LICENSE_SKIP: "1"
-          DOIP_ECU_BINARY: "build/zephyr/zephyr.exe"
-          DOIP_ECU_HOST: "127.0.0.1"
-          DOIP_ECU_PORT: "13400"
-          DOIP_STARTUP_DELAY_S: "2.0"
-          DOIP_TEST_TIMEOUT_S: "10.0"
+      - name: Verify DoIP server reaches listen state (boot check)
         run: |
-          # Exit code 5 = no tests collected (all skipped when xaloqi-tester
-          # is not installed). Treat as success — the ECU binary built correctly.
-          pytest tests/test_doip_integration.py -v --timeout=60 || {
-            rc=$?; [ $rc -eq 5 ] && echo "All tests skipped (xaloqi not installed) — OK" || exit $rc
-          }
+          # Asserts on the ECU's own log line, not a live host TCP connect.
+          # examples/basic_ecu_doip's native_sim_doip.conf sets
+          # CONFIG_NET_LOOPBACK=y, which (see the diagnosed-but-not-yet-
+          # merged fix/eds230-native-sim-doip-realzeth branch) silently
+          # drops the Ethernet driver subtree and binds the DoIP server to
+          # Zephyr's internal virtual loopback only -- never reachable from
+          # the host OS, by any client, regardless of method. A real host-
+          # side connection needs a "zeth" TAP bridge (net-tools' own
+          # net-setup.sh, typically requiring sudo) that this job
+          # deliberately does not set up -- out of scope for a build+boot
+          # job (see the job header comment above). The log line below is
+          # emitted by transport/doip/zephyr_lwip.c immediately after its
+          # zsock_listen() call returns success, so it is a true positive
+          # assertion that the server reached listen state, independent of
+          # host-network reachability.
+          build/zephyr/zephyr.exe > /tmp/doip_boot_output.txt 2>&1 &
+          ECU_PID=$!
+          echo "Started ECU binary (pid $ECU_PID), waiting for DoIP listen state..."
+
+          LISTENING=0
+          for i in $(seq 1 30); do
+            if grep -q "DoIP: listening on port 13400" /tmp/doip_boot_output.txt 2>/dev/null; then
+              LISTENING=1
+              break
+            fi
+            sleep 1
+          done
+
+          kill "$ECU_PID" 2>/dev/null || true
+          wait "$ECU_PID" 2>/dev/null || true
+
+          echo "--- ECU boot output ---"
+          cat /tmp/doip_boot_output.txt
+          echo "-----------------------"
+
+          if [ "$LISTENING" -eq 1 ]; then
+            echo "PASS: DoIP server reached listen state (logged 'DoIP: listening on port 13400') after ${i}s"
+          else
+            echo "FAIL: DoIP server never logged 'DoIP: listening on port 13400' within 30s"
+            exit 1
+          fi
+
+          echo "NOT COVERED BY THIS JOB: real DoIP protocol/connection testing over a live"
+          echo "         TCP handshake. xaloqi-tester (TestLab) is a private, commercial"
+          echo "         dependency never present in this public repo's CI, by design, and"
+          echo "         this example's native_sim config has no host-reachable network"
+          echo "         bridge. This job proves build + boot only; it is never counted"
+          echo "         toward a DoIP integration claim. Canonical real-DoIP verification:"
+          echo "         xaloqi-compatibility-tests' basic_ecu_doip leg, which runs the real"
+          echo "         campaign over real DoIP/TCP and passes on main."
 
       - name: Upload ECU binary artifact
         uses: actions/upload-artifact@v4
@@ -2317,14 +2360,23 @@ jobs:
   # ASIL-B safety wrappers. Harness exits 1 and prints HARNESS FAILURES on
   # any failure.
   #
+  # harness/ is a Professional-tier deliverable (#68) and is absent from
+  # public checkouts by design. When absent, both steps below report
+  # BLOCKED explicitly (never a silent pass — ADR-005) and exit 0, unless
+  # EDS_QUALIFICATION_RUN=1 is set, in which case BLOCKED is a hard failure.
+  #
   # Warning flags (zero-warning gate):
   #   -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion
   #   -Wstrict-prototypes -Wmissing-prototypes -Wredundant-decls
   #   -Wlogical-op -Wduplicated-cond -Wimplicit-fallthrough=5
   # ──────────────────────────────────────────────────────────────────────────
   harness-tests:
-    name: "Harness Integration Tests (68 C tests, MISRA-clean build)"
+    name: "Harness Integration Tests (MISRA-clean build)"
     runs-on: ubuntu-22.04
+    env:
+      # ADR-005 rule 3: PASS requires a declared minimum executed floor.
+      # This job cannot report PASS below this many executed harness cases.
+      HARNESS_FLOOR: "68"
 
     steps:
       - uses: actions/checkout@v4
@@ -2336,15 +2388,38 @@ jobs:
 
       - name: Build harness (MISRA-clean warning set, zero warnings)
         run: |
-          [ -f harness/harness_main.c ] \
-            || { echo "Harness C sources not present (commercial-only) — skipped."; exit 0; }
+          if [ ! -f harness/harness_main.c ]; then
+            echo "BLOCKED: harness/ is absent from this checkout — it is a Professional-tier"
+            echo "         deliverable (#68) and is not present in public checkouts by design."
+            echo "BLOCKED: 0 of the declared floor of ${HARNESS_FLOOR} harness tests executed."
+            echo "         This is never reported or counted as a pass (ADR-005)."
+            if [ "${EDS_QUALIFICATION_RUN:-}" = "1" ]; then
+              echo "ERROR: EDS_QUALIFICATION_RUN=1 — BLOCKED is a hard failure in a qualification"
+              echo "       context (ADR-005 rule 5). Refusing to proceed."
+              exit 1
+            fi
+            echo "Public/community CI run — BLOCKED is permitted here (ADR-005 rule 5); exiting 0."
+            exit 0
+          fi
           bash build_harness.sh
           echo "[harness] Build succeeded — zero warnings confirmed"
 
-      - name: Run 68 harness integration tests
+      - name: Run harness integration tests (floor ${{ env.HARNESS_FLOOR }})
         run: |
-          [ -f harness/harness_main.c ] \
-            || { echo "Harness C sources not present (commercial-only) — skipped."; exit 0; }
+          if [ ! -f harness/harness_main.c ]; then
+            echo "BLOCKED: harness/ is absent from this checkout — it is a Professional-tier"
+            echo "         deliverable (#68) and is not present in public checkouts by design."
+            echo "BLOCKED: 0 of the declared floor of ${HARNESS_FLOOR} harness tests executed."
+            echo "         This is never reported or counted as a pass (ADR-005)."
+            if [ "${EDS_QUALIFICATION_RUN:-}" = "1" ]; then
+              echo "ERROR: EDS_QUALIFICATION_RUN=1 — BLOCKED is a hard failure in a qualification"
+              echo "       context (ADR-005 rule 5). Refusing to proceed."
+              exit 1
+            fi
+            echo "Public/community CI run — BLOCKED is permitted here (ADR-005 rule 5); exiting 0."
+            exit 0
+          fi
           bash build_harness.sh --run 2>&1 | tee /tmp/harness_output.txt
-          grep -q "ALL 68 HARNESS TESTS PASSED" /tmp/harness_output.txt \
-            || (echo "ERROR: Expected ALL 68 HARNESS TESTS PASSED" && exit 1)
+          grep -q "ALL ${HARNESS_FLOOR} HARNESS TESTS PASSED" /tmp/harness_output.txt \
+            || (echo "ERROR: Expected ALL ${HARNESS_FLOOR} HARNESS TESTS PASSED (declared floor) — got a different count or a failure" && exit 1)
+          echo "PASS: executed >= declared floor of ${HARNESS_FLOOR} harness tests"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,64 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+### Changed
+
+- **CI can no longer report a passing job that executed zero tests**
+  (#234, #230 — Phases 1–2 of a 4-phase execution-truth fix; #234 stays
+  open for the Python-runner and claim/floor-rederivation phases still to
+  come). Two CI jobs reported green while proving nothing, both now fixed
+  at the CI layer only — neither `build_harness.sh` nor the test suites
+  themselves changed:
+  - **Harness Integration Tests.** `harness/` is a Professional-tier
+    deliverable (#68) and is absent from every public checkout by design,
+    so the CI wrapper around `build_harness.sh` printed "skipped" and
+    exited 0 — indistinguishable from 68/68 passing. It now prints
+    **BLOCKED** explicitly, states the declared floor (68 executed
+    cases), and still exits 0 in normal/public CI (BLOCKED is permitted
+    there and is never counted toward a claim) — but exits non-zero when
+    `EDS_QUALIFICATION_RUN=1` is set, so a release-qualification run can
+    no longer pass without actually executing the harness. The floor is
+    load-bearing, not decorative: the pass assertion's `grep` pattern is
+    now built from the same `HARNESS_FLOOR` variable it is declared with
+    (`ALL ${HARNESS_FLOOR} HARNESS TESTS PASSED`), so raising the floor
+    without a matching increase in what actually ran fails the job
+    instead of silently printing a stale "PASS" claim. Renamed
+    `Harness Integration Tests (68 C tests, MISRA-clean build)` →
+    `Harness Integration Tests (MISRA-clean build)` (job names carry no
+    counts, ADR-005 rule 7).
+  - **DoIP job.** `doip-integration` swallowed pytest's exit code 5
+    ("no tests collected") as "OK" whenever `xaloqi-tester` (TestLab)
+    wasn't installed — which is always, in this public repo's CI, since
+    TestLab is a private commercial dependency never present at
+    `../TestLab` here. The job had never executed a real DoIP connection
+    test. The swallow is deleted along with the pytest invocation itself;
+    the job is rescoped to what it can actually prove without a secret —
+    that `basic_ecu_doip` builds for `native_sim` and its DoIP server
+    reaches listen state on boot — and now asserts that positively by
+    watching the ECU's own log for the line `transport/doip/zephyr_lwip.c`
+    emits right after its `zsock_listen()` call succeeds, rather than by
+    opening a live host TCP connection. **Found in the process:**
+    `examples/basic_ecu_doip`'s `native_sim_doip.conf` sets
+    `CONFIG_NET_LOOPBACK=y`, which silently drops the Ethernet driver
+    subtree and binds the DoIP server to Zephyr's internal virtual
+    loopback only — never reachable from the host OS by any client,
+    which is why the log-based assertion was used instead of a live
+    connect. A real host-reachable bridge needs a "zeth" TAP interface;
+    that fix already exists as an unmerged, diagnosed branch
+    (`fix/eds230-native-sim-doip-realzeth`) and is not part of this
+    change. No `GH_PAT` was added here: it would not help
+    fork-originated PRs (GitHub withholds secrets from forks) and would
+    break the OD-14 reproducible-by-anyone boundary. Real DoIP
+    protocol/connection verification is `xaloqi-compatibility-tests`'
+    `basic_ecu_doip` leg, which runs the real campaign over real
+    DoIP/TCP and passes on `main` — the job now says so explicitly.
+    Renamed `DoIP Integration (native_sim + DoipBus)` →
+    `DoIP ECU Build + Boot (native_sim)` to match what it verifies.
+
+  Both job renames land with this change; the repository ruleset that
+  pins required status checks by exact job name is being updated
+  separately by the maintainer.
+
 ### Documentation
 
 - **Phase B of the robustness suite covers 10 of the 19 UDS services, not


### PR DESCRIPTION
## Summary

Implements Phases 1 and 2 of the v1.14.0 execution-truth scope
(ADR-005): fixes the two CI jobs that reported success having executed
zero tests, at the CI layer only. Neither `build_harness.sh` nor any
test suite changed.

### Phase 1 — `harness-tests` job (`Harness Integration Tests (MISRA-clean build)`)

- `harness/` is a Professional-tier deliverable (#68) and is absent from
  every public checkout by design. The old wrapper printed "skipped" and
  `exit 0` — indistinguishable from 68/68 passing.
- Both steps now print **BLOCKED** explicitly, state the declared floor
  (68 executed cases), and still exit 0 in normal/public CI (BLOCKED is
  permitted there per ADR-005 and never counted toward a claim).
- Gated hard failure: when `EDS_QUALIFICATION_RUN=1` is set, a BLOCKED
  outcome exits non-zero instead.
- **The floor is load-bearing, not decorative.** The pass assertion's
  `grep` pattern is derived from `${HARNESS_FLOOR}` itself
  (`ALL ${HARNESS_FLOOR} HARNESS TESTS PASSED`), not a separate hardcoded
  `68`, so raising the floor without a matching increase in what actually
  ran fails the job instead of printing a stale `PASS` claim.
- Renamed `Harness Integration Tests (68 C tests, MISRA-clean build)` →
  `Harness Integration Tests (MISRA-clean build)` (ADR-005 rule 7: job
  names carry no counts).

### Phase 2 — `doip-integration` job (`DoIP ECU Build + Boot (native_sim)`)

- Deleted the exit-5 swallow (`rc -eq 5 && echo OK`) and the pytest
  invocation it wrapped. `xaloqi-tester` (TestLab) is a private,
  commercial dependency never present at `../TestLab` in this public
  repo's CI, so the job had never executed a real DoIP connection test.
- Removed the now-unused "Install xaloqi-tester (TestLab)" step and the
  `pytest`/`pytest-asyncio`/`pytest-timeout` installs.
- Rescoped the job to what it can prove without a secret: `basic_ecu_doip`
  builds for `native_sim`, and its DoIP server reaches listen state on
  boot. Added a positive assertion for that — **by watching the ECU's
  own log** for the line `transport/doip/zephyr_lwip.c` emits right
  after its `zsock_listen()` call succeeds, not by opening a live host
  TCP connection.
- **Real bug found and worked around:** a first version of this job
  tried a live host TCP connect (30s poll against `127.0.0.1:13400`) and
  it consistently failed in real CI, even though the ECU logged
  "listening" almost instantly. Root cause:
  `examples/basic_ecu_doip`'s `native_sim_doip.conf` sets
  `CONFIG_NET_LOOPBACK=y`, which silently drops the Ethernet driver
  subtree and binds the DoIP server to Zephyr's internal virtual
  loopback only — never reachable from the host OS by any client,
  regardless of method. This is a pre-existing issue in the example
  config, invisible until now because the old job's swallowed pytest
  invocation never actually attempted a connection either. A real
  host-reachable fix (a "zeth" TAP bridge) already exists as a
  diagnosed-but-unmerged branch, `fix/eds230-native-sim-doip-realzeth`
  — out of scope here; flagging it below.
- No `GH_PAT` added — per the owner decision on #230, it would not help
  fork-originated PRs (GitHub withholds secrets from forks) and would
  break the OD-14 reproducible-by-anyone boundary.
- The job prints `NOT COVERED BY THIS JOB: ...` (not `BLOCKED:`) pointing
  real DoIP protocol/connection verification at
  `xaloqi-compatibility-tests`' `basic_ecu_doip` leg, which runs the real
  campaign over real DoIP/TCP and passes on `main`. `BLOCKED` is a
  reserved outcome token under ADR-005's FAIL > BLOCKED > PASS
  precedence (consumed by the `test-outcomes.json` parser coming in
  Phases 3–4); this job's declared scope (build + boot) fully executes
  and passes, so the note is a scope disclaimer, not an outcome, and
  must not use that token.
- Renamed `DoIP Integration (native_sim + DoipBus)` →
  `DoIP ECU Build + Boot (native_sim)` to match what it verifies.

### Out of scope (deliberately not touched)

- `run_python_tests.sh` / the `[ENV]` → `BLOCKED` rename (Phase 3).
- `test-outcomes.json`, docs count updates, ADR-004 amendment (Phase 4).
- The repository ruleset / branch protection — the maintainer is handling
  that transition separately against these two exact job-name strings.
- `Robustness Campaign (439 tests, 12 phases)` job name — untouched,
  scheduled for Phase 4 once floors are re-derived.
- A real host-reachable DoIP bridge for `native_sim` (the `zeth` TAP
  approach in `fix/eds230-native-sim-doip-realzeth`) — the networking
  bug found above is real but its fix is a separate, larger change
  already staged elsewhere; not folded into this PR.

### CHANGELOG

Added a `[Unreleased]` → `### Changed` entry describing the behavior
change in customer-facing terms, including the `native_sim_doip.conf`
networking finding.

## Verification performed

- **Absent case:** extracted "Build harness" step run with `harness/`
  absent — printed `BLOCKED: harness/ is absent from this checkout...`
  and exited 0.
- **Qualification case:** same absent case with `EDS_QUALIFICATION_RUN=1`
  — printed the BLOCKED reason plus `ERROR: EDS_QUALIFICATION_RUN=1 —
  BLOCKED is a hard failure...` and exited 1.
- **Present case:** recreated the harness symlink, ran both extracted
  steps — build succeeded, `ALL 68 HARNESS TESTS PASSED`, and
  `PASS: executed >= declared floor of 68 harness tests` printed. Symlink
  removed afterward; `git status` confirmed clean.
- **Floor-gating (this review's Finding 1), verified under
  `bash --noprofile --norc -eo pipefail`** (GitHub Actions' actual `run:`
  shell, not a plain `bash script.sh` — the difference matters: the
  `grep ... || (echo ...; exit 1)` subshell idiom only aborts the step
  under `-e`): `HARNESS_FLOOR=70` against a real 68/68 harness run
  **correctly exits 1** (`ERROR: Expected ALL 70 HARNESS TESTS PASSED...`,
  no false `PASS` line); `HARNESS_FLOOR=68` **correctly exits 0**.
- **Defect-catching check (lessons/run-014):** git-stashed back to the
  original unfixed `ci.yml`, ran the real (unfixed) step text under
  `EDS_QUALIFICATION_RUN=1` with `harness/` absent — printed "skipped"
  and exited 0, reproducing the defect verbatim. Restored the fix and
  re-ran the same scenario — now exits 1.
- **DoIP boot-check (log-based, this review's Finding 2 + the real bug
  above):** exercised against stand-in binaries for both the pass path
  (emits the real `DoIP: listening on port 13400` line → `PASS`, exit 0,
  **no `BLOCKED` token anywhere on this path**) and the fail path (never
  emits it → `FAIL` after 30s, exit 1, ECU process still killed cleanly).
- `bash build_tests.sh`: **45/45 modules, 923/923 cases, 0 failed.**
- `bash scripts/verify_closing_keyword_syntax.sh main`: OK.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`: OK.
- **Real CI on this PR** caught the first (live-TCP-connect) version of
  the DoIP boot check failing exactly as the `native_sim_doip.conf`
  finding predicts — every other job passed, including
  `Harness Integration Tests (MISRA-clean build)` and
  `Commit message lint (closing-keyword syntax)`. The log-based
  replacement above is what real CI now runs; awaiting the next run's
  result on this push.

## Issue status

Closes #230.

Refs #234 — Phases 3 (Python-runner case-level accounting) and 4
(claim/floor re-derivation, ADR-004 amendment, docs sweep) remain open.
**#234 must stay open after this PR merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
