### PR TITLE
fix: give ISOTP_ENABLE_CAN_FD an explicit default, fix nested comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,20 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   `main`. One `git show origin/main:<path>` would have caught it at any
   point.
 
+- **Two pre-existing MISRA C:2012 Rule 20.9 findings in `platform/`** (#269),
+  found incidentally while running `misra_analysis.py` over #267's changed
+  code — not introduced by that PR. `platform/platform_api.h` used
+  `#if ISOTP_ENABLE_CAN_FD` without the macro being defined anywhere in the
+  include path for builds that don't set it, so the preprocessor silently
+  evaluated it to `0`. Rule 20.9 exists exactly to catch that: a typo in the
+  macro name would have looked identical. Now defaulted locally
+  (`#ifndef`/`#define ISOTP_ENABLE_CAN_FD 0`) next to its documentation,
+  matching the existing default in `transport/isotp.h`; any build already
+  passing `-DISOTP_ENABLE_CAN_FD=...` is unaffected. Also fixed a nested
+  `/*` inside a banner comment in `platform/freertos/freertos_rng_example.c`
+  (an `examples/*_freertos/...` glob whose `/*` read as a comment-start to
+  the compiler).
+
 
 ## [1.14.0] — 2026-09-07
 

--- a/platform/freertos/freertos_rng_example.c
+++ b/platform/freertos/freertos_rng_example.c
@@ -14,7 +14,7 @@
  *     your own application source tree and adapt it to your MCU's actual
  *     TRNG peripheral before use — the STM32 HAL calls below are a worked
  *     example, not a portable driver.
- *   - Every shipped FreeRTOS example (examples/*_freertos/src/main.c) passes
+ *   - Every shipped FreeRTOS example (examples/<name>_freertos/src/main.c) passes
  *     NULL to uds_security_algo_set_rng_cb() and logs a "no TRNG — CI/dev
  *     build" warning. That NULL is intentional for CI/simulation and is NOT
  *     something to leave in a production build — see docs/SECURITY_NOTICE.md.

--- a/platform/platform_api.h
+++ b/platform/platform_api.h
@@ -62,7 +62,16 @@ extern "C" {
  * Maximum payload bytes in eds_can_frame_t.
  * 8 for Classic CAN builds; 64 when ISOTP_ENABLE_CAN_FD=1.
  * Must agree with UDS_CAN_FRAME_MAX_LEN in uds_types.h (both = 64 for FD).
+ *
+ * Defaulted here (MISRA 20.9) rather than assuming transport/isotp.h's own
+ * default was already pulled in: this header must not depend on transport/
+ * to stay build-order-independent, and any build already passing
+ * -DISOTP_ENABLE_CAN_FD=... still wins over this default.
  */
+#ifndef ISOTP_ENABLE_CAN_FD
+#define ISOTP_ENABLE_CAN_FD 0
+#endif
+
 #if ISOTP_ENABLE_CAN_FD
 #define EDS_CAN_FRAME_MAX_DLEN  (64U)
 #else


### PR DESCRIPTION
Closes #269.

Two pre-existing MISRA C:2012 findings in `platform/`, found incidentally
while running `misra_analysis.py` over #267's changed code — not introduced
by that PR, filed separately per this repo's standing habit of tracking
pre-existing bugs rather than leaving them only in a PR description.

## Findings

| Rule | Category | File | Line |
|---|---|---|---|
| 20.9 | required | `platform/platform_api.h` | 66 |
| 20.9 | required | `platform/platform_api.h` | 77 |
| N/A | advisory | `platform/freertos/freertos_rng_example.c` | 17 |

**Rule 20.9** — `ISOTP_ENABLE_CAN_FD` was used in `#if` without being defined
anywhere in the include path for builds that don't set it, so the
preprocessor silently evaluated it to `0`. Exactly the failure mode Rule
20.9 exists to catch: a typo in the macro name would look identical. Fixed
by defaulting it locally, next to its documentation, matching the existing
default already in `transport/isotp.h` — not included directly, to avoid a
`platform/` → `transport/` dependency inversion. Any build already passing
`-DISOTP_ENABLE_CAN_FD=...` is unaffected.

**Advisory** — a nested `/*` inside a banner comment: the glob
`examples/*_freertos/src/main.c` contains a literal `/*` (`...s` + `/` +
`*_freertos...`) that reads as a comment-start to the compiler. Reworded to
`examples/<name>_freertos/src/main.c`.

## Verification

```
$ python3 misra_analysis.py --src-dirs platform/freertos --out /tmp/misra.json
Total findings   : 1
OPEN violations  : 1
```

The one remaining finding is the pre-existing, intentional `#error` at
`freertos_rng_example.c:113` ("no TRNG backend selected") — the issue said
to leave that alone.

`bash build_tests.sh`: 923 cases, 45/45 passed, 0 failed.

No behaviour change: both builds already evaluated `ISOTP_ENABLE_CAN_FD` to
`0` in practice via the undefined-macro-in-`#if` path; this just makes it
explicit and MISRA-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)