### PR TITLE
fix: reject stm32h7/stm32f4 BOARD options instead of silently linking unbootable images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,31 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`basic_ecu_freertos` and `sensor_ecu_freertos` advertised `-DBOARD=stm32h7`
+  and `-DBOARD=stm32f4` options that could never produce a working image**
+  (#272, found while fixing #268 — separate defect, deliberately not fixed
+  there). `stm32h7` pointed at a linker script that does not exist
+  (`boards/stm32h7/linker.ld`); the `if(EXISTS ...)` guard around the link
+  step then silently fell through to linking with no memory layout and no
+  vector table at all. `stm32f4` was worse: it shared `qemu_cortex_m4`'s
+  linker script, whose `FLASH` region starts at `0x00000000` — the real
+  STM32F4's internal flash starts at `0x08000000`, so an image linked this
+  way cannot run on the part. Neither was ever caught because, until #268,
+  no FreeRTOS example produced a non-empty binary at all, and only
+  `qemu_cortex_m4` is exercised in CI.
+
+  Rather than build out real board support for two parts nobody has asked
+  for, both now fail loudly at configure time with `FATAL_ERROR` — an
+  advertised board option that silently links an unbootable image is worse
+  than no option, which is #268's whole lesson applied one level up. The
+  generic `else()` fallback (unknown `BOARD` → `message(WARNING ...)` +
+  Cortex-M4 flags) is gone for the same reason. `-DBOARD=qemu_cortex_m4` is
+  unaffected and was rebuilt to confirm: `basic_ecu_freertos` still links to
+  the same `.text` 23236 B / `.data` 68 B / `.bss` 70244 B as #271 produced.
+
+  `safeboot_freertos_ecu` was not affected — both of its board options
+  already resolve to real directories.
+
 - **The three remaining FreeRTOS examples produced non-functional binaries**
   — `basic_ecu_freertos`, `sensor_ecu_freertos` and `safeboot_freertos_ecu`
   (both of its boards). Same defect as `basic_ecu_doip_freertos` below, still

--- a/examples/basic_ecu_freertos/CMakeLists.txt
+++ b/examples/basic_ecu_freertos/CMakeLists.txt
@@ -97,7 +97,7 @@ include(${DIAG_ROOT}/cmake/eds_build_mode.cmake)
 # (EDS issue #268).
 set(EDS_COMMON_BOARDS "${DIAG_ROOT}/examples/common/boards")
 
-if(BOARD STREQUAL "qemu_cortex_m4" OR BOARD STREQUAL "stm32f4")
+if(BOARD STREQUAL "qemu_cortex_m4")
     set(CPU_FLAGS
         -mcpu=cortex-m4
         -mthumb
@@ -105,25 +105,34 @@ if(BOARD STREQUAL "qemu_cortex_m4" OR BOARD STREQUAL "stm32f4")
         -mfloat-abi=hard
     )
     set(LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/boards/qemu_cortex_m4/linker.ld")
-    if(BOARD STREQUAL "qemu_cortex_m4")
-        set(BOARD_SRCS
-            ${EDS_COMMON_BOARDS}/qemu_cortex_m4/startup.c
-            ${EDS_COMMON_BOARDS}/qemu_cortex_m4/freertos_hooks.c
-            ${EDS_COMMON_BOARDS}/qemu_cortex_m4/board_log.c
-        )
-    endif()
-elseif(BOARD STREQUAL "stm32h7")
-    set(CPU_FLAGS
-        -mcpu=cortex-m7
-        -mthumb
-        -mfpu=fpv5-d16
-        -mfloat-abi=hard
+    set(BOARD_SRCS
+        ${EDS_COMMON_BOARDS}/qemu_cortex_m4/startup.c
+        ${EDS_COMMON_BOARDS}/qemu_cortex_m4/freertos_hooks.c
+        ${EDS_COMMON_BOARDS}/qemu_cortex_m4/board_log.c
     )
-    set(LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/boards/stm32h7/linker.ld")
+elseif(BOARD STREQUAL "stm32h7" OR BOARD STREQUAL "stm32f4")
+    # EDS#272: these used to "build" — stm32h7 pointed at a linker script that
+    # doesn't exist (silently falling through to no memory layout at all), and
+    # stm32f4 shared qemu_cortex_m4's script, whose FLASH origin (0x00000000)
+    # is wrong for a real STM32F4 (0x08000000). Neither ever produced a
+    # bootable image; nothing caught it because nothing ran these images
+    # before #268. Fail loudly instead of shipping an option that doesn't work.
+    message(FATAL_ERROR
+        "BOARD '${BOARD}' has no real board support in this example — it "
+        "previously built an unbootable image silently (missing vector "
+        "table, or the wrong flash origin) instead of failing (EDS#272). "
+        "Add boards/${BOARD}/{linker.ld,startup.c} with the correct memory "
+        "map and IRQ vector table for the real part first — see "
+        "examples/safeboot_freertos_ecu/boards/nucleo_h743zi/ for the "
+        "pattern this example doesn't yet have.")
 else()
-    message(WARNING "Unknown BOARD '${BOARD}' — using Cortex-M4 flags. "
-                    "Provide a toolchain file for custom boards.")
-    set(CPU_FLAGS -mcpu=cortex-m4 -mthumb)
+    message(FATAL_ERROR
+        "Unknown BOARD '${BOARD}'. Supported: qemu_cortex_m4. Add real "
+        "board support (linker script + startup.c, see "
+        "examples/safeboot_freertos_ecu/boards/nucleo_h743zi/ for the "
+        "pattern) before adding a new BOARD value here — see EDS#268/#272; "
+        "a build that silently falls back to generic Cortex-M4 flags with "
+        "no linker script is exactly the defect those fixed.")
 endif()
 
 # ---------------------------------------------------------------------------

--- a/examples/sensor_ecu_freertos/CMakeLists.txt
+++ b/examples/sensor_ecu_freertos/CMakeLists.txt
@@ -104,22 +104,37 @@ include(${DIAG_ROOT}/cmake/eds_build_mode.cmake)
 # (EDS issue #268).
 set(EDS_COMMON_BOARDS "${DIAG_ROOT}/examples/common/boards")
 
-if(BOARD STREQUAL "qemu_cortex_m4" OR BOARD STREQUAL "stm32f4")
+if(BOARD STREQUAL "qemu_cortex_m4")
     set(CPU_FLAGS -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=hard)
     set(LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/boards/qemu_cortex_m4/linker.ld")
-    if(BOARD STREQUAL "qemu_cortex_m4")
-        set(BOARD_SRCS
-            ${EDS_COMMON_BOARDS}/qemu_cortex_m4/startup.c
-            ${EDS_COMMON_BOARDS}/qemu_cortex_m4/freertos_hooks.c
-            ${EDS_COMMON_BOARDS}/qemu_cortex_m4/board_log.c
-        )
-    endif()
-elseif(BOARD STREQUAL "stm32h7")
-    set(CPU_FLAGS -mcpu=cortex-m7 -mthumb -mfpu=fpv5-d16 -mfloat-abi=hard)
-    set(LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/boards/stm32h7/linker.ld")
+    set(BOARD_SRCS
+        ${EDS_COMMON_BOARDS}/qemu_cortex_m4/startup.c
+        ${EDS_COMMON_BOARDS}/qemu_cortex_m4/freertos_hooks.c
+        ${EDS_COMMON_BOARDS}/qemu_cortex_m4/board_log.c
+    )
+elseif(BOARD STREQUAL "stm32h7" OR BOARD STREQUAL "stm32f4")
+    # EDS#272: these used to "build" — stm32h7 pointed at a linker script that
+    # doesn't exist (silently falling through to no memory layout at all), and
+    # stm32f4 shared qemu_cortex_m4's script, whose FLASH origin (0x00000000)
+    # is wrong for a real STM32F4 (0x08000000). Neither ever produced a
+    # bootable image; nothing caught it because nothing ran these images
+    # before #268. Fail loudly instead of shipping an option that doesn't work.
+    message(FATAL_ERROR
+        "BOARD '${BOARD}' has no real board support in this example — it "
+        "previously built an unbootable image silently (missing vector "
+        "table, or the wrong flash origin) instead of failing (EDS#272). "
+        "Add boards/${BOARD}/{linker.ld,startup.c} with the correct memory "
+        "map and IRQ vector table for the real part first — see "
+        "examples/safeboot_freertos_ecu/boards/nucleo_h743zi/ for the "
+        "pattern this example doesn't yet have.")
 else()
-    message(WARNING "Unknown BOARD '${BOARD}' — using Cortex-M4 flags.")
-    set(CPU_FLAGS -mcpu=cortex-m4 -mthumb)
+    message(FATAL_ERROR
+        "Unknown BOARD '${BOARD}'. Supported: qemu_cortex_m4. Add real "
+        "board support (linker script + startup.c, see "
+        "examples/safeboot_freertos_ecu/boards/nucleo_h743zi/ for the "
+        "pattern) before adding a new BOARD value here — see EDS#268/#272; "
+        "a build that silently falls back to generic Cortex-M4 flags with "
+        "no linker script is exactly the defect those fixed.")
 endif()
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #272.

Found while fixing #268, deliberately not fixed there — separate defect,
different fix shape.

## Problem

`basic_ecu_freertos` and `sensor_ecu_freertos` both advertised
`-DBOARD=stm32h7` and `-DBOARD=stm32f4` options that could never produce a
working image:

- **`stm32h7`** pointed at a linker script that doesn't exist
  (`boards/stm32h7/linker.ld`). The `if(EXISTS ...)` guard around the link
  step silently fell through to linking with no memory layout and no vector
  table at all.
- **`stm32f4`** shared `qemu_cortex_m4`'s linker script, whose `FLASH` region
  starts at `0x00000000` — the real STM32F4's internal flash starts at
  `0x08000000`, so an image linked this way cannot run on the part.

Neither was ever caught because, until #268/#271, no FreeRTOS example
produced a non-empty binary at all, and only `qemu_cortex_m4` is exercised in
CI.

## Fix

Both now fail loudly at configure time (`message(FATAL_ERROR ...)`) instead
of silently producing an image that cannot boot. The generic `else()`
fallback (unknown `BOARD` → `message(WARNING ...)` + Cortex-M4 flags) is
gone for the same reason — an advertised board option that silently links an
unbootable image is worse than no option at all, which is #268's whole
lesson applied one level up.

Deliberately **not** fixing this by building out real `stm32h7`/`stm32f4`
board support — nobody has asked for those parts, and #268/#271 already
established the pattern (`linker.ld` + `startup.c` + `freertos_hooks.c`, see
`examples/safeboot_freertos_ecu/boards/nucleo_h743zi/`) for whoever needs one
later. The `FATAL_ERROR` message points there.

`safeboot_freertos_ecu` was not affected — both of its board options already
resolve to real directories.

## Verification

Cloned `FreeRTOS-Kernel` to a scratch dir locally, matching CI's own setup
step, for both examples:

- `BOARD=qemu_cortex_m4` configures and links **unchanged**:
  `basic_ecu_freertos` → `.text` 23236 / `.data` 68 / `.bss` 70244, identical
  to what #271 produced — confirms no regression.
- `BOARD=stm32h7`, `BOARD=stm32f4`, and an unrecognised value all fail
  `cmake` configure (exit 1) with the new message, for both examples.

CMake-only change, no C sources touched — MISRA analysis doesn't apply.
`build_tests.sh`: 923 cases, 45/45 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)