### PR TITLE
release: v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+## [1.14.0] — 2026-09-07
+
 ### A note on the numbers in this release
 
 Starting with this release, test counts mean **executed** cases — a test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@
 #
 # SAFETY CONTEXT : Contains ASIL-B candidate modules (ISO 26262 Part 6).
 # CODING STANDARD: MISRA C:2012 alignment intended.
-# VERSION        : 1.13.4
+# VERSION        : 1.14.0
 # SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 
@@ -74,7 +74,7 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(zephyr_diagnostics_suite
-    VERSION     1.13.4
+    VERSION     1.14.0
     LANGUAGES   C
     DESCRIPTION "Production-grade UDS/ISO-TP diagnostics stack for Zephyr RTOS"
 )

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 > repo. Community users cloning the public repo can ignore this file.
 
 **Product:** Xaloqi EDS (Xaloqi Embedded Diagnostic Suite)  
-**Version:** v1.13.4  
+**Version:** v1.14.0  
 **Support:** contact@xaloqi.com
 
 ---
@@ -50,7 +50,7 @@ cd EDS
 Verify you are on the correct version:
 
 ```bash
-git checkout v1.13.4
+git checkout v1.14.0
 ```
 
 ---
@@ -59,10 +59,10 @@ git checkout v1.13.4
 
 ```bash
 # From the EDS repo root:
-unzip -o /path/to/xaloqi-eds-developer-v1.13.4.zip
+unzip -o /path/to/xaloqi-eds-developer-v1.14.0.zip
 
 # Or for Professional:
-unzip -o /path/to/xaloqi-eds-professional-v1.13.4.zip
+unzip -o /path/to/xaloqi-eds-professional-v1.14.0.zip
 ```
 
 The `-o` flag overwrites existing files without prompting — required when updating an existing installation.
@@ -75,7 +75,7 @@ The `-o` flag overwrites existing files without prompting — required when upda
 >
 > ```bash
 > rm -f tools/templates tools/testgen.py tools/_license.py harness
-> unzip -o /path/to/xaloqi-eds-developer-v1.13.4.zip
+> unzip -o /path/to/xaloqi-eds-developer-v1.14.0.zip
 > ```
 
 This extracts the toolchain files directly into the repo tree. No separate directory. After extraction you will have:
@@ -195,7 +195,7 @@ Expected output:
 
 ```
 ========================================================================
-  Xaloqi EDS — Code Generator v1.13.4
+  Xaloqi EDS — Code Generator v1.14.0
 ========================================================================
   Config   : examples/bms_ecu/diagnostics_config.yaml
   ...

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Xaloqi Embedded Diagnostics Suite
 
 [![CI](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml/badge.svg)](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-v1.13.4-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.13.4)
+[![Version](https://img.shields.io/badge/version-v1.14.0-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.14.0)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](LICENSE)
 [![Zephyr](https://img.shields.io/badge/Zephyr-v3.7%2B-brightgreen)](https://zephyrproject.org)
 
@@ -22,7 +22,7 @@ Zephyr's `native_sim`. No CAN hardware, no commercial license:
 
 ```bash
 pip install west
-west init -m https://github.com/Xaloqi/EDS --mr v1.13.4 eds-workspace
+west init -m https://github.com/Xaloqi/EDS --mr v1.14.0 eds-workspace
 cd eds-workspace && west update
 pip install -r tools/requirements.txt
 
@@ -166,7 +166,7 @@ manifest:
   projects:
     - name: EDS
       remote: xaloqi
-      revision: v1.13.4
+      revision: v1.14.0
       path: modules/eds
 ```
 
@@ -218,7 +218,7 @@ The `ZEPHYR_EDS_MODULE_DIR` variable is set automatically by west when the modul
 
 ```bash
 pip install west
-west init -m https://github.com/Xaloqi/EDS --mr v1.13.4 eds-workspace
+west init -m https://github.com/Xaloqi/EDS --mr v1.14.0 eds-workspace
 cd eds-workspace && west update
 pip install -r tools/requirements.txt
 ```
@@ -505,7 +505,7 @@ Unlike alternatives that use PolyForm Noncommercial (which prohibits production 
 **Just want to see an ECU run?**
 
 ```bash
-west init -m https://github.com/Xaloqi/EDS --mr v1.13.4 eds-workspace
+west init -m https://github.com/Xaloqi/EDS --mr v1.14.0 eds-workspace
 cd eds-workspace && west update
 west build -b native_sim examples/basic_ecu \
   -- -DDTC_OVERLAY_FILE=boards/native_sim/native_sim.overlay \

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Security fixes |
 |---|---|
-| 1.13.x (current) | ✅ Yes |
+| 1.14.x (current) | ✅ Yes |
 | 1.11.x | ✅ Yes (critical only) |
 | < 1.13 | ❌ No — please upgrade |
 

--- a/core/uds_types.h
+++ b/core/uds_types.h
@@ -35,11 +35,11 @@ extern "C" {
  * Bumped to 1.12.0 for the v1.12.0 release.
  * -------------------------------------------------------------------------- */
 #define UDS_SUITE_VERSION_MAJOR  (1U)
-#define UDS_SUITE_VERSION_MINOR  (13U)
-#define UDS_SUITE_VERSION_PATCH  (4U)
+#define UDS_SUITE_VERSION_MINOR  (14U)
+#define UDS_SUITE_VERSION_PATCH  (0U)
 
 /** Compile-time version string — matches UDS_STACK_VERSION in safety_config.h. */
-#define UDS_SUITE_VERSION_STRING "1.13.4"
+#define UDS_SUITE_VERSION_STRING "1.14.0"
 
 /* --------------------------------------------------------------------------
  * Buffer and protocol sizing constants

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -13,7 +13,7 @@ ISO 15765-2 (ISO-TP) diagnostics stack for embedded RTOS targets. It is YAML-dri
 describe your DIDs, DTCs, and routines in YAML, run the code generator, and receive
 ASIL-B safety-wrapped C code ready to compile into your ECU firmware.
 
-**Version:** v1.13.4
+**Version:** v1.14.0
 **Target RTOS:** Zephyr v3.7+ · FreeRTOS (any version with static allocation support)
 **Target boards:** native_sim (CI/dev) · STM32 Nucleo-H743ZI2 (Cortex-M7) · NXP FRDM-MCX-N947 (MCX N947, Cortex-M33) · NXP MR-CANHUBK3 (S32K344, Cortex-M7) · QEMU ARM Cortex-M4 (FreeRTOS CI)
 **Transport:** ISO-TP over CAN (default) · DoIP over Ethernet/TCP (v1.6.0+)
@@ -1038,5 +1038,5 @@ tooling and lives in EDS-toolchain — it is not part of this repo's public CI.)
 
 ---
 
-*EDS v1.13.4 — Developer €690/yr · Professional €1,990/yr — xaloqi.com*
+*EDS v1.14.0 — Developer €690/yr · Professional €1,990/yr — xaloqi.com*
 *Runtime: GPL v2 · Examples: Apache 2.0 · Tools + IDE + GUI: Commercial*

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture — Xaloqi EDS
 
-**Version:** v1.13.4  
+**Version:** v1.14.0  
 **Status:** Production-ready. All CI jobs passing.
 
 ---

--- a/docs/CODEGEN_ARCHITECTURE.md
+++ b/docs/CODEGEN_ARCHITECTURE.md
@@ -571,7 +571,7 @@ SDV tooling, OEM SOVD clients, or any tool that understands the OpenSOVD
 ```json
 {
   "sovdVersion": "1.0.0",
-  "generatedBy":  "Xaloqi EDS codegen v1.13.4",
+  "generatedBy":  "Xaloqi EDS codegen v1.14.0",
   "generatedAt":  "<ISO 8601 UTC>",
   "ecuIdentification": {
     "name":    "<ecu_name>",

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -61,7 +61,7 @@ west --version   # must print 1.2 or newer
 mkdir eds-workspace && cd eds-workspace
 
 # Initialise the workspace from the EDS repository
-west init -m https://github.com/Xaloqi/EDS --mr v1.13.4 .
+west init -m https://github.com/Xaloqi/EDS --mr v1.14.0 .
 
 # Pull Zephyr and all dependencies (this downloads ~500 MB, takes 2-4 min)
 west update

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -1,10 +1,10 @@
 # Integration Guide
 
-## Xaloqi EDS — Zephyr RTOS, FreeRTOS, DoIP, and SOVD (v1.13.4)
+## Xaloqi EDS — Zephyr RTOS, FreeRTOS, DoIP, and SOVD (v1.14.0)
 
 | Field | Value |
 |---|---|
-| Stack version | 1.13.4 |
+| Stack version | 1.14.0 |
 | Zephyr version | v3.7.0 (pinned in `west.yml`) |
 | FreeRTOS version | FreeRTOS-Kernel (any recent release; tested with HEAD) |
 | ISO standard | ISO 14229-1:2020 (UDS), ISO 15765-2:2016 (ISO-TP), ISO 13400-2 (DoIP) |
@@ -186,7 +186,7 @@ manifest:
 
     - name: embedded-diagnostics-suite
       url: https://github.com/your-org/embedded-diagnostics-suite
-      revision: v1.13.4            # pin to a release tag
+      revision: v1.14.0            # pin to a release tag
       path: eds
 ```
 
@@ -1256,7 +1256,7 @@ The flag is opt-in — omitting it leaves all existing behaviour unchanged.
 ```json
 {
   "sovdVersion": "1.0.0",
-  "generatedBy": "Xaloqi EDS codegen v1.13.4",
+  "generatedBy": "Xaloqi EDS codegen v1.14.0",
   "generatedAt": "2026-05-20T10:00:00Z",
   "ecuIdentification": {
     "name": "BasicECU",

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -1,6 +1,6 @@
 # Testing Strategy — Xaloqi EDS
 
-**Version:** v1.13.4  
+**Version:** v1.14.0  
 **Status:** 45/45 unit test modules passing. 23/23 CI jobs green. 68/68 harness
 tests passing — **Professional tier only**: `harness/` sources are a gitignored
 commercial deliverable (#68), absent from a Developer-tier checkout (every
@@ -20,7 +20,7 @@ all covered.
 EDS uses a four-layer testing strategy: unit tests, harness tests, integration tests, and system
 tests. All four layers run automatically in CI on every push and pull request.
 
-**Current test counts (v1.13.4):**
+**Current test counts (v1.14.0):**
 
 | Layer | Count | Framework | Status |
 |---|---|---|---|
@@ -40,7 +40,7 @@ tests. All four layers run automatically in CI on every push and pull request.
 ### What "the generated pytest suite" (row above) actually runs on a clean checkout
 
 `cd examples/basic_ecu/generated/tests && pytest --collect-only -q` reports **632 tests
-collected** for `basic_ecu` (v1.13.4). That is a *collection* count, not a claim that
+collected** for `basic_ecu` (v1.14.0). That is a *collection* count, not a claim that
 632 tests execute — and pass — right after `pip install -r tools/requirements.txt`. A
 meaningful share need TestLab (the commercial `xaloqi-tester` package), the
 (not-publicly-included) `firmware_bus` harness, or the commercial `tools/templates/`

--- a/examples/ardep_ecu/generated/safety_config.h
+++ b/examples/ardep_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.4"
+#define UDS_STACK_VERSION "1.14.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu/generated/safety_config.h
+++ b/examples/basic_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.4"
+#define UDS_STACK_VERSION "1.14.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu_doip/generated/safety_config.h
+++ b/examples/basic_ecu_doip/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.4"
+#define UDS_STACK_VERSION "1.14.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu_doip_freertos/generated/safety_config.h
+++ b/examples/basic_ecu_doip_freertos/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.4"
+#define UDS_STACK_VERSION "1.14.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu_freertos/generated/safety_config.h
+++ b/examples/basic_ecu_freertos/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.4"
+#define UDS_STACK_VERSION "1.14.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/bms_ecu/generated/safety_config.h
+++ b/examples/bms_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.4"
+#define UDS_STACK_VERSION "1.14.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/motor_controller_ecu/generated/safety_config.h
+++ b/examples/motor_controller_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.4"
+#define UDS_STACK_VERSION "1.14.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/robot_joint_controller_ecu/generated/safety_config.h
+++ b/examples/robot_joint_controller_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.4"
+#define UDS_STACK_VERSION "1.14.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/safeboot_ecu/generated/safety_config.h
+++ b/examples/safeboot_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.4"
+#define UDS_STACK_VERSION "1.14.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/safeboot_freertos_ecu/generated/safety_config.h
+++ b/examples/safeboot_freertos_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.4"
+#define UDS_STACK_VERSION "1.14.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/sensor_ecu/generated/safety_config.h
+++ b/examples/sensor_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.4"
+#define UDS_STACK_VERSION "1.14.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/sensor_ecu_freertos/generated/safety_config.h
+++ b/examples/sensor_ecu_freertos/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.13.4"
+#define UDS_STACK_VERSION "1.14.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/sbom.json
+++ b/sbom.json
@@ -4,7 +4,7 @@
   "serialNumber": "urn:uuid:7b3c9a5d-1f2e-4c8b-a6d0-8e4f2b1c5a3d",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-09-04T00:00:00Z",
+    "timestamp": "2026-09-07T00:00:00Z",
     "tools": [
       {
         "vendor": "Xaloqi",
@@ -14,9 +14,9 @@
     ],
     "component": {
       "type": "firmware",
-      "bom-ref": "xaloqi-eds@1.13.4",
+      "bom-ref": "xaloqi-eds@1.14.0",
       "name": "Xaloqi EDS",
-      "version": "1.13.4",
+      "version": "1.14.0",
       "description": "Production-grade UDS/ISO-TP/DoIP diagnostics stack for automotive ECUs (ASIL-B candidate, ISO 14229 / ISO 15765-2 / ISO 13400-2)",
       "licenses": [
         {

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -100,7 +100,7 @@ except ImportError:
     print("ERROR: Jinja2 is required.  pip install jinja2", file=sys.stderr)
     sys.exit(2)
 
-__version__ = "1.13.4"
+__version__ = "1.14.0"
 
 # =============================================================================
 # Constants


### PR DESCRIPTION
Version bump and CHANGELOG roll for **v1.14.0** — the execution-truth release. 26 files, all via `bump_release_version.py`.

## Verification (release-runbook step 1 + 3)

**Codegen spot-check — the step that proves the bump matches reality.** Regenerated `examples/bms_ecu` with a real `codegen.py` run against EDS-toolchain's templates and diffed it against what the script wrote:

```
IDENTICAL
```

Byte-identical including `UDS_STACK_VERSION`, with no timestamp churn in any other generated file. The targeted literal edit is exactly what real codegen produces.

**Docs sweep**: `check_release_docs.py --expected-version 1.14.0` exits **0**.

The two remaining warnings are false positives, both quoting historical text:
- `TESTING_STRATEGY.md:362` — quotes the old *"All 14 UDS services"* string inside the sentence explaining that very correction.
- `EDS-toolchain/README.md:182` — *"by 4 unit tests (37 → 45 jobrunner tests total)"* is an increment, not a total.

**`docs/` coverage confirmed** — 6 `docs/` files bumped, so run-020's gap (the script missing `docs/` files already documented in run-010) stays closed.

## One real finding, fixed outside this PR

The sweep hard-failed on `website/zephyr-uds.html` still claiming `revision: v1.13.4`. That is a copy-paste **west.yml module manifest** telling readers which ref to pin — not dated sample output — so leaving it stale would make everyone following the Zephyr integration guide pin the previous release. `bump_website()` covered only `index.html` and `eds.html`: the partial-coverage shape of run-010/run-020 again, caught only because the sweep already had a pattern for it.

Fixed on the website release branch, and `bump_release_version.py` extended so it's covered automatically from now on (xaloqi-knowledge PR).

## Companion PRs — all five must land before tagging

- `Xaloqi/EDS-toolchain` → `release/v1.14.0`
- `Xaloqi/website` → `release/eds-v1.14.0`
- `Xaloqi/automation` → `release/v1.14.0`
- `Xaloqi/xaloqi-knowledge` → `fix/bump-script-covers-zephyr-uds-page`

After merge I'll tag, verify the public Release, and run `build_release.sh` (gate + ZIPs).
