### PR TITLE
fix: free-tier collection error, misleading DoIP config claim, unguarded doc figures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,54 @@ Professional harness present — which figure you see depends on what's
 installed, not on how many tests exist. The full machine-readable
 breakdown for any run is written to `test-outcomes.json` at the repo root.
 
+### Fixed
+
+- **A free-tier install no longer turns the documented test command into a
+  collection error** (#260). `tests/test_doip_integration.py` guarded on
+  `pytest.importorskip("xaloqi")` and then imported `DoipBus` — a **Pro-only**
+  symbol under the OD-15 open-core split. With only the free, Apache-2.0
+  `xaloqi-tester` wheel installed (exactly what the free tier instructs), the
+  guard passed, the Pro import raised at module scope, and pytest reported a
+  *collection error* that aborted the entire `tests/` suite rather than
+  skipping one module. The two prerequisites are now checked separately and
+  both report **BLOCKED** (ADR-005), never FAIL — they are tier-gated
+  artifacts that are legitimately absent. Verified against the real published
+  wheel (`xaloqi-tester` 1.5.2 from PyPI, import path confirmed per
+  lessons/run-008): before, `1 skipped, 1 error` + `Interrupted: 1 error
+  during collection`; after, `2 skipped`. CI never caught this because CI
+  never installs the package at all — the bug was only reachable in the
+  free-tier user's environment, the one configuration nothing tested.
+
+- **`native_sim_doip.conf` no longer claims an Ethernet driver it does not
+  have** (#257). The file set `CONFIG_ETH_NATIVE_POSIX=y` under a comment
+  reading *"Networking: enable native posix Ethernet"*. That symbol is a
+  **no-op** here: `CONFIG_NET_LOOPBACK=y` blocks `NET_L2_ETHERNET`'s default
+  (`y if !NET_LOOPBACK && !NET_TEST`), leaving `ETH_DRIVER` and its whole
+  subtree invisible, silently dropped with no build error. A reader
+  reasonably concluded the DoIP example was host-reachable; it never has
+  been, from any client, by any method. The comment now states this plainly.
+  **No functional change** — the line is documented rather than deleted,
+  since removing an assumed-inert Kconfig symbol carries build risk that
+  cannot be verified without a full Zephyr toolchain, and keeping it makes
+  the eventual fix a one-place change. Real host-reachable DoIP remains
+  tracked by #257.
+
+- **The two published execution figures are now derived and guarded, not
+  hand-written prose** (#262). v1.14.0 states *1,958 of 2,981* (developer)
+  and *2,782 of 2,981* (professional) across `README.md`,
+  `docs/TESTING_STRATEGY.md` and this changelog, and nothing verified them —
+  they could drift the moment a suite changed, which is this release's own
+  failure mode reintroduced one layer up (the shape of lessons/run-010 and
+  run-020). `scripts/verify_doc_counts.py` now derives each executed figure
+  by summing `run_python_tests.sh`'s declared floor tables and fails when a
+  document disagrees, and separately fails when documents disagree with each
+  other on the collected total (which is a measured constant and cannot be
+  derived cheaply). It needs no test run, so it stays in the existing
+  per-PR `Unit Tests` job. Verified per lessons/run-014 that the guard can
+  actually fail: a drifted doc figure, a changed floor constant, and two
+  documents disagreeing on the total each produce exit 1; the clean tree
+  produces exit 0.
+
 ### Changed
 
 - **CI can no longer report a passing job that executed zero tests**

--- a/examples/basic_ecu_doip/boards/native_sim/native_sim_doip.conf
+++ b/examples/basic_ecu_doip/boards/native_sim/native_sim_doip.conf
@@ -25,7 +25,21 @@ CONFIG_STACK_CANARIES=n
 # --- Force newlib (consistent with rest of EDS) ---
 CONFIG_NEWLIB_LIBC=y
 
-# --- Networking: enable native posix Ethernet ---
+# --- Networking ---
+# NOTE (#257): CONFIG_ETH_NATIVE_POSIX below is currently a NO-OP, not a
+# working Ethernet driver. CONFIG_NET_LOOPBACK=y above blocks
+# NET_L2_ETHERNET's default (`y if !NET_LOOPBACK && !NET_TEST`), which
+# leaves ETH_DRIVER — and the whole CONFIG_ETH_NATIVE_POSIX subtree inside
+# it — invisible. Kconfig drops the symbol silently, with no build error.
+#
+# Consequence: this example's DoIP server is reachable only from inside the
+# same native_sim process. It is NOT reachable from the host OS, by any
+# client, by any method. The line is kept rather than deleted so the intent
+# stays visible and the fix is a one-place change once #257 is resolved.
+#
+# For a genuinely host-reachable DoIP ECU (real "zeth" TAP bridge, real
+# TCP), see the native_sim_doip_realzeth.conf work on branch
+# fix/eds230-native-sim-doip-realzeth, tracked by #257.
 CONFIG_NET_DRIVERS=y
 CONFIG_ETH_NATIVE_POSIX=y
 

--- a/scripts/verify_doc_counts.py
+++ b/scripts/verify_doc_counts.py
@@ -81,6 +81,84 @@ def docs():
         yield rel, p.read_text(encoding="utf-8")
 
 
+# ---------------------------------------------------------------------------
+# Execution-figure guard (#262)
+#
+# v1.14.0 publishes two headline figures — "1,958 of 2,981" (developer) and
+# "2,782 of 2,981" (professional) — in README.md, docs/TESTING_STRATEGY.md
+# and the CHANGELOG. They were hand-written prose that nothing verified, so
+# they could drift the moment a suite changed: the exact failure this
+# release removed from CI, reintroduced one layer up.
+#
+# The executed halves ARE derivable without running anything: they are the
+# sums of run_python_tests.sh's two declared floor tables. The collected
+# total (2,981) is a measured constant that cannot be derived cheaply, so it
+# is checked for *consistency* across documents instead — which catches the
+# common failure, a partial edit updating one file and not the others.
+# ---------------------------------------------------------------------------
+FLOOR_TABLE_RE = re.compile(
+    r"declare -A FLOOR_(DEVELOPER|PROFESSIONAL)=\((.*?)\n\)", re.DOTALL
+)
+FLOOR_ENTRY_RE = re.compile(r"\]=(\d+)")
+# "1,958 of 2,981 cases", "executes 2,782 of 2,981" — comma optional.
+EXEC_FIGURE_RE = re.compile(r"\b(\d{1,3}(?:,\d{3})*|\d+)\s+of\s+(\d{1,3}(?:,\d{3})*|\d+)\b")
+
+
+def _int(text: str) -> int:
+    return int(text.replace(",", ""))
+
+
+def declared_floor_totals() -> dict:
+    """Sum each profile's floor table in run_python_tests.sh."""
+    runner = ROOT / "run_python_tests.sh"
+    if not runner.exists():
+        sys.exit("FAIL: run_python_tests.sh not found — wrong repo root?")
+    text = runner.read_text(encoding="utf-8")
+    totals = {}
+    for profile, body in FLOOR_TABLE_RE.findall(text):
+        totals[profile.lower()] = sum(int(v) for v in FLOOR_ENTRY_RE.findall(body))
+    if set(totals) != {"developer", "professional"}:
+        sys.exit(
+            "FAIL: could not parse both FLOOR_DEVELOPER and FLOOR_PROFESSIONAL "
+            f"from run_python_tests.sh (found: {sorted(totals)})"
+        )
+    return totals
+
+
+def check_execution_figures(all_docs) -> list:
+    """Every 'N of M' execution figure must match a declared floor total,
+    and every M must agree with every other M."""
+    totals = declared_floor_totals()
+    valid = set(totals.values())
+    problems, collected_seen = [], {}
+
+    for rel, text in all_docs:
+        for lineno, line in enumerate(text.splitlines(), 1):
+            for m in EXEC_FIGURE_RE.finditer(line):
+                executed, collected = _int(m.group(1)), _int(m.group(2))
+                # Only consider figures in the right ballpark; "3 of 4
+                # examples" is not an execution claim.
+                if collected < 1000:
+                    continue
+                if executed not in valid:
+                    problems.append(
+                        f"{rel}:{lineno}: states {executed:,} executed cases, but the "
+                        f"declared floor totals are "
+                        f"developer={totals['developer']:,} / "
+                        f"professional={totals['professional']:,} — {m.group(0)!r}"
+                    )
+                collected_seen.setdefault(collected, []).append(f"{rel}:{lineno}")
+
+    if len(collected_seen) > 1:
+        detail = "; ".join(
+            f"{c:,} at {', '.join(where)}" for c, where in sorted(collected_seen.items())
+        )
+        problems.append(
+            f"documents disagree on the total collected-case count — {detail}"
+        )
+    return problems
+
+
 def main() -> int:
     expected = real_module_count()
     problems = []
@@ -132,8 +210,10 @@ def main() -> int:
                     f"actual is {expected} — {quote!r}"
                 )
 
+    problems.extend(check_execution_figures(list(docs())))
+
     if problems:
-        print("FAIL: stale references in prose docs (#119 guard)\n")
+        print("FAIL: stale references in prose docs (#119 / #262 guards)\n")
         for p in problems:
             print(f"  {p}")
         print(
@@ -142,7 +222,11 @@ def main() -> int:
         )
         return 1
 
-    print(f"PASS: prose docs agree with the real unit-test count ({expected}) "
+    totals = declared_floor_totals()
+    print(f"PASS: prose docs agree with the real unit-test count ({expected}), "
+          f"state execution figures matching the declared floor totals "
+          f"(developer={totals['developer']:,} / "
+          f"professional={totals['professional']:,}), "
           f"and reference no dead script paths.")
     return 0
 

--- a/tests/test_doip_integration.py
+++ b/tests/test_doip_integration.py
@@ -57,14 +57,35 @@ import pytest
 
 # ---------------------------------------------------------------------------
 # xaloqi-tester imports — DoIP transport + UDS client
-# Skip the entire module when xaloqi-tester is not installed (e.g. CI without
-# TestLab access). The ECU binary smoke-check and unit tests still run.
+# Skip the entire module when the pieces this file needs are not installed
+# (e.g. CI without TestLab access). The ECU binary smoke-check and unit tests
+# still run.
+#
+# Two separate prerequisites, and they must be checked separately (#260):
+#   1. the `xaloqi` package at all — the free, Apache-2.0 `xaloqi-tester`
+#      wheel on PyPI provides this;
+#   2. `DoipBus`, which is a **Pro-only** symbol under the OD-15 open-core
+#      split. The free wheel imports fine and then raises ImportError on
+#      this attribute.
+#
+# Guarding only on (1) meant a free-tier user — who has done exactly what
+# the free tier tells them to do — got an ImportError at module scope, which
+# pytest reports as a *collection error* that aborts the whole tests/ suite,
+# rather than a clean skip of this one module. Both prerequisites are
+# tier-gated artifacts that are legitimately absent, so both report BLOCKED
+# (ADR-005), never FAIL.
 # ---------------------------------------------------------------------------
 xaloqi = pytest.importorskip(
     "xaloqi",
     reason="BLOCKED: xaloqi-tester not installed — skipping DoIP integration tests"
 )
-from xaloqi.tester import DoipBus, Session, UdsTester
+try:
+    from xaloqi.tester import DoipBus, Session, UdsTester
+except ImportError as exc:  # Pro-only symbols absent — free wheel installed
+    pytest.skip(
+        f"BLOCKED: xaloqi-tester Pro components not installed — {exc}",
+        allow_module_level=True,
+    )
 
 # ---------------------------------------------------------------------------
 # Configuration


### PR DESCRIPTION
Three pre-release fixes, batched — same repo, all low-risk, and this saves two full CI matrix cycles over one-PR-per-issue (run-023).

## #260 — the release blocker

`tests/test_doip_integration.py` guarded on `importorskip("xaloqi")` and then imported `DoipBus`, a **Pro-only** symbol under the OD-15 split. With only the free Apache-2.0 wheel installed — exactly what the free tier instructs — the guard passed, the Pro import raised at module scope, and pytest reported a **collection error that aborted the entire `tests/` suite** rather than skipping one module.

Both prerequisites are now checked separately, and both report **BLOCKED**, never FAIL — each is a tier-gated artifact that is legitimately absent, which is what BLOCKED exists for.

Verified against the real published wheel (`xaloqi-tester` 1.5.2 from PyPI, import path confirmed per run-008):

| | Result |
|---|---|
| Before | `1 skipped, 1 error` + `Interrupted: 1 error during collection` |
| After | `2 skipped` (exit 5 → classified BLOCKED by the runner) |

CI never caught this because **CI never installs the package at all**. The bug was reachable only in the free-tier user's environment — the one configuration nothing tests. Shipping v1.14.0 without this would have undercut the release whose entire theme is that our published claims are now honest.

## #257 — corrects the claim, not the defect

The conf set `CONFIG_ETH_NATIVE_POSIX=y` under a comment reading *"Networking: enable native posix Ethernet"*. `CONFIG_NET_LOOPBACK=y` blocks `NET_L2_ETHERNET`'s default, leaving `ETH_DRIVER` and its whole subtree invisible — silently dropped, no build error. The example has never been reachable from the host, by any client, by any method.

The comment now says that plainly. **No functional change:** the line is documented rather than deleted, because removing an assumed-inert Kconfig symbol carries build risk I cannot verify without a full Zephyr toolchain, and keeping it makes the eventual fix a one-place change.

**This is why the PR says `Refs #257`, not `Closes`.** Only the misleading claim is fixed; the actual defect and the `realzeth` work remain open. A partial fix must not ride a closing keyword (run-029).

## #262 — closes the loop this release opened

The two headline figures (*1,958 of 2,981* developer, *2,782 of 2,981* professional) were hand-written prose that nothing verified — this release's own failure mode, one layer up.

`verify_doc_counts.py` now **derives** each executed figure by summing `run_python_tests.sh`'s declared floor tables, and separately fails when documents disagree with each other on the collected total (a measured constant that can't be derived cheaply). It needs no test run, so it stays in the existing per-PR `Unit Tests` job.

Proven to fail three ways (run-014 — a guard that cannot fail is worthless, as Phase 1 demonstrated):

```
drifted doc figure     → exit 1
changed floor constant → exit 1  (catches docs going stale when floors move)
docs disagreeing       → exit 1
clean tree             → exit 0
```

## Verification

- 45/45 unit tests
- Full runner, professional profile: **2,782 of 2,981 executed**, matching the declared floor exactly — no regression
- Doc guard green; free-tier path re-tested against the real PyPI wheel

Closes #260. Closes #262. Refs #257.

Note per run-024: GitHub reliably auto-closes only the first-listed issue, so #260 and #262 should both be checked after merge rather than assumed closed.
