### PR TITLE
fix(examples): serve real DoIP traffic on QEMU for basic_ecu_doip_freertos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,96 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **`examples/basic_ecu_doip_freertos` can now serve real DoIP traffic on
+  QEMU** — unblocks `xaloqi-compatibility-tests#7`. Setting
+  `-DLWIP_DIR=/path/to/lwip` builds the example against real lwIP plus a new
+  guest-side Ethernet driver, instead of the compile-only socket stub whose
+  every call returned `-1`.
+
+  New, all under `examples/basic_ecu_doip_freertos/`:
+
+  - `boards/qemu_cortex_m4/lwip_port/ethernetif_lan9118.c` — polled lwIP
+    netif driver for the SMSC LAN9118 MAC that QEMU's `mps2-an386` machine
+    emulates at `0x40200000`. Register semantics were taken from QEMU's own
+    `hw/net/lan9118.c` rather than the datasheet, since QEMU implements a
+    documented subset. Polled rather than interrupt-driven: at DoIP's
+    one-client request/response traffic level polling costs nothing
+    measurable and removes the ISR/`FromISR`/NVIC-priority class of bug
+    entirely.
+  - `boards/qemu_cortex_m4/lwip_port/sys_arch.c` + `lwipopts.h` + `arch/` —
+    lwIP `NO_SYS=0` OS abstraction on FreeRTOS primitives. Written here
+    rather than pulled from `lwip-contrib` (a second repository) for ~250
+    lines.
+  - `src/eds_net.c` — netif bring-up and RX poll task. Static addressing
+    (10.0.2.15/24, gw 10.0.2.2) because QEMU's slirp network is fixed and
+    DHCP would only negotiate back the hard-coded value.
+  - `boards/qemu_cortex_m4/startup.c` — ARMv7-M vector table and C runtime
+    startup (see below).
+
+  lwIP is **not** vendored into the repository. It is fetched and pointed at
+  via `LWIP_DIR`, exactly as `FREERTOS_DIR` already works and as `west.yml`
+  does for Zephyr — the existing convention for third-party dependencies
+  here. Pinned upstream: lwIP `STABLE-2_2_1_RELEASE`.
+
+  **The default build is unchanged**: with no `LWIP_DIR`, the example still
+  compiles against `boards/qemu_cortex_m4/lwip_stub` exactly as before.
+
+  Verified against real traffic, not just a successful compile: the
+  `xaloqi-compatibility-tests` `core_validation` campaign passes 8/8 over
+  real DoIP/TCP to the QEMU guest (tester present, extended session,
+  AES-128-CMAC SecurityAccess level 1, `0xF190` read, DTC read/clear/read,
+  return to default), 52 ms total. Against the stub build the identical
+  campaign fails at `DoIP: Routing Activation Response timed out`.
+
+  Note for anyone reproducing this: a bare TCP connect to the forwarded host
+  port succeeds **even against the stub build**, because QEMU's slirp
+  `hostfwd` accepts on the host side before it can know whether a guest
+  listener exists. Connect success is not evidence of anything; only a
+  completed DoIP exchange is.
+
 ### Fixed
+
+- **`examples/basic_ecu_doip_freertos` produced a completely empty
+  binary.** The example had no vector table and no `Reset_Handler` anywhere
+  in the repository, so the linker warned `cannot find entry symbol
+  Reset_Handler; defaulting to 00000000` and — with no root to trace from —
+  `--gc-sections` discarded the entire program. The resulting ELF had
+  `.text` size **0**, `.data` 0 and `.bss` 0. It linked, which is why the
+  compile-only CI leg reported success for as long as it has existed.
+  `boards/qemu_cortex_m4/startup.c` now supplies the vector table (with the
+  FreeRTOS `vPortSVCHandler` / `xPortPendSVHandler` / `xPortSysTickHandler`
+  slots wired), `.data` copy, `.bss` zeroing and the call to `main()`.
+
+- **`examples/basic_ecu_doip_freertos` never defined
+  `EDS_PLATFORM_FREERTOS`**, unlike every other FreeRTOS example
+  (`basic_ecu_freertos`, `sensor_ecu_freertos`, `safeboot_freertos_ecu`).
+  `platform/freertos/freertos_nvm.c` guards its entire body on that macro,
+  so the file compiled to an empty translation unit and
+  `nvm_store_read` / `nvm_store_write` / `nvm_store_is_ready` were
+  undefined at link time. Masked by the `--gc-sections` bug above.
+
+- **`eds_platform_init()` rejected the DoIP-only configuration it is
+  documented to support.** It returned `UDS_STATUS_ERR_INVALID_PARAM`
+  whenever `cfg->can_send == NULL`, but `basic_ecu_doip_freertos` passes
+  `NULL` deliberately — there is no CAN in a DoIP-only build. The example
+  could never have got past step 1 of its own integration sequence. The
+  check, and the `freertos_can_init()` call below it, are now guarded on
+  `EDS_DOIP_ONLY_BUILD` (that call was also an undefined reference, since
+  the DoIP-only build does not compile `freertos_can.c`).
+
+- **`examples/basic_ecu_doip_freertos/src/main.c` called `vTaskDelay()` from
+  its pre-scheduler fatal-error paths**, before `vTaskStartScheduler()`.
+  Replaced with plain halt loops, and each now reports the failing step over
+  the board UART instead of hanging silently.
+
+- Link flags changed from `-nostdlib` to `-nostartfiles` (plus
+  `--specs=nano.specs`). The compiler emits `memcpy`/`memset` calls from
+  ordinary struct and array initialisation, and lwIP additionally needs
+  `memcmp`/`strlen`; under `-nostdlib` those were simply unresolved. The
+  link only appeared to succeed because `--gc-sections` had already
+  discarded every caller.
 
 - **Corrected a factual error about `native_sim_doip_realzeth.conf` that
   v1.14.0 shipped** (#257). Two `ci.yml` comments and the

--- a/examples/basic_ecu_doip_freertos/CMakeLists.txt
+++ b/examples/basic_ecu_doip_freertos/CMakeLists.txt
@@ -106,6 +106,15 @@ add_executable(eds_freertos_doip
     # Application
     src/main.c
 
+    # Board support (QEMU mps2-an386): reset vector + C runtime startup, and
+    # the polled UART0 used for boot logging. Without startup.c there is no
+    # vector table, no Reset_Handler and no --gc-sections root at all — the
+    # linker warned "cannot find entry symbol Reset_Handler" and stripped the
+    # entire image, producing an ELF with .text size 0.
+    boards/qemu_cortex_m4/startup.c
+    boards/qemu_cortex_m4/board_uart.c
+    boards/qemu_cortex_m4/freertos_hooks.c
+
     # UDS core
     ${DIAG_ROOT}/core/uds_server.c
     ${DIAG_ROOT}/core/uds_session.c
@@ -162,18 +171,104 @@ target_include_directories(eds_freertos_doip PRIVATE
     ${DIAG_ROOT}/platform
     ${DIAG_ROOT}/platform/freertos       # platform_api.h, platform_doip.h, freertos_lwip.h
     ${CMAKE_CURRENT_SOURCE_DIR}/generated
+    ${CMAKE_CURRENT_SOURCE_DIR}/boards/qemu_cortex_m4   # board_uart.h
     ${FREERTOS_DIR}/include
     ${FREERTOS_PORT_DIR}
     ${FREERTOS_CONFIG_DIR}
 )
 
 if(NOT LWIP_STUB)
+    # -------------------------------------------------------------------
+    # Real lwIP build (-DLWIP_DIR=/path/to/lwip)
+    #
+    # Vendoring follows this repo's existing convention for third-party
+    # dependencies: fetch the upstream tree and point a *_DIR variable at
+    # it, exactly as FREERTOS_DIR already works (and as west.yml does for
+    # Zephyr). Nothing third-party is checked into the repo.
+    #
+    # Pinned upstream: lwIP STABLE-2_2_1_RELEASE. See the example README
+    # and the compat-tests workflow for the exact clone step.
+    #
+    # Only the IPv4 + socket subset is compiled. IPv6, PPP, 6LoWPAN,
+    # SLIP and the bridge interface are all deliberately excluded — DoIP
+    # is IPv4/TCP over Ethernet and nothing else.
+    # -------------------------------------------------------------------
+    if(NOT EXISTS "${LWIP_DIR}/src/core/init.c")
+        message(FATAL_ERROR
+            "LWIP_DIR='${LWIP_DIR}' does not look like an lwIP source tree "
+            "(expected src/core/init.c). Clone lwIP and point LWIP_DIR at it.")
+    endif()
+
+    set(LWIP_CORE_SRCS
+        ${LWIP_DIR}/src/core/init.c
+        ${LWIP_DIR}/src/core/def.c
+        ${LWIP_DIR}/src/core/dns.c
+        ${LWIP_DIR}/src/core/inet_chksum.c
+        ${LWIP_DIR}/src/core/ip.c
+        ${LWIP_DIR}/src/core/mem.c
+        ${LWIP_DIR}/src/core/memp.c
+        ${LWIP_DIR}/src/core/netif.c
+        ${LWIP_DIR}/src/core/pbuf.c
+        ${LWIP_DIR}/src/core/raw.c
+        ${LWIP_DIR}/src/core/stats.c
+        ${LWIP_DIR}/src/core/sys.c
+        ${LWIP_DIR}/src/core/altcp.c
+        ${LWIP_DIR}/src/core/altcp_alloc.c
+        ${LWIP_DIR}/src/core/altcp_tcp.c
+        ${LWIP_DIR}/src/core/tcp.c
+        ${LWIP_DIR}/src/core/tcp_in.c
+        ${LWIP_DIR}/src/core/tcp_out.c
+        ${LWIP_DIR}/src/core/timeouts.c
+        ${LWIP_DIR}/src/core/udp.c
+        ${LWIP_DIR}/src/core/ipv4/acd.c
+        ${LWIP_DIR}/src/core/ipv4/autoip.c
+        ${LWIP_DIR}/src/core/ipv4/dhcp.c
+        ${LWIP_DIR}/src/core/ipv4/etharp.c
+        ${LWIP_DIR}/src/core/ipv4/icmp.c
+        ${LWIP_DIR}/src/core/ipv4/igmp.c
+        ${LWIP_DIR}/src/core/ipv4/ip4_frag.c
+        ${LWIP_DIR}/src/core/ipv4/ip4.c
+        ${LWIP_DIR}/src/core/ipv4/ip4_addr.c
+        ${LWIP_DIR}/src/api/api_lib.c
+        ${LWIP_DIR}/src/api/api_msg.c
+        ${LWIP_DIR}/src/api/err.c
+        ${LWIP_DIR}/src/api/if_api.c
+        ${LWIP_DIR}/src/api/netbuf.c
+        ${LWIP_DIR}/src/api/netdb.c
+        ${LWIP_DIR}/src/api/netifapi.c
+        ${LWIP_DIR}/src/api/sockets.c
+        ${LWIP_DIR}/src/api/tcpip.c
+        ${LWIP_DIR}/src/netif/ethernet.c
+    )
+
+    target_sources(eds_freertos_doip PRIVATE
+        ${LWIP_CORE_SRCS}
+        # lwIP port: FreeRTOS OS abstraction + LAN9118 driver
+        boards/qemu_cortex_m4/lwip_port/sys_arch.c
+        boards/qemu_cortex_m4/lwip_port/ethernetif_lan9118.c
+        # Application-side bring-up (static IP, netif, RX poll task)
+        src/eds_net.c
+    )
+
     target_include_directories(eds_freertos_doip PRIVATE
         ${LWIP_DIR}/src/include
-        ${LWIP_DIR}/src/include/ipv4
+        ${CMAKE_CURRENT_SOURCE_DIR}/boards/qemu_cortex_m4/lwip_port
+    )
+
+    target_compile_definitions(eds_freertos_doip PRIVATE
+        EDS_LWIP_REAL=1
+    )
+
+    # Upstream lwIP does not build warning-clean under this example's
+    # -Wall -Wextra. Those warnings are not actionable here (we do not
+    # patch vendored sources), so silence them for lwIP's own files only
+    # — the EDS sources and the port layer keep the full warning set.
+    set_source_files_properties(${LWIP_CORE_SRCS}
+        PROPERTIES COMPILE_OPTIONS "-Wno-unused-but-set-variable;-Wno-type-limits;-Wno-implicit-fallthrough"
     )
 else()
-    # Compile-only stub — provide a minimal lwip/sockets.h shim
+    # Compile-only stub — provide a minimal lwip/sockets.h shim.
+    # This remains the default when LWIP_DIR is not set, unchanged.
     target_include_directories(eds_freertos_doip PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/boards/qemu_cortex_m4/lwip_stub
     )
@@ -186,6 +281,14 @@ endif()
 target_compile_definitions(eds_freertos_doip PRIVATE
     EDS_MSG_BUF_MAX_STACK_BYTES=8192
     EDS_DOIP_ONLY_BUILD=1
+    # Every other FreeRTOS example defines this (basic_ecu_freertos,
+    # sensor_ecu_freertos, safeboot_freertos_ecu); this one never did.
+    # platform/freertos/freertos_nvm.c guards its entire body on
+    # `#if defined(EDS_PLATFORM_FREERTOS) && !defined(NVM_STORE_HOST_MOCK)`,
+    # so without it the file compiled to an empty translation unit and
+    # nvm_store_read/write/is_ready were undefined at link time. That went
+    # unnoticed only because --gc-sections had been discarding every caller.
+    EDS_PLATFORM_FREERTOS=1
     FREERTOS_DOIP_TASK_STACK_WORDS=1024
     FREERTOS_DOIP_TASK_PRIORITY=6
     # [SEC-BUILD-MODE-01 / issue #84] Give EDS_BUILD_IS_PRODUCTION the same
@@ -206,11 +309,23 @@ target_compile_options(eds_freertos_doip PRIVATE
     -Wall -Wextra -Wno-unused-parameter -Wno-sign-conversion
 )
 
+# -nostartfiles (not -nostdlib): boards/qemu_cortex_m4/startup.c supplies the
+# reset vector and C runtime bring-up, so newlib's crt0 must stay out — but
+# libc itself must stay IN. The compiler emits calls to memcpy/memset from
+# ordinary struct assignment and array initialisation, and lwIP additionally
+# needs memcmp/strlen/strcmp. Under the previous -nostdlib those were simply
+# unresolved; the link only appeared to succeed because --gc-sections had
+# already discarded every caller along with the rest of the image.
+#
+# --specs=nano.specs picks newlib-nano (smaller, no wide-char/locale bulk);
+# --specs=nosys.specs supplies the bare-metal syscall stubs it expects.
 target_link_options(eds_freertos_doip PRIVATE
-    -mcpu=cortex-m4 -mthumb
+    -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=hard
     -Wl,--gc-sections
+    -Wl,-Map=eds_freertos_doip.map
     -T "${CMAKE_CURRENT_SOURCE_DIR}/boards/qemu_cortex_m4/linker.ld"
-    -nostdlib
+    -nostartfiles
+    --specs=nano.specs
     --specs=nosys.specs
 )
 

--- a/examples/basic_ecu_doip_freertos/README.md
+++ b/examples/basic_ecu_doip_freertos/README.md
@@ -3,7 +3,7 @@
 **EDS version:** v1.6.0  
 **Transport:** DoIP (ISO 13400-2) over Ethernet/TCP  
 **Platform:** FreeRTOS + LwIP — any Ethernet-capable MCU (STM32H7, i.MX RT, etc.)  
-**CI target:** QEMU ARM Cortex-M4 (compile-only; LwIP TCP not emulated in CI)  
+**CI target:** QEMU `mps2-an386` (Cortex-M4) — real DoIP/TCP over an emulated LAN9118 MAC when `LWIP_DIR` is set; compile-only otherwise  
 **DIDs:** 5 · **DTCs:** 2 · **Routines:** 3
 
 ---
@@ -44,23 +44,91 @@ ecu:
 
 ## Building
 
-### QEMU ARM Cortex-M4 (CI — compile test only)
+There are two QEMU builds: a **compile-only** one (the default) and a
+**runnable, network-capable** one selected by setting `LWIP_DIR`.
+
+### QEMU ARM Cortex-M4 — compile test only (default)
 
 ```bash
 cmake -B build \
   -DEDS_PLATFORM=freertos \
   -DFREERTOS_DIR=/path/to/FreeRTOS-Kernel \
-  -DLWIP_DIR=/path/to/lwip \
-  -DEDS_DOIP_ONLY_BUILD=ON \
   -GNinja \
   examples/basic_ecu_doip_freertos
 
 ninja -C build
 ```
 
-In CI, LwIP stub headers under `boards/qemu_cortex_m4/lwip_stubs/` satisfy include
-dependencies without bringing in the full LwIP source. The binary compiles and links; TCP
-operation requires real LwIP at runtime.
+With no `LWIP_DIR`, the stub headers under `boards/qemu_cortex_m4/lwip_stub/`
+satisfy the include dependencies without bringing in lwIP. Every socket call
+in that stub returns `-1` by design, so the binary builds and boots but can
+never accept a DoIP connection. Use it to check that the UDS stack compiles
+for FreeRTOS — not to test DoIP.
+
+### QEMU ARM Cortex-M4 — real DoIP over emulated Ethernet
+
+This is what the `xaloqi-compatibility-tests` `basic_ecu_doip_freertos` leg
+runs. lwIP is fetched, not vendored — the same convention as
+`FREERTOS_DIR`:
+
+```bash
+git clone --depth=1 -b STABLE-2_2_1_RELEASE \
+  https://github.com/lwip-tcpip/lwip.git /opt/lwip
+
+cmake -B build \
+  -DEDS_PLATFORM=freertos \
+  -DFREERTOS_DIR=/path/to/FreeRTOS-Kernel \
+  -DLWIP_DIR=/opt/lwip \
+  -GNinja \
+  examples/basic_ecu_doip_freertos
+
+ninja -C build
+```
+
+Run it, with the guest's port 13400 forwarded to the host:
+
+```bash
+qemu-system-arm \
+  -machine mps2-an386 \
+  -kernel build/eds_freertos_doip.elf \
+  -net nic,model=lan9118 \
+  -net user,hostfwd=tcp::13400-:13400 \
+  -nographic -serial file:boot.log
+```
+
+`mps2-an386` is the correct machine: it is QEMU's **Cortex-M4** MPS2 variant,
+matching this example's `-mcpu=cortex-m4 -mfpu=fpv4-sp-d16` build and the
+memory map in `boards/qemu_cortex_m4/linker.ld`. It emulates an SMSC
+**LAN9118** MAC at `0x40200000`, which
+`boards/qemu_cortex_m4/lwip_port/ethernetif_lan9118.c` drives. (`lm3s6965evb`
+is a Cortex-M3 machine with a different MAC and a different memory map — a
+Cortex-M4 hard-float image will not run on it.)
+
+`boot.log` should show the network coming up:
+
+```
+[eds] basic_ecu_doip_freertos boot
+[eds] board=qemu mps2-an386 cortex-m4f
+[eds] platform init ok
+[eds] uds stack init ok
+[eds] doip task created, starting scheduler
+[net] tcpip_init...
+[net] tcpip up, lwip 2.2.1
+[net] mac  02:00:00:ed:50:01
+[net] chip id_rev 01180001
+[net] ip   10.0.2.15
+[net] mask 255.255.255.0
+[net] gw   10.0.2.2
+[net] netif up — DoIP reachable on port 13400
+```
+
+`chip id_rev 01180001` is read back from the emulated MAC, so that line is
+positive proof the driver reached real hardware registers.
+
+> **Do not use a bare TCP connect as a liveness check.** Connecting to the
+> forwarded host port succeeds even against the stub build, because QEMU's
+> slirp `hostfwd` accepts on the host side before it can know whether a guest
+> listener exists. Only a completed DoIP exchange proves anything.
 
 ### STM32H7 (hardware target)
 
@@ -129,7 +197,17 @@ basic_ecu_doip_freertos/
 ├── CMakeLists.txt              FreeRTOS CMake — DoIP sources, EDS_DOIP_ONLY_BUILD flag
 ├── boards/
 │   └── qemu_cortex_m4/
-│       └── lwip_stubs/         Minimal LwIP headers for CI compile test
+│       ├── startup.c           ARMv7-M vector table + C runtime startup
+│       ├── freertos_hooks.c    Static-allocation callbacks (idle task memory)
+│       ├── board_uart.c/.h     Polled CMSDK UART0 — boot logging
+│       ├── linker.ld           mps2-an386 memory map
+│       ├── FreeRTOSConfig.h    1 ms tick, 48 KB heap
+│       ├── lwip_stub/          Minimal LwIP headers — compile-only default
+│       └── lwip_port/          Real LwIP port (used when LWIP_DIR is set)
+│           ├── lwipopts.h              IPv4 + sockets, static pools
+│           ├── arch/cc.h, sys_arch.h   Compiler/OS abstraction types
+│           ├── sys_arch.c              lwIP NO_SYS=0 layer on FreeRTOS
+│           └── ethernetif_lan9118.c/.h QEMU LAN9118 netif driver
 ├── src/
 │   └── main.c                  Integration sequence — eds_platform_init → DoIP start
 └── generated/                  Pre-generated C files (committed, updated by codegen)

--- a/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/FreeRTOSConfig.h
+++ b/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/FreeRTOSConfig.h
@@ -23,7 +23,11 @@
 #define configTICK_RATE_HZ                      1000U        /* 1ms tick — required for ISO-TP */
 #define configMAX_PRIORITIES                    8U
 #define configMINIMAL_STACK_SIZE                128U
-#define configTOTAL_HEAP_SIZE                   (16 * 1024U)
+/* 48 KB, raised from 16 KB. The real-lwIP build (-DLWIP_DIR=...) draws the
+ * tcpip thread stack, the netif/RX task stack, the DoIP server task stack and
+ * every lwIP semaphore, mutex and mailbox from this heap. 16 KB is not enough
+ * to reach netif-up; the failure looks like tcpip_init() never returning. */
+#define configTOTAL_HEAP_SIZE                   (48 * 1024U)
 #define configMAX_TASK_NAME_LEN                 16U
 #define configUSE_TRACE_FACILITY                0
 #define configUSE_16_BIT_TICKS                  0

--- a/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/board_uart.c
+++ b/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/board_uart.c
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Xaloqi
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/board_uart.c
+ *
+ * PURPOSE: Polled CMSDK APB UART0 driver for QEMU mps2-an386 boot logging.
+ *
+ *          Register layout verified against QEMU's own device model
+ *          (hw/char/cmsdk-apb-uart.c, v7.0.0) rather than from datasheet
+ *          memory, since QEMU is the only target this driver ever runs on:
+ *            DATA     @ 0x00
+ *            STATE    @ 0x04  bit 0 = TXFULL
+ *            CTRL     @ 0x08  bit 0 = TX_EN, bit 1 = RX_EN
+ *            BAUDDIV  @ 0x10  (QEMU warns below 16; the divisor is otherwise
+ *                              ignored because the backend is a host chardev)
+ *
+ *          UART0 base 0x40004000 is from hw/arm/mps2.c uartbase[0].
+ *
+ * SAFETY  : Example diagnostics output — not safety-assessed.
+ * STANDARD: MISRA C:2012 alignment intended. No malloc, no recursion.
+ * =============================================================================
+ */
+
+#include "board_uart.h"
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* ---------------------------------------------------------------------------
+ * Register map
+ * ------------------------------------------------------------------------ */
+
+#define UART0_BASE          (0x40004000UL)
+
+#define UART_DATA_OFFSET    (0x00UL)
+#define UART_STATE_OFFSET   (0x04UL)
+#define UART_CTRL_OFFSET    (0x08UL)
+#define UART_BAUDDIV_OFFSET (0x10UL)
+
+#define UART_STATE_TXFULL   (0x01UL)
+#define UART_CTRL_TX_EN     (0x01UL)
+#define UART_CTRL_RX_EN     (0x02UL)
+
+/* QEMU's model logs a guest error for BAUDDIV < 16; the value is otherwise
+ * unused because the backend is a host character device. */
+#define UART_BAUDDIV_MIN    (16UL)
+
+#define UART_REG(off)  (*(volatile uint32_t *)(UART0_BASE + (off)))
+
+#define DECIMAL_BASE   (10U)
+#define HEX_DIGITS     (8U)
+#define NIBBLE_BITS    (4U)
+#define NIBBLE_MASK    (0x0FU)
+
+/* uint32_t max is 4294967295 — 10 digits plus terminator. */
+#define U32_DEC_DIGITS_MAX (10U)
+
+/* ---------------------------------------------------------------------------
+ * Public API
+ * ------------------------------------------------------------------------ */
+
+void board_uart_init(void)
+{
+    UART_REG(UART_BAUDDIV_OFFSET) = UART_BAUDDIV_MIN;
+    UART_REG(UART_CTRL_OFFSET)    = UART_CTRL_TX_EN | UART_CTRL_RX_EN;
+}
+
+static void board_uart_putc(char c)
+{
+    while ((UART_REG(UART_STATE_OFFSET) & UART_STATE_TXFULL) != 0UL) {
+        /* Busy-wait for TX FIFO space. */
+    }
+    UART_REG(UART_DATA_OFFSET) = (uint32_t)(uint8_t)c;
+}
+
+void board_uart_puts(const char *s)
+{
+    const char *p = s;
+
+    if (p == NULL) {
+        return;
+    }
+
+    while (*p != '\0') {
+        board_uart_putc(*p);
+        p++;
+    }
+}
+
+void board_uart_put_hex32(uint32_t val)
+{
+    static const char digits[] = "0123456789abcdef";
+    uint32_t          shift    = HEX_DIGITS * NIBBLE_BITS;
+
+    while (shift > 0U) {
+        shift -= NIBBLE_BITS;
+        board_uart_putc(digits[(val >> shift) & NIBBLE_MASK]);
+    }
+}
+
+void board_uart_put_u32(uint32_t val)
+{
+    char     buf[U32_DEC_DIGITS_MAX];
+    uint32_t v   = val;
+    uint32_t len = 0U;
+
+    if (v == 0U) {
+        board_uart_putc('0');
+        return;
+    }
+
+    while ((v > 0U) && (len < U32_DEC_DIGITS_MAX)) {
+        buf[len] = (char)('0' + (char)(v % DECIMAL_BASE));
+        v       /= DECIMAL_BASE;
+        len++;
+    }
+
+    while (len > 0U) {
+        len--;
+        board_uart_putc(buf[len]);
+    }
+}

--- a/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/board_uart.h
+++ b/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/board_uart.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Xaloqi
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/board_uart.h
+ *
+ * PURPOSE: Boot-log output over the CMSDK APB UART0 of QEMU's mps2-an386.
+ *
+ *          Exists so the CI leg can produce real, checkable evidence that the
+ *          firmware booted, that the Ethernet MAC was identified, and that the
+ *          DoIP server reached its listen state — rather than inferring all of
+ *          that from whether a TCP connect happened to succeed.
+ *
+ * SAFETY  : Example diagnostics output — not safety-assessed.
+ * STANDARD: MISRA C:2012 alignment intended. No malloc, no recursion.
+ * =============================================================================
+ */
+
+#ifndef EDS_BOARD_UART_H
+#define EDS_BOARD_UART_H
+
+#include <stdint.h>
+
+/** Enable UART0 transmit. Safe to call before the scheduler starts. */
+void board_uart_init(void);
+
+/** Write a NUL-terminated string. Blocking, polled; no buffering. */
+void board_uart_puts(const char *s);
+
+/** Write @p val as 8 lowercase hex digits, no prefix. */
+void board_uart_put_hex32(uint32_t val);
+
+/** Write @p val as unsigned decimal. */
+void board_uart_put_u32(uint32_t val);
+
+#endif /* EDS_BOARD_UART_H */

--- a/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/freertos_hooks.c
+++ b/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/freertos_hooks.c
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Xaloqi
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/freertos_hooks.c
+ *
+ * PURPOSE: Application-supplied FreeRTOS static-allocation callbacks.
+ *
+ *          FreeRTOSConfig.h sets configSUPPORT_STATIC_ALLOCATION = 1, which
+ *          makes vTaskStartScheduler() call vApplicationGetIdleTaskMemory()
+ *          to obtain the idle task's TCB and stack. The application must
+ *          provide it; the kernel deliberately does not.
+ *
+ *          Nothing in the repository defined it before, because no FreeRTOS
+ *          example had ever linked a non-empty image (see startup.c for the
+ *          --gc-sections root cause). The undefined reference only surfaced
+ *          once the vector table gave the linker something to keep.
+ *
+ *          configUSE_TIMERS is 0, so vApplicationGetTimerTaskMemory() is not
+ *          required and is intentionally absent.
+ *
+ * SAFETY  : Example board support — not safety-assessed.
+ * STANDARD: MISRA C:2012 alignment intended. Static storage only — no malloc.
+ * =============================================================================
+ */
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+#if (configSUPPORT_STATIC_ALLOCATION == 1)
+
+/* Statically allocated idle-task storage. Deliberately file-scope static
+ * rather than heap: the no-malloc rule applies, and these must outlive
+ * every caller for the lifetime of the scheduler. */
+static StaticTask_t s_idle_tcb;
+static StackType_t  s_idle_stack[configMINIMAL_STACK_SIZE];
+
+void vApplicationGetIdleTaskMemory(StaticTask_t **ppxIdleTaskTCBBuffer,
+                                   StackType_t  **ppxIdleTaskStackBuffer,
+                                   uint32_t      *pulIdleTaskStackSize);
+
+void vApplicationGetIdleTaskMemory(StaticTask_t **ppxIdleTaskTCBBuffer,
+                                   StackType_t  **ppxIdleTaskStackBuffer,
+                                   uint32_t      *pulIdleTaskStackSize)
+{
+    *ppxIdleTaskTCBBuffer   = &s_idle_tcb;
+    *ppxIdleTaskStackBuffer = s_idle_stack;
+    *pulIdleTaskStackSize   = (uint32_t)configMINIMAL_STACK_SIZE;
+}
+
+#endif /* configSUPPORT_STATIC_ALLOCATION */

--- a/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/linker.ld
+++ b/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/linker.ld
@@ -1,18 +1,23 @@
 /*
  * linker.ld — QEMU mps2-an386 (ARM Cortex-M4)
  *
- * Memory map for QEMU mps2-an386:
- *   FLASH: 0x00000000 – 0x003FFFFF (4 MB)
- *   SRAM:  0x20000000 – 0x20FFFFFF (16 MB addressable, 4 MB typical)
+ * Memory map for QEMU mps2-an386, as modelled in QEMU's hw/arm/mps2.c:
+ *   ZBT SSRAM1   : 0x00000000 – 0x003FFFFF (4 MB)  — code ("FLASH")
+ *   ZBT SSRAM2&3 : 0x20000000 – 0x203FFFFF (4 MB)  — data
  *
- * Xaloqi EDS basic_ecu_freertos — CI build only.
+ * SRAM is declared as 1 MB rather than the earlier 256 KB: the lwIP build
+ * (-DLWIP_DIR=...) adds the lwIP heap, the pbuf pool and a larger FreeRTOS
+ * heap to .bss. 1 MB stays comfortably inside the 4 MB the machine provides
+ * while leaving obvious headroom.
+ *
+ * Xaloqi EDS basic_ecu_doip_freertos — CI/QEMU build only.
  * For production targets, replace with your MCU's linker script.
  */
 
 MEMORY
 {
     FLASH (rx)  : ORIGIN = 0x00000000, LENGTH = 4M
-    SRAM  (rwx) : ORIGIN = 0x20000000, LENGTH = 256K
+    SRAM  (rwx) : ORIGIN = 0x20000000, LENGTH = 1M
 }
 
 ENTRY(Reset_Handler)
@@ -79,7 +84,7 @@ SECTIONS
     {
         . = ALIGN(8);
         _stack_start = .;
-        . = . + 0x1000;    /* 4 KB initial stack */
+        . = . + 0x2000;    /* 8 KB initial stack (MSP: startup + all ISRs) */
         . = ALIGN(8);
         _stack_end = .;
     } > SRAM

--- a/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/lwip_port/arch/cc.h
+++ b/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/lwip_port/arch/cc.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Xaloqi
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: .../boards/qemu_cortex_m4/lwip_port/arch/cc.h
+ *
+ * PURPOSE: lwIP compiler/architecture abstraction for arm-none-eabi-gcc on
+ *          Cortex-M4 (little-endian, 32-bit).
+ *
+ * SAFETY  : Example port layer — not safety-assessed.
+ * =============================================================================
+ */
+
+#ifndef EDS_LWIP_ARCH_CC_H
+#define EDS_LWIP_ARCH_CC_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* Cortex-M is little-endian in every configuration this example supports. */
+#define BYTE_ORDER          LITTLE_ENDIAN
+
+/* lwIP uses the C99 <inttypes.h> format macros for its own printf output. */
+#define LWIP_NO_INTTYPES_H  0
+
+#define LWIP_CHKSUM_ALGORITHM  2
+
+/* Structure packing — GCC syntax. */
+#define PACK_STRUCT_BEGIN
+#define PACK_STRUCT_STRUCT  __attribute__((packed))
+#define PACK_STRUCT_END
+#define PACK_STRUCT_FIELD(x) x
+
+/* Diagnostics.
+ *
+ * LWIP_PLATFORM_DIAG is routed to the board UART so lwIP's own messages land
+ * in the same boot log as everything else. LWIP_PLATFORM_ASSERT halts rather
+ * than continuing: an assertion failure inside the IP stack leaves it in an
+ * undefined state, and a halted CPU is far easier to diagnose from a CI log
+ * than a stack that limps on and fails later somewhere unrelated.
+ */
+void eds_lwip_platform_diag(const char *msg);
+void eds_lwip_platform_assert(const char *msg, const char *file, int line);
+
+#define LWIP_PLATFORM_DIAG(x)   do { eds_lwip_platform_diag("lwip"); } while (0)
+#define LWIP_PLATFORM_ASSERT(x) \
+    do { eds_lwip_platform_assert((x), __FILE__, __LINE__); } while (0)
+
+#endif /* EDS_LWIP_ARCH_CC_H */

--- a/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/lwip_port/arch/sys_arch.h
+++ b/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/lwip_port/arch/sys_arch.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Xaloqi
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: .../boards/qemu_cortex_m4/lwip_port/arch/sys_arch.h
+ *
+ * PURPOSE: lwIP OS abstraction types, mapped onto FreeRTOS primitives.
+ *
+ *          lwIP's contrib tree ships a FreeRTOS port, but contrib is a
+ *          separate repository from the lwIP release this build pins. Rather
+ *          than pull a second dependency for ~250 lines, the port lives here
+ *          alongside the driver it is used with.
+ *
+ * SAFETY  : Example port layer — not safety-assessed.
+ * =============================================================================
+ */
+
+#ifndef EDS_LWIP_ARCH_SYS_ARCH_H
+#define EDS_LWIP_ARCH_SYS_ARCH_H
+
+#include "FreeRTOS.h"
+#include "semphr.h"
+#include "task.h"
+#include "queue.h"
+
+/* lwIP checks against these sentinels, so an "empty" handle must compare
+ * equal to NULL — which FreeRTOS handles do when uninitialised. */
+#define SYS_MBOX_NULL   NULL
+#define SYS_SEM_NULL    NULL
+
+typedef SemaphoreHandle_t sys_sem_t;
+typedef SemaphoreHandle_t sys_mutex_t;
+typedef QueueHandle_t     sys_mbox_t;
+typedef TaskHandle_t      sys_thread_t;
+
+/* SYS_ARCH_PROTECT nesting level. Unused value on FreeRTOS (the critical
+ * section itself nests), but lwIP requires the type to exist. */
+typedef UBaseType_t sys_prot_t;
+
+#endif /* EDS_LWIP_ARCH_SYS_ARCH_H */

--- a/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/lwip_port/ethernetif_lan9118.c
+++ b/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/lwip_port/ethernetif_lan9118.c
@@ -1,0 +1,497 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Xaloqi
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: .../boards/qemu_cortex_m4/lwip_port/ethernetif_lan9118.c
+ *
+ * PURPOSE: lwIP netif driver for the SMSC LAN9118 Ethernet MAC as emulated by
+ *          QEMU's mps2-an386 machine (hw/net/lan9118.c, base 0x40200000).
+ *
+ *          This is the piece compat-tests#7 was actually missing. Before it,
+ *          the example compiled against boards/qemu_cortex_m4/lwip_stub,
+ *          whose every socket call returns -1 unconditionally — so the DoIP
+ *          CI leg could never exchange a byte no matter what the harness did.
+ *
+ *          REGISTER SEMANTICS were taken from QEMU's own device model rather
+ *          than the SMSC datasheet, because QEMU is the only target this
+ *          driver runs on and the model implements a documented subset:
+ *            - RX data FIFO   : offsets 0x00..0x1f (read)
+ *            - TX data FIFO   : offsets 0x20..0x3f (write)
+ *            - RX status FIFO : 0x40 (pop), 0x44 (peek)
+ *            - BYTE_TEST      : reads 0x87654321 — endianness/presence probe
+ *            - ID_REV         : reads 0x01180001
+ *            - RX_FIFO_INF    : (status_fifo_used << 16) | (data_used << 2)
+ *
+ *          TRANSMIT is a single-segment write: TX command 'A' (buffer size in
+ *          bits 0..10, first-segment bit 13, last-segment bit 12), then
+ *          command 'B', then the frame as little-endian 32-bit words. QEMU's
+ *          tx_fifo_push() assembles bytes least-significant-first — its own
+ *          comment notes the datasheet is unclear and that empirical results
+ *          are little-endian.
+ *
+ *          RECEIVE pops one RX status word per frame; bits 16..29 carry the
+ *          frame length *including* the 4-byte CRC that the model appends, so
+ *          the payload handed to lwIP is length - 4.
+ *
+ *          POLLED, NOT INTERRUPT-DRIVEN. The RX path runs from an ordinary
+ *          FreeRTOS task (see eds_net.c), which keeps three things out of the
+ *          design: an ISR that must not call blocking lwIP APIs, a
+ *          FromISR/critical-section interaction with the tcpip mailbox, and
+ *          any NVIC priority coupling to configMAX_SYSCALL_INTERRUPT_PRIORITY.
+ *          At DoIP's traffic level (one diagnostic client, request/response)
+ *          polling costs nothing measurable and removes a whole class of
+ *          concurrency bug.
+ *
+ * SAFETY  : Example driver — not safety-assessed.
+ * STANDARD: MISRA C:2012 alignment intended. No malloc (lwIP pbuf pools and
+ *           file-scope static staging buffers only), no recursion, and every
+ *           hardware wait loop is bounded.
+ * =============================================================================
+ */
+
+#include "ethernetif_lan9118.h"
+#include "board_uart.h"
+
+#include "lwip/opt.h"
+#include "lwip/def.h"
+#include "lwip/mem.h"
+#include "lwip/pbuf.h"
+#include "lwip/stats.h"
+#include "lwip/snmp.h"
+#include "lwip/etharp.h"
+#include "netif/ethernet.h"
+
+#include <string.h>
+
+/* ---------------------------------------------------------------------------
+ * Register map (QEMU mps2-an386: hw/arm/mps2.c ethernet_base = 0x40200000)
+ * ------------------------------------------------------------------------ */
+
+#define LAN9118_BASE            (0x40200000UL)
+
+#define REG_RX_DATA_FIFO        (0x00UL)
+#define REG_TX_DATA_FIFO        (0x20UL)
+#define REG_RX_STATUS_FIFO      (0x40UL)
+#define REG_ID_REV              (0x50UL)
+#define REG_IRQ_CFG             (0x54UL)
+#define REG_INT_STS             (0x58UL)
+#define REG_INT_EN              (0x5CUL)
+#define REG_BYTE_TEST           (0x64UL)
+#define REG_RX_CFG              (0x6CUL)
+#define REG_TX_CFG              (0x70UL)
+#define REG_HW_CFG              (0x74UL)
+#define REG_RX_DP_CTRL          (0x78UL)
+#define REG_RX_FIFO_INF         (0x7CUL)
+#define REG_TX_FIFO_INF         (0x80UL)
+#define REG_MAC_CSR_CMD         (0xA4UL)
+#define REG_MAC_CSR_DATA        (0xA8UL)
+
+#define LAN9118_REG(off)  (*(volatile uint32_t *)(LAN9118_BASE + (off)))
+
+/* Expected probe values (QEMU lan9118_readl). */
+#define BYTE_TEST_EXPECTED      (0x87654321UL)
+#define ID_REV_LAN9118          (0x01180001UL)
+#define ID_REV_CHIP_MASK        (0xFFFF0000UL)
+#define ID_REV_LAN9118_CHIP     (0x01180000UL)
+
+/* HW_CFG */
+#define HW_CFG_SRST             (0x00000001UL)
+
+/* TX_CFG */
+#define TX_CFG_TX_ON            (0x00000002UL)
+#define TX_CFG_TXS_DUMP         (0x00008000UL)
+#define TX_CFG_TXD_DUMP         (0x00004000UL)
+
+/* RX_DP_CTRL */
+#define RX_DP_CTRL_FFWD         (0x80000000UL)
+
+/* MAC CSR command register */
+#define MAC_CSR_CMD_BUSY        (0x80000000UL)
+#define MAC_CSR_CMD_READ        (0x40000000UL)
+#define MAC_CSR_CMD_ADDR_MASK   (0x0000000FUL)
+
+/* Indirect MAC register indices */
+#define MAC_REG_CR              (1UL)
+#define MAC_REG_ADDRH           (2UL)
+#define MAC_REG_ADDRL           (3UL)
+
+/* MAC_CR bits */
+#define MAC_CR_TXEN             (0x00000008UL)
+#define MAC_CR_RXEN             (0x00000004UL)
+/* NOTE: MAC_CR_BCAST is a *disable*. QEMU's lan9118_filter() accepts a
+ * broadcast frame only when this bit is CLEAR. Setting it would silently
+ * drop every ARP request and make the ECU unreachable. */
+#define MAC_CR_BCAST_DISABLE    (0x00000800UL)
+
+/* TX command 'A' */
+#define TX_CMD_A_LAST_SEG       (0x00001000UL)
+#define TX_CMD_A_FIRST_SEG      (0x00002000UL)
+#define TX_CMD_A_BUFSIZE_MASK   (0x000007FFUL)
+
+/* RX status word */
+#define RX_STATUS_LEN_SHIFT     (16U)
+#define RX_STATUS_LEN_MASK      (0x3FFFUL)
+#define RX_STATUS_ERROR         (0x00008000UL)
+
+/* RX_FIFO_INF */
+#define RX_FIFO_INF_SFUSED_SHIFT (16U)
+#define RX_FIFO_INF_SFUSED_MASK  (0x00FFUL)
+
+/* Ethernet framing */
+#define ETH_CRC_LEN             (4U)
+#define ETH_FRAME_MAX           (1536U)
+#define ETH_FRAME_MIN           (14U)
+
+#define BYTES_PER_WORD          (4U)
+
+/** Bound for every hardware poll loop. QEMU completes these synchronously;
+ *  the bound exists so real silicon cannot hang the driver. */
+#define LAN9118_WAIT_ITERATIONS (100000UL)
+
+/* ---------------------------------------------------------------------------
+ * Module state
+ *
+ * Static staging buffers rather than dynamic allocation. TX and RX get
+ * separate buffers on purpose: linkoutput runs on lwIP's tcpip thread while
+ * lan9118_poll() runs on the RX task, so a shared buffer would be a genuine
+ * data race rather than a theoretical one.
+ * ------------------------------------------------------------------------ */
+
+static uint32_t s_id_rev = 0UL;
+
+static uint8_t s_tx_buf[ETH_FRAME_MAX] __attribute__((aligned(4)));
+static uint8_t s_rx_buf[ETH_FRAME_MAX] __attribute__((aligned(4)));
+
+/* ---------------------------------------------------------------------------
+ * Indirect MAC register access
+ * ------------------------------------------------------------------------ */
+
+static bool mac_csr_wait_idle(void)
+{
+    uint32_t spins = 0UL;
+
+    while (spins < LAN9118_WAIT_ITERATIONS) {
+        if ((LAN9118_REG(REG_MAC_CSR_CMD) & MAC_CSR_CMD_BUSY) == 0UL) {
+            return true;
+        }
+        spins++;
+    }
+    return false;
+}
+
+static bool mac_csr_write(uint32_t reg, uint32_t val)
+{
+    if (!mac_csr_wait_idle()) {
+        return false;
+    }
+    LAN9118_REG(REG_MAC_CSR_DATA) = val;
+    LAN9118_REG(REG_MAC_CSR_CMD)  =
+        MAC_CSR_CMD_BUSY | (reg & MAC_CSR_CMD_ADDR_MASK);
+    return mac_csr_wait_idle();
+}
+
+static bool mac_csr_read(uint32_t reg, uint32_t *out)
+{
+    if (out == NULL) {
+        return false;
+    }
+    if (!mac_csr_wait_idle()) {
+        return false;
+    }
+    LAN9118_REG(REG_MAC_CSR_CMD) =
+        MAC_CSR_CMD_BUSY | MAC_CSR_CMD_READ | (reg & MAC_CSR_CMD_ADDR_MASK);
+    if (!mac_csr_wait_idle()) {
+        return false;
+    }
+    *out = LAN9118_REG(REG_MAC_CSR_DATA);
+    return true;
+}
+
+/* ---------------------------------------------------------------------------
+ * Transmit
+ * ------------------------------------------------------------------------ */
+
+static err_t lan9118_linkoutput(struct netif *netif, struct pbuf *p)
+{
+    uint32_t len;
+    uint32_t words;
+    uint32_t i;
+    uint32_t cmd_a;
+    uint32_t cmd_b;
+
+    if ((netif == NULL) || (p == NULL)) {
+        return ERR_ARG;
+    }
+
+    len = (uint32_t)p->tot_len;
+    if ((len == 0UL) || (len > ETH_FRAME_MAX)) {
+        return ERR_VAL;
+    }
+
+    /* Flatten the pbuf chain into a word-aligned staging buffer. The TX FIFO
+     * is written 32 bits at a time, so a chain whose segments have arbitrary
+     * lengths cannot be streamed directly without re-packing anyway. */
+    (void)memset(s_tx_buf, 0, sizeof(s_tx_buf));
+    if (pbuf_copy_partial(p, s_tx_buf, (u16_t)len, 0U) != (u16_t)len) {
+        return ERR_BUF;
+    }
+
+    /* Single-segment transfer: first and last at once, zero data offset. */
+    cmd_a = TX_CMD_A_FIRST_SEG | TX_CMD_A_LAST_SEG |
+            (len & TX_CMD_A_BUFSIZE_MASK);
+    /* Command B: the low half is the frame length; the high half is a tag
+     * echoed back through the TX status FIFO. We do not read that FIFO, so
+     * the tag value only has to be stable. */
+    cmd_b = (len & 0x0000FFFFUL) | ((len & 0x0000FFFFUL) << 16U);
+
+    LAN9118_REG(REG_TX_DATA_FIFO) = cmd_a;
+    LAN9118_REG(REG_TX_DATA_FIFO) = cmd_b;
+
+    words = (len + (BYTES_PER_WORD - 1U)) / BYTES_PER_WORD;
+    for (i = 0UL; i < words; i++) {
+        uint32_t w;
+        /* Little-endian assembly, matching QEMU's tx_fifo_push(). Built byte
+         * by byte rather than by casting s_tx_buf to uint32_t* so that this
+         * stays free of alignment and strict-aliasing assumptions. */
+        w  =  (uint32_t)s_tx_buf[(i * BYTES_PER_WORD) + 0U];
+        w |= ((uint32_t)s_tx_buf[(i * BYTES_PER_WORD) + 1U]) << 8U;
+        w |= ((uint32_t)s_tx_buf[(i * BYTES_PER_WORD) + 2U]) << 16U;
+        w |= ((uint32_t)s_tx_buf[(i * BYTES_PER_WORD) + 3U]) << 24U;
+        LAN9118_REG(REG_TX_DATA_FIFO) = w;
+    }
+
+    MIB2_STATS_NETIF_ADD(netif, ifoutoctets, (u32_t)len);
+    LINK_STATS_INC(link.xmit);
+
+    return ERR_OK;
+}
+
+/* ---------------------------------------------------------------------------
+ * Receive
+ * ------------------------------------------------------------------------ */
+
+/** Pop and discard the frame currently at the head of the RX FIFO. */
+static void lan9118_rx_discard(void)
+{
+    LAN9118_REG(REG_RX_DP_CTRL) = RX_DP_CTRL_FFWD;
+}
+
+/**
+ * Read one complete frame out of the RX data FIFO into @p s_rx_buf.
+ *
+ * @param status   the frame's RX status word, already popped.
+ * @param out_len  receives the payload length (CRC stripped).
+ * @return true if a frame was read and is worth handing to lwIP.
+ */
+static bool lan9118_rx_frame(uint32_t status, uint32_t *out_len)
+{
+    uint32_t frame_len;
+    uint32_t payload_len;
+    uint32_t words;
+    uint32_t i;
+
+    frame_len = (status >> RX_STATUS_LEN_SHIFT) & RX_STATUS_LEN_MASK;
+
+    if ((status & RX_STATUS_ERROR) != 0UL) {
+        lan9118_rx_discard();
+        return false;
+    }
+
+    /* frame_len counts the 4-byte CRC the MAC appends. */
+    if ((frame_len <= ETH_CRC_LEN) ||
+        (frame_len > (ETH_FRAME_MAX + ETH_CRC_LEN))) {
+        lan9118_rx_discard();
+        return false;
+    }
+    payload_len = frame_len - ETH_CRC_LEN;
+    if (payload_len < ETH_FRAME_MIN) {
+        lan9118_rx_discard();
+        return false;
+    }
+
+    /* The FIFO delivers whole words; read the CRC too and drop it. */
+    words = (frame_len + (BYTES_PER_WORD - 1U)) / BYTES_PER_WORD;
+    for (i = 0UL; i < words; i++) {
+        uint32_t w   = LAN9118_REG(REG_RX_DATA_FIFO);
+        uint32_t off = i * BYTES_PER_WORD;
+
+        /* Only store bytes that fall inside the payload; the trailing CRC
+         * and any final partial word are read to drain the FIFO, not kept. */
+        if ((off + 0U) < payload_len) {
+            s_rx_buf[off + 0U] = (uint8_t)(w & 0xFFUL);
+        }
+        if ((off + 1U) < payload_len) {
+            s_rx_buf[off + 1U] = (uint8_t)((w >> 8U) & 0xFFUL);
+        }
+        if ((off + 2U) < payload_len) {
+            s_rx_buf[off + 2U] = (uint8_t)((w >> 16U) & 0xFFUL);
+        }
+        if ((off + 3U) < payload_len) {
+            s_rx_buf[off + 3U] = (uint8_t)((w >> 24U) & 0xFFUL);
+        }
+    }
+
+    *out_len = payload_len;
+    return true;
+}
+
+uint32_t lan9118_poll(struct netif *netif)
+{
+    uint32_t delivered = 0UL;
+    uint32_t pending;
+
+    if (netif == NULL) {
+        return 0UL;
+    }
+
+    pending = (LAN9118_REG(REG_RX_FIFO_INF) >> RX_FIFO_INF_SFUSED_SHIFT) &
+              RX_FIFO_INF_SFUSED_MASK;
+
+    while (pending > 0UL) {
+        uint32_t status = LAN9118_REG(REG_RX_STATUS_FIFO);
+        uint32_t len    = 0UL;
+
+        pending--;
+
+        if (lan9118_rx_frame(status, &len)) {
+            struct pbuf *p = pbuf_alloc(PBUF_RAW, (u16_t)len, PBUF_POOL);
+
+            if (p == NULL) {
+                /* Out of pbufs: the frame is already drained from the FIFO,
+                 * so it is simply lost. TCP will retransmit. */
+                LINK_STATS_INC(link.memerr);
+                LINK_STATS_INC(link.drop);
+            } else {
+                if (pbuf_take(p, s_rx_buf, (u16_t)len) != ERR_OK) {
+                    (void)pbuf_free(p);
+                    LINK_STATS_INC(link.drop);
+                } else {
+                    MIB2_STATS_NETIF_ADD(netif, ifinoctets, (u32_t)len);
+                    LINK_STATS_INC(link.recv);
+
+                    if (netif->input(p, netif) != ERR_OK) {
+                        (void)pbuf_free(p);
+                        LINK_STATS_INC(link.drop);
+                    } else {
+                        delivered++;
+                    }
+                }
+            }
+        }
+    }
+
+    return delivered;
+}
+
+/* ---------------------------------------------------------------------------
+ * Initialisation
+ * ------------------------------------------------------------------------ */
+
+uint32_t lan9118_id_rev(void)
+{
+    return s_id_rev;
+}
+
+err_t lan9118_netif_init(struct netif *netif)
+{
+    uint32_t byte_test;
+    uint32_t spins = 0UL;
+    uint32_t mac_lo;
+    uint32_t mac_hi;
+    uint32_t mac_cr = 0UL;
+
+    if (netif == NULL) {
+        return ERR_ARG;
+    }
+
+    /* 1. Presence/endianness probe before touching anything else. */
+    byte_test = LAN9118_REG(REG_BYTE_TEST);
+    if (byte_test != BYTE_TEST_EXPECTED) {
+        board_uart_puts("[eth] BYTE_TEST mismatch: ");
+        board_uart_put_hex32(byte_test);
+        board_uart_puts("\r\n");
+        return ERR_IF;
+    }
+
+    s_id_rev = LAN9118_REG(REG_ID_REV);
+    if ((s_id_rev & ID_REV_CHIP_MASK) != ID_REV_LAN9118_CHIP) {
+        board_uart_puts("[eth] unexpected ID_REV: ");
+        board_uart_put_hex32(s_id_rev);
+        board_uart_puts("\r\n");
+        return ERR_IF;
+    }
+
+    /* 2. Soft reset, then wait for it to clear (bounded). */
+    LAN9118_REG(REG_HW_CFG) = HW_CFG_SRST;
+    while (((LAN9118_REG(REG_HW_CFG) & HW_CFG_SRST) != 0UL) &&
+           (spins < LAN9118_WAIT_ITERATIONS)) {
+        spins++;
+    }
+    if (spins >= LAN9118_WAIT_ITERATIONS) {
+        board_uart_puts("[eth] soft reset did not complete\r\n");
+        return ERR_IF;
+    }
+
+    /* 3. Interrupts stay masked — this driver is polled. */
+    LAN9118_REG(REG_INT_EN)  = 0UL;
+    LAN9118_REG(REG_INT_STS) = 0xFFFFFFFFUL;
+
+    /* 4. Program the station address from the netif hwaddr.
+     *    ADDRL holds bytes 0..3, ADDRH bytes 4..5 — this ordering is what
+     *    QEMU's do_mac_write() writes back into its filter address, so
+     *    getting it wrong makes unicast frames silently vanish. */
+    mac_lo = ((uint32_t)netif->hwaddr[0])        |
+             (((uint32_t)netif->hwaddr[1]) << 8U) |
+             (((uint32_t)netif->hwaddr[2]) << 16U) |
+             (((uint32_t)netif->hwaddr[3]) << 24U);
+    mac_hi = ((uint32_t)netif->hwaddr[4])        |
+             (((uint32_t)netif->hwaddr[5]) << 8U);
+
+    if (!mac_csr_write(MAC_REG_ADDRL, mac_lo) ||
+        !mac_csr_write(MAC_REG_ADDRH, mac_hi)) {
+        board_uart_puts("[eth] MAC address programming failed\r\n");
+        return ERR_IF;
+    }
+
+    /* 5. No RX offset/padding — the driver reads packed words. */
+    LAN9118_REG(REG_RX_CFG) = 0UL;
+
+    /* 6. Flush both TX FIFOs, then enable the transmitter. */
+    LAN9118_REG(REG_TX_CFG) = TX_CFG_TXS_DUMP | TX_CFG_TXD_DUMP;
+    LAN9118_REG(REG_TX_CFG) = TX_CFG_TX_ON;
+
+    /* 7. Enable MAC TX and RX. BCAST_DISABLE deliberately left clear so ARP
+     *    requests are received. */
+    if (!mac_csr_write(MAC_REG_CR, MAC_CR_TXEN | MAC_CR_RXEN)) {
+        board_uart_puts("[eth] MAC_CR write failed\r\n");
+        return ERR_IF;
+    }
+    if (!mac_csr_read(MAC_REG_CR, &mac_cr)) {
+        return ERR_IF;
+    }
+    if ((mac_cr & (MAC_CR_TXEN | MAC_CR_RXEN)) !=
+        (MAC_CR_TXEN | MAC_CR_RXEN)) {
+        board_uart_puts("[eth] MAC_CR readback wrong: ");
+        board_uart_put_hex32(mac_cr);
+        board_uart_puts("\r\n");
+        return ERR_IF;
+    }
+
+    /* 8. Describe the interface to lwIP. */
+#if LWIP_NETIF_HOSTNAME
+    netif->hostname = "eds-doip";
+#endif
+    netif->name[0]     = 'e';
+    netif->name[1]     = 'n';
+    netif->output      = etharp_output;
+    netif->linkoutput  = lan9118_linkoutput;
+    netif->mtu         = 1500U;
+    netif->hwaddr_len  = ETH_HWADDR_LEN;
+    netif->flags       = NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP |
+                         NETIF_FLAG_LINK_UP | NETIF_FLAG_ETHERNET;
+
+    NETIF_INIT_SNMP(netif, snmp_ifType_ethernet_csmacd, 100000000UL);
+
+    return ERR_OK;
+}

--- a/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/lwip_port/ethernetif_lan9118.h
+++ b/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/lwip_port/ethernetif_lan9118.h
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Xaloqi
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: .../boards/qemu_cortex_m4/lwip_port/ethernetif_lan9118.h
+ *
+ * PURPOSE: lwIP netif driver for the SMSC LAN9118 Ethernet controller
+ *          emulated by QEMU's mps2-an386 machine.
+ *
+ * SAFETY  : Example driver — not safety-assessed.
+ * =============================================================================
+ */
+
+#ifndef EDS_ETHERNETIF_LAN9118_H
+#define EDS_ETHERNETIF_LAN9118_H
+
+#include "lwip/err.h"
+#include "lwip/netif.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * netif init callback — pass to netif_add().
+ *
+ * Resets the controller, verifies it is actually a LAN9118, programs the MAC
+ * address from @p netif->hwaddr and enables TX/RX.
+ *
+ * @return ERR_OK on success, ERR_IF if no LAN9118 responds at the expected
+ *         address.
+ */
+err_t lan9118_netif_init(struct netif *netif);
+
+/**
+ * Drain every complete frame currently in the RX FIFO into lwIP.
+ *
+ * Must be called from a task context (it calls netif->input, which posts to
+ * the tcpip mailbox). The driver is deliberately polled rather than
+ * interrupt-driven — see the .c file for why.
+ *
+ * @return number of frames handed to lwIP.
+ */
+uint32_t lan9118_poll(struct netif *netif);
+
+/** Chip ID/revision read during init, for boot logging. 0 if init failed. */
+uint32_t lan9118_id_rev(void);
+
+#endif /* EDS_ETHERNETIF_LAN9118_H */

--- a/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/lwip_port/lwipopts.h
+++ b/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/lwip_port/lwipopts.h
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Xaloqi
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/lwip_port/
+ *       lwipopts.h
+ *
+ * PURPOSE: lwIP configuration for the FreeRTOS + DoIP example on QEMU
+ *          mps2-an386.
+ *
+ *          Only used by the real-lwIP build (-DLWIP_DIR=/path/to/lwip). The
+ *          default build still compiles against ../lwip_stub and never sees
+ *          this file.
+ *
+ *          Sizing rationale: DoIP carries one diagnostic client over a single
+ *          TCP connection at a time (DOIP_MAX_CONNECTIONS), so the pools are
+ *          deliberately small. They are sized for the UDS worst case — a
+ *          0x36 TransferData block — not for throughput.
+ *
+ * SAFETY  : Example configuration — not safety-assessed.
+ * =============================================================================
+ */
+
+#ifndef EDS_LWIPOPTS_H
+#define EDS_LWIPOPTS_H
+
+/* ---------------------------------------------------------------------------
+ * OS mode
+ *
+ * NO_SYS = 0 is mandatory here, not a preference: transport/doip/
+ * freertos_lwip.c is written against the BSD socket API (lwip_socket,
+ * lwip_select, lwip_accept...), which only exists in the OS-ful build.
+ * ------------------------------------------------------------------------ */
+
+#define NO_SYS                          0
+#define SYS_LIGHTWEIGHT_PROT            1
+#define LWIP_TCPIP_CORE_LOCKING         1
+
+/* ---------------------------------------------------------------------------
+ * Memory
+ *
+ * MEM_LIBC_MALLOC = 0: lwIP uses its own static heap array rather than
+ * newlib's malloc. newlib's _sbrk under --specs=nosys.specs fails, and the
+ * project's allocation rules rule out a libc heap regardless.
+ * ------------------------------------------------------------------------ */
+
+#define MEM_LIBC_MALLOC                 0
+#define MEMP_MEM_MALLOC                 0
+#define MEM_ALIGNMENT                   4
+#define MEM_SIZE                        (24 * 1024)
+
+#define MEMP_NUM_PBUF                   16
+#define MEMP_NUM_RAW_PCB                0
+#define MEMP_NUM_UDP_PCB                4
+#define MEMP_NUM_TCP_PCB                6
+#define MEMP_NUM_TCP_PCB_LISTEN         2
+#define MEMP_NUM_TCP_SEG                16
+#define MEMP_NUM_NETBUF                 8
+#define MEMP_NUM_NETCONN                8
+#define MEMP_NUM_TCPIP_MSG_API          8
+#define MEMP_NUM_TCPIP_MSG_INPKT        16
+#define MEMP_NUM_SYS_TIMEOUT            8
+
+#define PBUF_POOL_SIZE                  16
+#define PBUF_POOL_BUFSIZE               1536   /* one full Ethernet frame */
+
+/* ---------------------------------------------------------------------------
+ * Protocols
+ * ------------------------------------------------------------------------ */
+
+#define LWIP_IPV4                       1
+#define LWIP_IPV6                       0
+#define LWIP_ARP                        1
+#define LWIP_ETHERNET                   1
+#define LWIP_ICMP                       1      /* ping = cheap liveness proof */
+#define LWIP_RAW                        0
+#define LWIP_UDP                        1      /* DoIP vehicle identification */
+#define LWIP_TCP                        1      /* DoIP diagnostic channel     */
+#define LWIP_DNS                        0
+#define LWIP_IGMP                       0
+
+/* Static addressing — see eds_net.c. QEMU's user-mode (slirp) network hands
+ * 10.0.2.15 to the guest and forwards -net user,hostfwd there, so DHCP would
+ * only ever hand back the address we already hard-code. Skipping it removes
+ * a multi-second, timing-dependent step from every CI run. */
+#define LWIP_DHCP                       0
+#define LWIP_AUTOIP                     0
+
+#define LWIP_TCP_KEEPALIVE              1
+
+/* ---------------------------------------------------------------------------
+ * TCP tuning
+ * ------------------------------------------------------------------------ */
+
+#define TCP_MSS                         1460
+#define TCP_SND_BUF                     (4 * TCP_MSS)
+#define TCP_SND_QUEUELEN                ((4 * TCP_SND_BUF) / TCP_MSS)
+#define TCP_WND                         (4 * TCP_MSS)
+
+/* ---------------------------------------------------------------------------
+ * API layers
+ * ------------------------------------------------------------------------ */
+
+#define LWIP_NETCONN                    1
+#define LWIP_SOCKET                     1
+#define LWIP_SOCKET_SELECT              1      /* freertos_lwip.c uses select */
+#define LWIP_SOCKET_POLL                0
+#define LWIP_COMPAT_SOCKETS             0      /* keep the lwip_* prefixes    */
+#define LWIP_POSIX_SOCKETS_IO_NAMES     0
+#define LWIP_NETIF_API                  0
+#define LWIP_SO_RCVTIMEO                1
+#define LWIP_SO_SNDTIMEO                1
+#define LWIP_TCP_KEEPALIVE              1
+
+/* lwIP declares `struct timeval` itself. newlib-nano's <sys/time.h> does not
+ * reliably provide it for this bare-metal multilib — with
+ * LWIP_TIMEVAL_PRIVATE = 0 the DoIP binding fails to compile with
+ * "storage size of 'tv' isn't known" at transport/doip/freertos_lwip.c:120.
+ * Nothing in this build includes <sys/time.h>, so there is no competing
+ * definition to collide with. */
+#define LWIP_TIMEVAL_PRIVATE            1
+#define LWIP_PROVIDE_ERRNO              0
+
+/* ---------------------------------------------------------------------------
+ * Threading
+ *
+ * TCPIP_THREAD_PRIO sits above the DoIP server task (priority 6) so inbound
+ * segments are processed promptly even while the DoIP task is runnable.
+ * FreeRTOSConfig.h caps priorities at configMAX_PRIORITIES = 8.
+ * ------------------------------------------------------------------------ */
+
+#define TCPIP_THREAD_NAME               "tcpip"
+#define TCPIP_THREAD_STACKSIZE          2048
+#define TCPIP_THREAD_PRIO               7
+#define TCPIP_MBOX_SIZE                 16
+#define DEFAULT_THREAD_STACKSIZE        1024
+#define DEFAULT_THREAD_PRIO             3
+#define DEFAULT_RAW_RECVMBOX_SIZE       8
+#define DEFAULT_UDP_RECVMBOX_SIZE       8
+#define DEFAULT_TCP_RECVMBOX_SIZE       8
+#define DEFAULT_ACCEPTMBOX_SIZE         8
+
+/* ---------------------------------------------------------------------------
+ * Callbacks / diagnostics
+ * ------------------------------------------------------------------------ */
+
+#define LWIP_NETIF_STATUS_CALLBACK      1
+#define LWIP_NETIF_LINK_CALLBACK        1
+#define LWIP_NETIF_HOSTNAME             1
+
+#define LWIP_STATS                      0
+#define LWIP_DEBUG                      0
+#define CHECKSUM_GEN_IP                 1
+#define CHECKSUM_GEN_TCP                1
+#define CHECKSUM_GEN_UDP                1
+#define CHECKSUM_CHECK_IP               1
+#define CHECKSUM_CHECK_TCP              1
+#define CHECKSUM_CHECK_UDP              1
+
+#endif /* EDS_LWIPOPTS_H */

--- a/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/lwip_port/sys_arch.c
+++ b/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/lwip_port/sys_arch.c
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Xaloqi
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: .../boards/qemu_cortex_m4/lwip_port/sys_arch.c
+ *
+ * PURPOSE: lwIP OS abstraction layer implemented on FreeRTOS primitives.
+ *
+ *          Implements the NO_SYS=0 contract from lwIP's sys.h: mutexes,
+ *          binary/counting semaphores, mailboxes, thread creation, a
+ *          millisecond clock, and the SYS_ARCH_PROTECT critical section.
+ *
+ *          Timeout semantics follow lwIP's contract exactly:
+ *            - timeout == 0 means "wait forever"
+ *            - a timed-out wait returns SYS_ARCH_TIMEOUT
+ *            - a successful wait returns elapsed milliseconds
+ *          Getting the timeout==0 case backwards is the classic failure mode
+ *          here: it turns every blocking lwIP wait into a busy spin.
+ *
+ * SAFETY  : Example port layer — not safety-assessed.
+ * STANDARD: No recursion. Allocation is FreeRTOS-pool only (heap_4's static
+ *           array), never libc malloc.
+ * =============================================================================
+ */
+
+#include "lwip/opt.h"
+#include "lwip/sys.h"
+#include "lwip/err.h"
+#include "lwip/stats.h"
+
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+#include "semphr.h"
+
+#include "board_uart.h"
+
+#include <stddef.h>
+
+/** Upper bound for counting semaphores handed to lwIP. lwIP never uses a
+ *  semaphore as a deep counter — this only has to exceed the number of
+ *  signals that can pile up before the waiter is scheduled. */
+#define EDS_LWIP_SEM_MAX_COUNT  (16U)
+
+/** Milliseconds per second, for tick <-> ms conversion. */
+#define EDS_MS_PER_SEC          (1000ULL)
+
+/* ---------------------------------------------------------------------------
+ * Init / time
+ * ------------------------------------------------------------------------ */
+
+void sys_init(void)
+{
+    /* Nothing to do: FreeRTOS is already initialised by the time lwIP starts
+     * (eds_net.c runs tcpip_init() from a task, after the scheduler). */
+}
+
+u32_t sys_now(void)
+{
+    return (u32_t)(((uint64_t)xTaskGetTickCount() * 1000ULL) /
+                   (uint64_t)configTICK_RATE_HZ);
+}
+
+u32_t sys_jiffies(void)
+{
+    return (u32_t)xTaskGetTickCount();
+}
+
+/* ---------------------------------------------------------------------------
+ * Critical section (SYS_LIGHTWEIGHT_PROT)
+ * ------------------------------------------------------------------------ */
+
+sys_prot_t sys_arch_protect(void)
+{
+    taskENTER_CRITICAL();
+    return (sys_prot_t)1;
+}
+
+void sys_arch_unprotect(sys_prot_t pval)
+{
+    (void)pval;
+    taskEXIT_CRITICAL();
+}
+
+/* ---------------------------------------------------------------------------
+ * Mutexes
+ * ------------------------------------------------------------------------ */
+
+err_t sys_mutex_new(sys_mutex_t *mutex)
+{
+    if (mutex == NULL) {
+        return ERR_ARG;
+    }
+    *mutex = xSemaphoreCreateMutex();
+    if (*mutex == NULL) {
+        return ERR_MEM;
+    }
+    return ERR_OK;
+}
+
+void sys_mutex_lock(sys_mutex_t *mutex)
+{
+    (void)xSemaphoreTake(*mutex, portMAX_DELAY);
+}
+
+void sys_mutex_unlock(sys_mutex_t *mutex)
+{
+    (void)xSemaphoreGive(*mutex);
+}
+
+void sys_mutex_free(sys_mutex_t *mutex)
+{
+    vSemaphoreDelete(*mutex);
+    *mutex = NULL;
+}
+
+int sys_mutex_valid(sys_mutex_t *mutex)
+{
+    return ((mutex != NULL) && (*mutex != NULL)) ? 1 : 0;
+}
+
+void sys_mutex_set_invalid(sys_mutex_t *mutex)
+{
+    if (mutex != NULL) {
+        *mutex = NULL;
+    }
+}
+
+/* ---------------------------------------------------------------------------
+ * Semaphores
+ * ------------------------------------------------------------------------ */
+
+err_t sys_sem_new(sys_sem_t *sem, u8_t count)
+{
+    if (sem == NULL) {
+        return ERR_ARG;
+    }
+
+    /* Counting, not binary: lwIP's sem usage relies on a signal given before
+     * a matching wait being remembered. xSemaphoreCreateCounting takes
+     * (maxCount, initialCount) in that order — passing the initial count as
+     * the maximum caps the semaphore at 0 and deadlocks every waiter. */
+    *sem = xSemaphoreCreateCounting((UBaseType_t)EDS_LWIP_SEM_MAX_COUNT,
+                                    (UBaseType_t)count);
+    if (*sem == NULL) {
+        return ERR_MEM;
+    }
+    return ERR_OK;
+}
+
+void sys_sem_signal(sys_sem_t *sem)
+{
+    (void)xSemaphoreGive(*sem);
+}
+
+u32_t sys_arch_sem_wait(sys_sem_t *sem, u32_t timeout)
+{
+    TickType_t started = xTaskGetTickCount();
+
+    if (timeout == 0U) {
+        /* lwIP contract: 0 means block indefinitely. */
+        (void)xSemaphoreTake(*sem, portMAX_DELAY);
+    } else {
+        if (xSemaphoreTake(*sem, pdMS_TO_TICKS(timeout)) != pdTRUE) {
+            return SYS_ARCH_TIMEOUT;
+        }
+    }
+
+    return (u32_t)(((uint64_t)(xTaskGetTickCount() - started) * 1000ULL) /
+                   (uint64_t)configTICK_RATE_HZ);
+}
+
+void sys_sem_free(sys_sem_t *sem)
+{
+    vSemaphoreDelete(*sem);
+    *sem = NULL;
+}
+
+int sys_sem_valid(sys_sem_t *sem)
+{
+    return ((sem != NULL) && (*sem != NULL)) ? 1 : 0;
+}
+
+void sys_sem_set_invalid(sys_sem_t *sem)
+{
+    if (sem != NULL) {
+        *sem = NULL;
+    }
+}
+
+/* ---------------------------------------------------------------------------
+ * Mailboxes
+ * ------------------------------------------------------------------------ */
+
+err_t sys_mbox_new(sys_mbox_t *mbox, int size)
+{
+    if (mbox == NULL) {
+        return ERR_ARG;
+    }
+    *mbox = xQueueCreate((UBaseType_t)size, (UBaseType_t)sizeof(void *));
+    if (*mbox == NULL) {
+        return ERR_MEM;
+    }
+    return ERR_OK;
+}
+
+void sys_mbox_post(sys_mbox_t *mbox, void *msg)
+{
+    (void)xQueueSendToBack(*mbox, &msg, portMAX_DELAY);
+}
+
+err_t sys_mbox_trypost(sys_mbox_t *mbox, void *msg)
+{
+    if (xQueueSendToBack(*mbox, &msg, (TickType_t)0) != pdTRUE) {
+        return ERR_MEM;
+    }
+    return ERR_OK;
+}
+
+err_t sys_mbox_trypost_fromisr(sys_mbox_t *mbox, void *msg)
+{
+    BaseType_t higher_woken = pdFALSE;
+
+    if (xQueueSendToBackFromISR(*mbox, &msg, &higher_woken) != pdTRUE) {
+        return ERR_MEM;
+    }
+
+    /* lwIP 2.2.1 has no ERR_NEED_SCHED, so the "a higher-priority task was
+     * woken" signal cannot be returned to the caller — request the context
+     * switch here instead. Unused in practice: this driver is polled and
+     * never posts from an ISR (see ethernetif_lan9118.c). */
+    portYIELD_FROM_ISR(higher_woken);
+    return ERR_OK;
+}
+
+u32_t sys_arch_mbox_fetch(sys_mbox_t *mbox, void **msg, u32_t timeout)
+{
+    TickType_t started = xTaskGetTickCount();
+    void      *received = NULL;
+
+    if (timeout == 0U) {
+        (void)xQueueReceive(*mbox, &received, portMAX_DELAY);
+    } else {
+        if (xQueueReceive(*mbox, &received, pdMS_TO_TICKS(timeout)) != pdTRUE) {
+            if (msg != NULL) {
+                *msg = NULL;
+            }
+            return SYS_ARCH_TIMEOUT;
+        }
+    }
+
+    if (msg != NULL) {
+        *msg = received;
+    }
+
+    return (u32_t)(((uint64_t)(xTaskGetTickCount() - started) * 1000ULL) /
+                   (uint64_t)configTICK_RATE_HZ);
+}
+
+u32_t sys_arch_mbox_tryfetch(sys_mbox_t *mbox, void **msg)
+{
+    void *received = NULL;
+
+    if (xQueueReceive(*mbox, &received, (TickType_t)0) != pdTRUE) {
+        if (msg != NULL) {
+            *msg = NULL;
+        }
+        return SYS_MBOX_EMPTY;
+    }
+
+    if (msg != NULL) {
+        *msg = received;
+    }
+    return 0U;
+}
+
+void sys_mbox_free(sys_mbox_t *mbox)
+{
+    vQueueDelete(*mbox);
+    *mbox = NULL;
+}
+
+int sys_mbox_valid(sys_mbox_t *mbox)
+{
+    return ((mbox != NULL) && (*mbox != NULL)) ? 1 : 0;
+}
+
+void sys_mbox_set_invalid(sys_mbox_t *mbox)
+{
+    if (mbox != NULL) {
+        *mbox = NULL;
+    }
+}
+
+/* ---------------------------------------------------------------------------
+ * Threads
+ * ------------------------------------------------------------------------ */
+
+sys_thread_t sys_thread_new(const char *name, lwip_thread_fn thread,
+                            void *arg, int stacksize, int prio)
+{
+    TaskHandle_t handle = NULL;
+
+    /* lwIP passes stacksize in bytes; FreeRTOS wants words. */
+    BaseType_t rc = xTaskCreate(
+        thread,
+        name,
+        (configSTACK_DEPTH_TYPE)((uint32_t)stacksize / sizeof(StackType_t)),
+        arg,
+        (UBaseType_t)prio,
+        &handle);
+
+    if (rc != pdPASS) {
+        return NULL;
+    }
+    return handle;
+}
+
+/* ---------------------------------------------------------------------------
+ * Diagnostics hooks referenced by arch/cc.h
+ * ------------------------------------------------------------------------ */
+
+void eds_lwip_platform_diag(const char *msg)
+{
+    board_uart_puts("[lwip] ");
+    board_uart_puts(msg);
+    board_uart_puts("\r\n");
+}
+
+void eds_lwip_platform_assert(const char *msg, const char *file, int line)
+{
+    (void)file;
+    board_uart_puts("[lwip] ASSERT: ");
+    board_uart_puts(msg);
+    board_uart_puts(" line ");
+    board_uart_put_u32((uint32_t)line);
+    board_uart_puts("\r\n");
+
+    taskDISABLE_INTERRUPTS();
+    for (;;) {
+        /* Halt: the stack is in an undefined state. */
+    }
+}

--- a/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/startup.c
+++ b/examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/startup.c
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Xaloqi
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: examples/basic_ecu_doip_freertos/boards/qemu_cortex_m4/startup.c
+ *
+ * PURPOSE: ARMv7-M reset vector and C runtime startup for QEMU mps2-an386.
+ *
+ *          Before this file existed the example had no vector table and no
+ *          Reset_Handler at all: the linker emitted
+ *            "cannot find entry symbol Reset_Handler; defaulting to 00000000"
+ *          and, because nothing anchored a root for --gc-sections, the whole
+ *          program was garbage-collected. The resulting ELF had .text size 0
+ *          — an empty binary that could never boot. See EDS issue for the
+ *          identical gap still present in basic_ecu_freertos.
+ *
+ *          Responsibilities, in order:
+ *            1. Publish the ARMv7-M vector table at address 0 (.isr_vector),
+ *               with the initial stack pointer and reset vector QEMU reads
+ *               from offsets 0x0 and 0x4 at machine reset.
+ *            2. Copy .data from its FLASH load address into SRAM.
+ *            3. Zero .bss.
+ *            4. Call main().
+ *
+ *          The SVC / PendSV / SysTick slots are wired directly to the
+ *          FreeRTOS ARM_CM4F port entry points (vPortSVCHandler,
+ *          xPortPendSVHandler, xPortSysTickHandler). Without these three the
+ *          scheduler starts but never context-switches.
+ *
+ * TARGET : QEMU mps2-an386 (ARM Cortex-M4F). num-irq = 32 on this machine
+ *          (hw/arm/mps2.c), so the table carries 32 external IRQ slots.
+ *
+ * SAFETY  : Example startup code — not safety-assessed.
+ * STANDARD: MISRA C:2012 alignment intended. No malloc, no recursion.
+ * =============================================================================
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* ---------------------------------------------------------------------------
+ * Symbols provided by linker.ld
+ * ------------------------------------------------------------------------ */
+
+extern uint32_t _sidata;      /**< .data load address in FLASH            */
+extern uint32_t _sdata;       /**< .data start in SRAM                    */
+extern uint32_t _edata;       /**< .data end in SRAM                      */
+extern uint32_t _sbss;        /**< .bss start                             */
+extern uint32_t _ebss;        /**< .bss end                               */
+extern uint32_t _stack_end;   /**< top of the initial (MSP) stack         */
+
+/* ---------------------------------------------------------------------------
+ * FreeRTOS ARM_CM4F port handlers
+ * ------------------------------------------------------------------------ */
+
+extern void vPortSVCHandler(void);
+extern void xPortPendSVHandler(void);
+extern void xPortSysTickHandler(void);
+
+extern int main(void);
+
+void Reset_Handler(void);
+
+/* ---------------------------------------------------------------------------
+ * Default handlers
+ *
+ * Each spins rather than returning: on a Cortex-M an unexpected fault that
+ * returns simply re-faults forever and hides the original cause. A halted
+ * CPU is observable in QEMU (-d int, or the monitor) whereas a fault loop
+ * that keeps re-entering is not.
+ * ------------------------------------------------------------------------ */
+
+static void Default_Handler(void)
+{
+    for (;;) {
+        /* Intentionally empty: halt on unexpected exception. */
+    }
+}
+
+void NMI_Handler(void)        __attribute__((weak, alias("Default_Handler")));
+void HardFault_Handler(void)  __attribute__((weak, alias("Default_Handler")));
+void MemManage_Handler(void)  __attribute__((weak, alias("Default_Handler")));
+void BusFault_Handler(void)   __attribute__((weak, alias("Default_Handler")));
+void UsageFault_Handler(void) __attribute__((weak, alias("Default_Handler")));
+void DebugMon_Handler(void)   __attribute__((weak, alias("Default_Handler")));
+void IRQ_Default_Handler(void) __attribute__((weak, alias("Default_Handler")));
+
+/* ---------------------------------------------------------------------------
+ * Vector table
+ *
+ * KEEP(*(.isr_vector)) in linker.ld anchors this array, which in turn
+ * references Reset_Handler -> main() -> the rest of the program. This is what
+ * stops --gc-sections from discarding the entire image.
+ * ------------------------------------------------------------------------ */
+
+typedef void (*isr_fn_t)(void);
+
+/*
+ * Vector-table entries are a union rather than a bare function pointer.
+ *
+ * Slot 0 is not a handler at all — it is the initial MSP value the core
+ * loads at reset. Storing it as a function pointer would require converting
+ * an object pointer to a function pointer, which ISO C forbids and MISRA
+ * C:2012 Rule 1.1 flags (confirmed by misra_analysis.py: "ISO C forbids
+ * conversion of object pointer to function pointer type"). The union
+ * expresses the two genuinely different kinds of entry directly, so no
+ * deviation record is needed.
+ */
+typedef union {
+    isr_fn_t  handler;   /**< slots 1..N: exception/IRQ handler   */
+    uintptr_t value;     /**< slot 0: initial stack pointer value */
+} isr_entry_t;
+
+/* 16 ARMv7-M system vectors + 32 external IRQs (mps2-an386 num-irq = 32). */
+#define MPS2_AN386_NUM_IRQ  (32U)
+
+const isr_entry_t g_isr_vector[16U + MPS2_AN386_NUM_IRQ]
+    __attribute__((section(".isr_vector"), used)) = {
+    { .value = (uintptr_t)&_stack_end },   /*  0: Initial MSP value */
+    { .handler = Reset_Handler       },  /*  1: Reset               */
+    { .handler = NMI_Handler         },  /*  2: NMI                 */
+    { .handler = HardFault_Handler   },  /*  3: HardFault           */
+    { .handler = MemManage_Handler   },  /*  4: MemManage           */
+    { .handler = BusFault_Handler    },  /*  5: BusFault            */
+    { .handler = UsageFault_Handler  },  /*  6: UsageFault          */
+    { .value   = 0U                  },  /*  7: Reserved            */
+    { .value   = 0U                  },  /*  8: Reserved            */
+    { .value   = 0U                  },  /*  9: Reserved            */
+    { .value   = 0U                  },  /* 10: Reserved            */
+    { .handler = vPortSVCHandler     },  /* 11: SVCall  — FreeRTOS  */
+    { .handler = DebugMon_Handler    },  /* 12: DebugMon            */
+    { .value   = 0U                  },  /* 13: Reserved            */
+    { .handler = xPortPendSVHandler  },  /* 14: PendSV  — FreeRTOS  */
+    { .handler = xPortSysTickHandler },  /* 15: SysTick — FreeRTOS  */
+
+    /* External interrupts 0..31. The LAN9118 Ethernet controller is IRQ 13
+     * on this machine, but the ethernetif driver polls its RX FIFO from a
+     * FreeRTOS task rather than taking interrupts, so no slot is wired. */
+    { .handler = IRQ_Default_Handler }, { .handler = IRQ_Default_Handler },
+    { .handler = IRQ_Default_Handler }, { .handler = IRQ_Default_Handler },
+    { .handler = IRQ_Default_Handler }, { .handler = IRQ_Default_Handler },
+    { .handler = IRQ_Default_Handler }, { .handler = IRQ_Default_Handler },
+    { .handler = IRQ_Default_Handler }, { .handler = IRQ_Default_Handler },
+    { .handler = IRQ_Default_Handler }, { .handler = IRQ_Default_Handler },
+    { .handler = IRQ_Default_Handler }, { .handler = IRQ_Default_Handler },
+    { .handler = IRQ_Default_Handler }, { .handler = IRQ_Default_Handler },
+    { .handler = IRQ_Default_Handler }, { .handler = IRQ_Default_Handler },
+    { .handler = IRQ_Default_Handler }, { .handler = IRQ_Default_Handler },
+    { .handler = IRQ_Default_Handler }, { .handler = IRQ_Default_Handler },
+    { .handler = IRQ_Default_Handler }, { .handler = IRQ_Default_Handler },
+    { .handler = IRQ_Default_Handler }, { .handler = IRQ_Default_Handler },
+    { .handler = IRQ_Default_Handler }, { .handler = IRQ_Default_Handler },
+    { .handler = IRQ_Default_Handler }, { .handler = IRQ_Default_Handler },
+    { .handler = IRQ_Default_Handler }, { .handler = IRQ_Default_Handler }
+};
+
+/* ---------------------------------------------------------------------------
+ * Reset_Handler
+ * ------------------------------------------------------------------------ */
+
+void Reset_Handler(void)
+{
+    uint32_t       *dst = &_sdata;
+    const uint32_t *src = &_sidata;
+
+    /* 1. Copy initialised data from FLASH to SRAM. */
+    while (dst < &_edata) {
+        *dst = *src;
+        dst++;
+        src++;
+    }
+
+    /* 2. Zero the BSS. */
+    dst = &_sbss;
+    while (dst < &_ebss) {
+        *dst = 0U;
+        dst++;
+    }
+
+    /* 3. Enter the application. main() does not return; the loop below is a
+     *    belt-and-braces guard only. */
+    (void)main();
+
+    for (;;) {
+        /* Intentionally empty. */
+    }
+}

--- a/examples/basic_ecu_doip_freertos/src/eds_net.c
+++ b/examples/basic_ecu_doip_freertos/src/eds_net.c
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Xaloqi
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: examples/basic_ecu_doip_freertos/src/eds_net.c
+ *
+ * PURPOSE: Bring up lwIP over the QEMU mps2-an386 LAN9118 MAC, so the DoIP
+ *          server task has a real TCP/IP stack to listen on.
+ *
+ *          ADDRESSING. QEMU's user-mode ("slirp") network is fixed:
+ *            guest    10.0.2.15
+ *            gateway  10.0.2.2
+ *            netmask  255.255.255.0
+ *          and `-net user,hostfwd=tcp::13400-:13400` forwards the host port
+ *          to 10.0.2.15:13400 unless told otherwise. The address is therefore
+ *          configured statically — DHCP would negotiate for several seconds
+ *          only to hand back the value already hard-coded here, and would add
+ *          a timing-dependent step to every CI run.
+ *
+ *          TASK STRUCTURE.
+ *            eds_net_start()  — called from main() before the scheduler;
+ *                               only creates the bring-up task.
+ *            net_setup_task   — runs tcpip_init(), adds the netif, brings it
+ *                               up, then becomes the RX poll loop.
+ *
+ *          The setup task deletes nothing and never returns: after
+ *          initialisation it *is* the RX poll task, which avoids a second
+ *          task control block and a second stack.
+ *
+ * SAFETY  : Example application code — not safety-assessed.
+ * STANDARD: No recursion. Static netif storage, no malloc.
+ * =============================================================================
+ */
+
+#include "eds_net.h"
+#include "board_uart.h"
+#include "ethernetif_lan9118.h"
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+#include "lwip/opt.h"
+#include "lwip/tcpip.h"
+#include "lwip/netif.h"
+#include "lwip/ip4_addr.h"
+#include "lwip/init.h"
+#include "netif/ethernet.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* ---------------------------------------------------------------------------
+ * Configuration
+ * ------------------------------------------------------------------------ */
+
+/* QEMU slirp fixed addressing — see file header. */
+#define EDS_NET_IP_0        (10U)
+#define EDS_NET_IP_1        (0U)
+#define EDS_NET_IP_2        (2U)
+#define EDS_NET_IP_3        (15U)
+
+#define EDS_NET_GW_3        (2U)
+
+#define EDS_NET_MASK_0      (255U)
+#define EDS_NET_MASK_1      (255U)
+#define EDS_NET_MASK_2      (255U)
+#define EDS_NET_MASK_3      (0U)
+
+/* Locally administered MAC (bit 1 of the first octet set, multicast bit
+ * clear). slirp learns the guest address from ARP, so the exact value only
+ * needs to be stable and unicast. */
+#define EDS_NET_MAC_0       (0x02U)
+#define EDS_NET_MAC_1       (0x00U)
+#define EDS_NET_MAC_2       (0x00U)
+#define EDS_NET_MAC_3       (0xEDU)
+#define EDS_NET_MAC_4       (0x50U)
+#define EDS_NET_MAC_5       (0x01U)
+
+#define NET_TASK_STACK_WORDS  (1024U)
+/* Above the DoIP server task (6) and below tcpip (7): inbound frames must be
+ * lifted out of the FIFO promptly, but must not starve the stack thread that
+ * consumes them. */
+#define NET_TASK_PRIORITY     (6U)
+
+/** RX poll period. 1 tick = 1 ms at configTICK_RATE_HZ = 1000. */
+#define NET_POLL_PERIOD_TICKS (1U)
+
+/* ---------------------------------------------------------------------------
+ * Module state
+ * ------------------------------------------------------------------------ */
+
+static struct netif   s_netif;
+static volatile bool  s_net_ready = false;
+
+/* ---------------------------------------------------------------------------
+ * Helpers
+ * ------------------------------------------------------------------------ */
+
+static void net_log_ipv4(const char *label, const ip4_addr_t *addr)
+{
+    uint32_t host_order = lwip_ntohl(ip4_addr_get_u32(addr));
+
+    board_uart_puts(label);
+    board_uart_put_u32((host_order >> 24U) & 0xFFU);
+    board_uart_puts(".");
+    board_uart_put_u32((host_order >> 16U) & 0xFFU);
+    board_uart_puts(".");
+    board_uart_put_u32((host_order >> 8U) & 0xFFU);
+    board_uart_puts(".");
+    board_uart_put_u32(host_order & 0xFFU);
+    board_uart_puts("\r\n");
+}
+
+static void net_setup_task(void *pvParameters)
+{
+    ip4_addr_t ipaddr;
+    ip4_addr_t netmask;
+    ip4_addr_t gateway;
+
+    (void)pvParameters;
+
+    board_uart_puts("[net] tcpip_init...\r\n");
+
+    /* Blocks until lwIP's own thread is running — legal here (scheduler is
+     * up), fatal if it had been called from main(). */
+    tcpip_init(NULL, NULL);
+
+    board_uart_puts("[net] tcpip up, lwip ");
+    board_uart_puts(LWIP_VERSION_STRING);
+    board_uart_puts("\r\n");
+
+    IP4_ADDR(&ipaddr,  EDS_NET_IP_0,   EDS_NET_IP_1,   EDS_NET_IP_2,   EDS_NET_IP_3);
+    IP4_ADDR(&gateway, EDS_NET_IP_0,   EDS_NET_IP_1,   EDS_NET_IP_2,   EDS_NET_GW_3);
+    IP4_ADDR(&netmask, EDS_NET_MASK_0, EDS_NET_MASK_1, EDS_NET_MASK_2, EDS_NET_MASK_3);
+
+    s_netif.hwaddr[0] = EDS_NET_MAC_0;
+    s_netif.hwaddr[1] = EDS_NET_MAC_1;
+    s_netif.hwaddr[2] = EDS_NET_MAC_2;
+    s_netif.hwaddr[3] = EDS_NET_MAC_3;
+    s_netif.hwaddr[4] = EDS_NET_MAC_4;
+    s_netif.hwaddr[5] = EDS_NET_MAC_5;
+
+    /* tcpip_input (not ethernet_input): the RX poll loop below runs on this
+     * task, not on lwIP's thread, so frames must be handed over through the
+     * tcpip mailbox rather than processed in place. */
+    if (netif_add(&s_netif, &ipaddr, &netmask, &gateway, NULL,
+                  lan9118_netif_init, tcpip_input) == NULL) {
+        board_uart_puts("[net] FATAL: netif_add failed (no LAN9118?)\r\n");
+        for (;;) {
+            vTaskDelay(pdMS_TO_TICKS(1000U));
+        }
+    }
+
+    netif_set_default(&s_netif);
+    netif_set_up(&s_netif);
+    netif_set_link_up(&s_netif);
+
+    board_uart_puts("[net] mac  02:00:00:ed:50:01\r\n");
+    board_uart_puts("[net] chip id_rev ");
+    board_uart_put_hex32(lan9118_id_rev());
+    board_uart_puts("\r\n");
+    net_log_ipv4("[net] ip   ", &ipaddr);
+    net_log_ipv4("[net] mask ", &netmask);
+    net_log_ipv4("[net] gw   ", &gateway);
+
+    s_net_ready = true;
+    board_uart_puts("[net] netif up — DoIP reachable on port 13400\r\n");
+
+    /* Become the RX poll loop. */
+    for (;;) {
+        (void)lan9118_poll(&s_netif);
+        vTaskDelay((TickType_t)NET_POLL_PERIOD_TICKS);
+    }
+}
+
+/* ---------------------------------------------------------------------------
+ * Public API
+ * ------------------------------------------------------------------------ */
+
+void eds_net_start(void)
+{
+    (void)xTaskCreate(
+        net_setup_task,
+        "net",
+        (configSTACK_DEPTH_TYPE)NET_TASK_STACK_WORDS,
+        NULL,
+        (UBaseType_t)NET_TASK_PRIORITY,
+        NULL);
+}
+
+bool eds_net_is_ready(void)
+{
+    return s_net_ready;
+}

--- a/examples/basic_ecu_doip_freertos/src/eds_net.h
+++ b/examples/basic_ecu_doip_freertos/src/eds_net.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Xaloqi
+/*
+ * =============================================================================
+ * Xaloqi EDS
+ * FILE: examples/basic_ecu_doip_freertos/src/eds_net.h
+ *
+ * PURPOSE: IP stack bring-up for the FreeRTOS + DoIP example on QEMU.
+ *
+ *          Only compiled in the real-lwIP build (-DLWIP_DIR=...).
+ *
+ * SAFETY  : Example application code — not safety-assessed.
+ * =============================================================================
+ */
+
+#ifndef EDS_NET_H
+#define EDS_NET_H
+
+#include <stdbool.h>
+
+/**
+ * Create the network bring-up task.
+ *
+ * Only creates the task; it must not do the work inline. lwIP's tcpip_init()
+ * blocks on a semaphore until its own thread signals back, which cannot
+ * happen before vTaskStartScheduler(). Called from main() before the
+ * scheduler starts.
+ */
+void eds_net_start(void);
+
+/** True once the netif is up and sockets can be opened. */
+bool eds_net_is_ready(void);
+
+#endif /* EDS_NET_H */

--- a/examples/basic_ecu_doip_freertos/src/main.c
+++ b/examples/basic_ecu_doip_freertos/src/main.c
@@ -58,6 +58,12 @@
 #include "platform_doip.h"
 #include "doip_server.h"
 
+/* Board support (QEMU mps2-an386) */
+#include "board_uart.h"
+#if defined(EDS_LWIP_REAL) && (EDS_LWIP_REAL == 1)
+#include "eds_net.h"
+#endif
+
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -190,6 +196,15 @@ int main(void)
     uds_server_ctx_t *srv = NULL;
 
     /*
+     * Step 0a: Board bring-up. UART first, so every later step has somewhere
+     * to report to. These lines are the CI leg's boot evidence — see
+     * compat-tests COVERAGE.md.
+     */
+    board_uart_init();
+    board_uart_puts("\r\n[eds] basic_ecu_doip_freertos boot\r\n");
+    board_uart_puts("[eds] board=qemu mps2-an386 cortex-m4f\r\n");
+
+    /*
      * Step 0: Security algorithm placeholder.
      * Inject TRNG callback and OEM keys before production.
      */
@@ -207,9 +222,10 @@ int main(void)
         .uds_task_priority   = 0U,
     });
     if (status != UDS_STATUS_OK) {
-        /* Platform init failure is fatal — no logging available yet */
-        for (;;) { vTaskDelay(pdMS_TO_TICKS(1000U)); }
+        board_uart_puts("[eds] FATAL: eds_platform_init failed\r\n");
+        for (;;) { }
     }
+    board_uart_puts("[eds] platform init ok\r\n");
 
     /*
      * Step 2: UDS stack init.
@@ -219,13 +235,16 @@ int main(void)
      */
     status = uds_generated_init(NULL, 0U, 0U);
     if (status != UDS_STATUS_OK) {
-        for (;;) { vTaskDelay(pdMS_TO_TICKS(1000U)); }
+        board_uart_puts("[eds] FATAL: uds_generated_init failed\r\n");
+        for (;;) { }
     }
 
     srv = uds_generated_get_server();
     if (srv == NULL) {
-        for (;;) { vTaskDelay(pdMS_TO_TICKS(1000U)); }
+        board_uart_puts("[eds] FATAL: uds_generated_get_server returned NULL\r\n");
+        for (;;) { }
     }
+    board_uart_puts("[eds] uds stack init ok\r\n");
 
     (void)uds_periodic_init();
     (void)uds_session_register_change_cb(srv->cfg.session_ctx,
@@ -248,13 +267,27 @@ int main(void)
     );
 
     /*
+     * Step 2.75: Bring up the IP stack.
+     *
+     * Only present in the real-lwIP build (-DLWIP_DIR=...). The default
+     * build compiles against boards/qemu_cortex_m4/lwip_stub, whose socket
+     * calls all return -1 by design, and has no netif to bring up.
+     *
+     * eds_net_start() only *creates* the bring-up task; lwIP's own
+     * tcpip_init() waits on a semaphore for its thread to come up, which
+     * would deadlock if it ran here, before vTaskStartScheduler(). So the
+     * real work happens in that task once the scheduler is running. The
+     * DoIP server task's existing 500 ms delay covers the ordering.
+     */
+#if defined(EDS_LWIP_REAL) && (EDS_LWIP_REAL == 1)
+    eds_net_start();
+#endif
+
+    /*
      * Step 3: Start DoIP server task.
      * The task is created here but blocks in vTaskDelay(500ms) before
      * calling lwip_listen — giving LwIP time to come up after the
      * scheduler starts.
-     *
-     * For production: call lwip_netif_add() / lwip_dhcp_start() before
-     * this point so the netif is ready when the DoIP task unblocks.
      */
     status = eds_doip_platform_start_freertos(
         DOIP_ECU_LOGICAL_ADDR,
@@ -264,8 +297,10 @@ int main(void)
         DOIP_TASK_PRIORITY
     );
     if (status != UDS_STATUS_OK) {
-        for (;;) { vTaskDelay(pdMS_TO_TICKS(1000U)); }
+        board_uart_puts("[eds] FATAL: doip platform start failed\r\n");
+        for (;;) { }
     }
+    board_uart_puts("[eds] doip task created, starting scheduler\r\n");
 
     /*
      * Step 4: Hand control to the FreeRTOS scheduler.

--- a/platform/freertos/freertos_platform_api.c
+++ b/platform/freertos/freertos_platform_api.c
@@ -215,6 +215,7 @@ uds_status_t eds_platform_init(const eds_platform_cfg_t *cfg)
         return UDS_STATUS_ERR_NULL_PTR;
     }
 
+#if !defined(EDS_DOIP_ONLY_BUILD) || (EDS_DOIP_ONLY_BUILD != 1)
     if (cfg->can_send == NULL) {
         /*
          * can_send is required. Without it the UDS stack cannot transmit
@@ -222,6 +223,14 @@ uds_status_t eds_platform_init(const eds_platform_cfg_t *cfg)
          */
         return UDS_STATUS_ERR_INVALID_PARAM;
     }
+#endif
+    /*
+     * EDS_DOIP_ONLY_BUILD: responses leave over DoIP/TCP, not CAN, so
+     * can_send is legitimately NULL and the check above must not run.
+     * examples/basic_ecu_doip_freertos passes .can_send = NULL deliberately
+     * (see its main.c step 1) — against the unguarded check that example
+     * could never get past eds_platform_init() at all.
+     */
 
     if (s_initialized) {
         return UDS_STATUS_ERR_ALREADY_INITIALIZED;
@@ -242,8 +251,14 @@ uds_status_t eds_platform_init(const eds_platform_cfg_t *cfg)
     /*
      * Initialise the CAN shim. This wires s_can_send into the
      * can_transport_ops_t vtable used by the ISO-TP layer.
+     *
+     * Skipped for EDS_DOIP_ONLY_BUILD, which does not compile
+     * platform/freertos/freertos_can.c at all — calling it there is an
+     * undefined reference at link time, not merely dead code.
      */
+#if !defined(EDS_DOIP_ONLY_BUILD) || (EDS_DOIP_ONLY_BUILD != 1)
     freertos_can_init(cfg->can_send);
+#endif
 
     /*
      * Initialise NVM.


### PR DESCRIPTION
## Summary

Makes `examples/basic_ecu_doip_freertos` actually serve DoIP over an emulated
Ethernet MAC in QEMU, instead of compiling against a socket stub whose every
call returns `-1`.

Unblocks Xaloqi/xaloqi-compatibility-tests#7.

## The stub was not the blocker — it was the fifth one

compat-tests#7 describes this leg as blocked on the lwIP stub. Building the
example exactly as compat-tests CI does surfaced something more basic first:

```
ld: warning: cannot find entry symbol Reset_Handler; defaulting to 00000000
$ arm-none-eabi-size eds_freertos_doip.elf
   text    data     bss     dec     hex
      0       0       0       0       0
```

Nothing in the repository defined a vector table or a `Reset_Handler`, so
`--gc-sections` had no root to trace from and discarded the entire program.
**The ELF was empty.** An empty binary links cleanly, which is exactly why a
compile-only CI leg has reported success for as long as it has existed.

Five independent blockers, fixed in the order they were hit:

| # | Blocker | Fix |
|---|---|---|
| 1 | No vector table / `Reset_Handler`; whole image garbage-collected | `boards/qemu_cortex_m4/startup.c` |
| 2 | `EDS_PLATFORM_FREERTOS` never defined → `freertos_nvm.c` compiled to an empty TU, `nvm_store_*` undefined | added to `target_compile_definitions` |
| 3 | `eds_platform_init()` rejected `can_send == NULL`, which a DoIP-only build passes deliberately | guarded on `EDS_DOIP_ONLY_BUILD` |
| 4 | `-nostdlib` left `memcpy`/`memset`/`memcmp`/`strlen` unresolved | `-nostartfiles` + `nano.specs` |
| 5 | lwIP socket stub — the one #7 names | real lwIP + LAN9118 driver when `LWIP_DIR` is set |

Blockers 2–4 were invisible because blocker 1 was deleting every caller.

## Also worth knowing: the CI leg targets the wrong machine

`compat.yml` launches `-machine lm3s6965evb`, which is **Cortex-M3**, against a
binary built `-mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard` — and whose
own `linker.ld` and `FreeRTOSConfig.h` both already say `mps2-an386`. It also
loads `basic_ecu.elf`, a filename CMake has never emitted (`eds_freertos_doip.elf`).

The correct machine is **`mps2-an386`**: QEMU's Cortex-M4 MPS2 variant, which
emulates an SMSC **LAN9118** MAC at `0x40200000` and supports `-netdev user`
(slirp/hostfwd). That is the companion compat-tests PR's job, not this one's.

## What was added

All under `examples/basic_ecu_doip_freertos/`:

- `boards/qemu_cortex_m4/startup.c` — ARMv7-M vector table (FreeRTOS
  `vPortSVCHandler` / `xPortPendSVHandler` / `xPortSysTickHandler` wired),
  `.data` copy, `.bss` zeroing, `main()`. Vector entries are a **union**, not a
  function-pointer array, so slot 0 (the initial MSP value) needs no
  object-to-function-pointer conversion — that avoids MISRA C:2012 Rule 1.1
  rather than deviating from it.
- `boards/qemu_cortex_m4/lwip_port/ethernetif_lan9118.c` — polled lwIP netif
  driver for the LAN9118.
- `boards/qemu_cortex_m4/lwip_port/sys_arch.c`, `lwipopts.h`, `arch/` — lwIP
  `NO_SYS=0` OS abstraction on FreeRTOS.
- `src/eds_net.c` — netif bring-up + RX poll task, static addressing.
- `boards/qemu_cortex_m4/board_uart.c` — polled CMSDK UART0, so the CI leg can
  produce checkable boot evidence instead of inferring liveness from a connect.

Register semantics were taken from QEMU's own `hw/net/lan9118.c`, not the SMSC
datasheet, because QEMU implements a documented subset and QEMU is the only
target this driver runs on. Same for the UART (`hw/char/cmsdk-apb-uart.c`) and
the ethernet base address (`hw/arm/mps2.c`).

**Polled, not interrupt-driven.** At DoIP's traffic level (one diagnostic
client, strict request/response) polling costs nothing measurable and removes
the ISR / `FromISR` / `configMAX_SYSCALL_INTERRUPT_PRIORITY` class of bug.

## lwIP is fetched, not vendored

This repo has no `vendor/` or `third_party/` convention. Its actual convention
is *fetch upstream and point a `*_DIR` variable at it* — `FREERTOS_DIR` already
works this way, and `west.yml` does it for Zephyr. `LWIP_DIR` follows suit and
was already supported by this `CMakeLists.txt`; nobody had ever supplied it.
Pinned upstream: `STABLE-2_2_1_RELEASE`.

## No customer-facing regression

The default path (no `LWIP_DIR`) still compiles against
`boards/qemu_cortex_m4/lwip_stub`, unchanged. It now produces a real 21 KB
bootable image instead of an empty one — strictly better than before.

## Evidence — real traffic, not a successful compile

Boot log from the emulated machine:

```
[eds] basic_ecu_doip_freertos boot
[eds] board=qemu mps2-an386 cortex-m4f
[eds] platform init ok
[eds] uds stack init ok
[eds] doip task created, starting scheduler
[net] tcpip_init...
[net] tcpip up, lwip 2.2.1
[net] mac  02:00:00:ed:50:01
[net] chip id_rev 01180001
[net] ip   10.0.2.15
[net] mask 255.255.255.0
[net] gw   10.0.2.2
[net] netif up — DoIP reachable on port 13400
```

`chip id_rev 01180001` is read back from the emulated MAC — positive proof the
driver reached real hardware registers, not a hard-coded string.

The compat-tests `core_validation.yaml` campaign, unmodified, over real
DoIP/TCP through the host port-forward:

```
[01/08] tester_present                     → OK  (4 ms)
[02/08] session(extended)                  → OK  (4 ms)
[03/08] security_access(level=1)           → OK  (24 ms)   AES-128-CMAC seed/key
[04/08] read_did(0xF190)                   → OK  (4 ms)
[05/08] read_dtc                           → OK  (4 ms)
[06/08] clear_dtc                          → OK  (4 ms)
[07/08] read_dtc                           → OK  (4 ms)
[08/08] session(default)                   → OK  (4 ms)
Result: PASS — 8/8 steps, 52 ms
```

### Negative control

The identical campaign against the **stub** build fails:

```
TransportError: DoIP: Routing Activation Response timed out
```

which is exactly the current CI leg's failure mode. The fix is demonstrably
what makes the difference.

### A trap worth recording

**A bare TCP connect to the forwarded port succeeds even against the stub
build.** QEMU's slirp `hostfwd` accepts on the host side before it can know
whether a guest listener exists. Connect-success is not evidence of
reachability; only a completed DoIP exchange is. Anyone validating this leg by
`nc`-ing port 13400 would get a false green.

## Gates

- `bash build_tests.sh` — 45/45 suites, 923 cases, 0 failed
- `misra_analysis.py` over all new code — **0 open violations**, no deviations
  needed
- Default stub build and real-lwIP build both verified

## Note on `generated/`

Not touched. DID reads return zeros because `generated/did_handlers.c` uses
zero-initialised mock storage by design — the already-verified Zephyr
`basic_ecu_doip` example has the identical mock, and the campaign saves the VIN
without asserting its content, so both legs behave the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
