### PR TITLE
fix(install): single-source tools/requirements.txt + INSTALL.md accuracy pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,33 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`tools/requirements.txt` is now the single source of truth for the Python
+  toolchain's dependencies, and the delivery ZIP ships this exact file.** A
+  second, divergent copy lived in the EDS-toolchain repo and the ZIP staged
+  that one, so INSTALL.md Step 2's `unzip -o` replaced this file with a list
+  that omitted `pytest`, `pycryptodome` and `pyelftools` — while INSTALL.md
+  Step 6 still instructed customers to run `pytest`. A customer who followed
+  "install everything at once" literally had no pytest by the time they
+  reached Step 6. The commercial copy is deleted in `EDS-toolchain#<PR>`; this
+  file gains `anthropic` (for `eds_ai.py`) and the toolchain copy's tighter
+  `cryptography`/`PyJWT` pins so nothing is lost in the merge.
+- **INSTALL.md corrections found by executing it literally from a fresh
+  clone** (2026-09-11 validation campaign):
+  - the Developer tier list said **17** Jinja2 templates; there are **18**
+    (`ls tools/templates/*.j2`). Every other doc already said 18.
+  - Step 5's expected output showed "(5 standard files + 3 safety wrapper
+    files)" and `[5/5] Manifest skipped (--no-manifest).`; a real run of the
+    documented command writes **6** standard files (`dtc_config.h`, since
+    #176/#249), 3 safety files, 2 routine-handler files, and *writes* the
+    manifest.
+  - the Developer tier was described as including "7 specialist ECU
+    examples". Those examples are in the public repo; what the tier adds is
+    the codegen engine that regenerates their output.
+  - Step 3 claimed `tools/requirements.txt` installs "everything at once".
+    It does not include `python-can`, which is only needed for a real CAN
+    interface — now stated explicitly.
+
+
 - **`basic_ecu_freertos` and `sensor_ecu_freertos` advertised `-DBOARD=stm32h7`
   and `-DBOARD=stm32f4` options that could never produce a working image**
   (#272, found while fixing #268 — separate defect, deliberately not fixed

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,7 @@ This ZIP delivers the commercial toolchain for Xaloqi EDS.
 It installs by extracting into the public EDS repo you already cloned.
 
 **Developer tier includes:**
-- 17 Jinja2 code generation templates (the generation engine)
+- 18 Jinja2 code generation templates (the generation engine)
 - SOVD Bridge: `--sovd` flag generates OpenSOVD 1.0 `sovd_cda.json` from any `diagnostics_config.yaml`
 - `testgen.py` — pytest + CANoe CAPL test suite generator
 - `arxml_parser.py` — AUTOSAR 4.x ECU Extract ARXML → `diagnostics_config.yaml` importer (stdlib only, no deps)
@@ -25,7 +25,10 @@ It installs by extracting into the public EDS repo you already cloned.
 - `_license.py` — offline license verification module
 - React/TypeScript GUI dashboard + WebSocket bridge
 - VS Code extension (YAML validation, hover docs, Run Codegen)
-- 7 specialist ECU examples: BMS, Motor Controller, ARDEP, Sensor, SafeBoot, Robotics, Sensor FreeRTOS
+- Full codegen support for the 7 specialist ECU examples (BMS, Motor
+  Controller, ARDEP, Sensor, SafeBoot, Robotics, Sensor FreeRTOS). The
+  examples themselves are in the public repo; what the ZIP adds is the
+  engine that regenerates their `generated/` output from YAML.
 
 **Professional tier adds:**
 - Integration test harness (`harness/`) — 68 C tests against the full UDS stack
@@ -124,11 +127,17 @@ For `eds_ai.py` (AI configuration assistant):
 pip install anthropic
 ```
 
-All dependencies are listed in `tools/requirements.txt`. To install everything at once:
+`tools/requirements.txt` lists everything the Python toolchain needs —
+codegen, testgen, license verification and `eds_ai.py`:
 
 ```bash
 pip install -r tools/requirements.txt
 ```
+
+> `python-can` is **not** in that file — it is only needed to drive a real
+> CAN interface (`--can-interface=can0`), not to generate code or to run
+> the generated suite against the simulator. Install it separately if you
+> need it: `pip install python-can`.
 
 > **Note for Ubuntu 23.04+ / Debian 12+ users:** if `pip install` fails with
 > `externally-managed-environment`, either use a virtual environment
@@ -203,10 +212,15 @@ Expected output:
 [2/5] Base validation passed.
 [2B]  ASIL-B safety validation passed.
 [3/5] Rendering standard templates...
-  [OK]     generated/uds_init.c
+  [OK]     generated/generated_config.h
+  [OK]     generated/did_handlers.h
   [OK]     generated/did_handlers.c
-  ... (5 standard files + 3 safety wrapper files)
-[5/5] Manifest skipped (--no-manifest).
+  [OK]     generated/uds_init.h
+  [OK]     generated/uds_init.c
+  [OK]     generated/dtc_config.h
+  ... (6 standard files, then 3 safety wrapper files and 2 routine
+       handler files)
+[5/5] Writing manifest...
 
 ========================================================================
   Generation complete.

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -2,16 +2,30 @@
 #
 # Install: pip install -r tools/requirements.txt
 #
+# SINGLE SOURCE OF TRUTH. The Developer/Professional delivery ZIP stages this
+# exact file rather than shipping its own copy, so `unzip -o` (INSTALL.md
+# Step 2) is a no-op for this path. Two divergent copies used to exist — this
+# one and EDS-toolchain's — and the ZIP's copy silently replaced this one,
+# dropping pytest/pycryptodome/pyelftools while INSTALL.md Step 6 still told
+# customers to run pytest. Keep this file and the tools it serves in sync;
+# do not reintroduce a second copy in EDS-toolchain.
+#
 # Required for codegen.py:
 pyyaml>=6.0
 jinja2>=3.1
 #
-# Required for license verification (_license.py) and key generation (keygen.py):
-# These are the ONLY additional dependencies beyond standard codegen requirements.
-cryptography>=41.0
-PyJWT>=2.7
+# Required for license verification (_license.py, activate.py) and key
+# generation (keygen.py). These are the ONLY additional dependencies beyond
+# standard codegen requirements:
+cryptography>=41.0.0
+PyJWT>=2.8.0
 #
-# Required for test generation (testgen.py) and integration tests:
+# Required for test generation (testgen.py) and the generated integration
+# tests (commercial tiers; harmless to install otherwise):
 pytest>=7.4
 pycryptodome>=3.18
 pyelftools>=0.29
+#
+# Required for eds_ai.py, the AI configuration assistant (commercial tiers).
+# Only needed if you actually run eds_ai.py:
+anthropic>=0.40.0


### PR DESCRIPTION
Found by the 2026-09-11 periodic validation campaign: fresh clone at `v1.14.0`, shipped ZIPs extracted per INSTALL.md Step 2, every step executed literally.

## 1. `tools/requirements.txt` — the one that bites a customer

Two divergent copies existed: this one and EDS-toolchain's. `build_release.sh` staged the **toolchain's**, and INSTALL.md Step 2 has customers `unzip -o` over their clone — so the ZIP silently replaced this file with a narrower list:

| | public repo | ZIP (toolchain copy) |
|---|---|---|
| `pytest`, `pycryptodome`, `pyelftools` | ✅ | ❌ **dropped** |
| `anthropic` (eds_ai.py) | ❌ | ✅ |
| `cryptography` / `PyJWT` pins | `>=41.0` / `>=2.7` | `>=41.0.0` / `>=2.8.0` |

INSTALL.md Step 6 then tells the customer to run `pytest . -v --can-interface=simulator`. Anyone who followed Step 3's "install everything at once" literally had **no pytest installed** by the time they reached Step 6.

This file becomes the single source of truth and the ZIP stages it verbatim — the toolchain copy is deleted in the companion PR. It gains `anthropic` and the tighter pins, so the merge loses nothing from either side.

Same root cause and same remedy as `activate.py` (#99): one file, staged from the public repo, making the `unzip -o` a no-op.

## 2. INSTALL.md accuracy

- **Template count** — said 17, actual 18 (`ls tools/templates/*.j2`). Every other doc already said 18.
- **Step 5 expected output** — claimed *"(5 standard files + 3 safety wrapper files)"* and `[5/5] Manifest skipped (--no-manifest).` A real run of the exact documented command writes **6** standard files (`dtc_config.h`, since #176/#249), 3 safety files, **2** routine-handler files, and **writes** the manifest. Replaced with captured real output.
- **Tier contents** — "Developer tier includes 7 specialist ECU examples"; those examples are in this public repo. What the tier adds is the codegen engine for them.
- **Step 3** — `requirements.txt` does not include `python-can` (only needed for a real CAN interface), so "everything at once" was overstated. Now explicit.

## Scope / verification

No code or template changes — generated output is byte-unaffected. The docs sweep (`check_release_docs.py`) passes with no template-count drift after the companion xaloqi-knowledge regex fix; that regex was verified against the unfixed INSTALL.md first, per `lessons/run-014`.

**Merge before** `Xaloqi/EDS-toolchain` PR for this campaign — that PR deletes the toolchain's `requirements.txt` and stages this one, and its release gate will flag the divergence until this lands.

Companion PRs: `Xaloqi/website#37` (same stale count, public pages), xaloqi-knowledge (regex blind spot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)