### PR TITLE
fix: correct the stale "unmerged branch" claim about native_sim_doip_realzeth.conf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1975,9 +1975,11 @@ jobs:
   # Not a live connection because this example's native_sim_doip.conf sets
   # CONFIG_NET_LOOPBACK=y, which binds the DoIP server to Zephyr's internal
   # virtual loopback only -- never reachable from the host OS by any
-  # client. A real host-side connection needs a "zeth" TAP bridge (see the
-  # diagnosed-but-not-yet-merged fix/eds230-native-sim-doip-realzeth
-  # branch), which this job deliberately does not set up.
+  # client. A real host-side connection needs a "zeth" TAP bridge, which
+  # this job deliberately does not set up. That configuration already
+  # exists and is supported: examples/basic_ecu_doip/boards/native_sim/
+  # native_sim_doip_realzeth.conf (merged #242), used by
+  # xaloqi-compatibility-tests' compat.yml for the real DoIP/TCP leg.
   #
   # This job proves build + boot only. It deliberately does NOT attempt a
   # real DoIP protocol/connection test: xaloqi-tester (TestLab) is a private,
@@ -2058,8 +2060,8 @@ jobs:
         run: |
           # Asserts on the ECU's own log line, not a live host TCP connect.
           # examples/basic_ecu_doip's native_sim_doip.conf sets
-          # CONFIG_NET_LOOPBACK=y, which (see the diagnosed-but-not-yet-
-          # merged fix/eds230-native-sim-doip-realzeth branch) silently
+          # CONFIG_NET_LOOPBACK=y, which (see native_sim_doip_realzeth.conf's
+          # header, merged #242) silently
           # drops the Ethernet driver subtree and binds the DoIP server to
           # Zephyr's internal virtual loopback only -- never reachable from
           # the host OS, by any client, regardless of method. A real host-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **Corrected a factual error about `native_sim_doip_realzeth.conf` that
+  v1.14.0 shipped** (#257). Two `ci.yml` comments and the
+  `native_sim_doip.conf` header described the real-DoIP zeth-bridge
+  configuration as living on a *"diagnosed-but-not-yet-merged"* branch. It
+  is neither diagnosed-only nor unmerged: it landed on `main` in **#242 on
+  2026-09-03**, and `xaloqi-compatibility-tests`' `compat.yml` has been
+  running the real DoIP/TCP leg against it ever since — which is why
+  `xaloqi-compatibility-tests#4` is closed. The comments now point at the
+  file as the supported host-reachable configuration, and say why this
+  example stays loopback-only on purpose: it needs no host network setup,
+  so it works in any clone or CI runner without `sudo`.
+
+  The v1.14.0 entry below repeats the same wrong claim. It is **left as
+  written**: those notes were extracted verbatim into the published GitHub
+  Release, and silently editing the record would desync the two. This entry
+  is the correction.
+
+  The error propagated by being copied rather than checked — written once
+  in a CI comment, then repeated into an issue, a config header and a
+  campaign record, none of which verified whether the file was actually on
+  `main`. One `git show origin/main:<path>` would have caught it at any
+  point.
+
+
 ## [1.14.0] — 2026-09-07
 
 ### A note on the numbers in this release

--- a/examples/basic_ecu_doip/boards/native_sim/native_sim_doip.conf
+++ b/examples/basic_ecu_doip/boards/native_sim/native_sim_doip.conf
@@ -38,8 +38,11 @@ CONFIG_NEWLIB_LIBC=y
 # stays visible and the fix is a one-place change once #257 is resolved.
 #
 # For a genuinely host-reachable DoIP ECU (real "zeth" TAP bridge, real
-# TCP), see the native_sim_doip_realzeth.conf work on branch
-# fix/eds230-native-sim-doip-realzeth, tracked by #257.
+# TCP) use native_sim_doip_realzeth.conf in this directory INSTEAD of this
+# file (merged #242). It is the supported host-reachable configuration and
+# is what xaloqi-compatibility-tests' compat.yml runs the real DoIP/TCP leg
+# against. This file stays loopback-only on purpose: it needs no host
+# network setup, so it works in any CI or clone without sudo.
 CONFIG_NET_DRIVERS=y
 CONFIG_ETH_NATIVE_POSIX=y
 


### PR DESCRIPTION
**No functional change.** Comment corrections only — but they correct something that was simply false, and that v1.14.0 shipped.

## What was wrong

Two `ci.yml` comments and `native_sim_doip.conf`'s header described the real-DoIP zeth-bridge configuration as living on a *"diagnosed-but-not-yet-merged"* branch.

It is neither diagnosed-only nor unmerged. `native_sim_doip_realzeth.conf` **landed on `main` in #242 on 2026-09-03**, and `xaloqi-compatibility-tests`' `compat.yml` has been running the real DoIP/TCP leg against it ever since — which is precisely why `xaloqi-compatibility-tests#4` is **closed**.

## What the comments say now

They point at the file as **the supported host-reachable configuration**, and state why this example stays loopback-only *on purpose*: it needs no host network setup, so it works in any clone or CI runner without `sudo`. That's a real property worth keeping, not a limitation to apologise for.

## The v1.14.0 entry is deliberately left wrong

The released CHANGELOG section repeats the same claim. Those notes were extracted **verbatim** into the published GitHub Release, so quietly editing the record would desync the two. The `[Unreleased]` entry carries the correction forward instead, where it will appear in the next release's notes.

## How this happened, since it's the useful part

The claim was written once in a CI comment during Phase 2, then copied into an issue (#257), a config header, and a campaign record — none of which checked whether the file was actually on `main`. A single `git show origin/main:<path>` would have caught it at any of those four points.

It also made #257 look far bigger than it was: filed as needing a host bridge and an architecture decision, when the capability already existed and shipped.

`ci.yml` validated as YAML; doc-count guard green.

Closes #257.
