### PR TITLE
release: v1.15.0 — version bump and CHANGELOG roll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ---
 ## [Unreleased]
 
+## [1.15.0] — 2026-09-11
+
 ### Added
 
 - **`examples/basic_ecu_doip_freertos` can now serve real DoIP traffic on

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@
 #
 # SAFETY CONTEXT : Contains ASIL-B candidate modules (ISO 26262 Part 6).
 # CODING STANDARD: MISRA C:2012 alignment intended.
-# VERSION        : 1.14.0
+# VERSION        : 1.15.0
 # SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 
@@ -74,7 +74,7 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(zephyr_diagnostics_suite
-    VERSION     1.14.0
+    VERSION     1.15.0
     LANGUAGES   C
     DESCRIPTION "Production-grade UDS/ISO-TP diagnostics stack for Zephyr RTOS"
 )

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 > repo. Community users cloning the public repo can ignore this file.
 
 **Product:** Xaloqi EDS (Xaloqi Embedded Diagnostic Suite)  
-**Version:** v1.14.0  
+**Version:** v1.15.0  
 **Support:** contact@xaloqi.com
 
 ---
@@ -53,7 +53,7 @@ cd EDS
 Verify you are on the correct version:
 
 ```bash
-git checkout v1.14.0
+git checkout v1.15.0
 ```
 
 ---
@@ -62,10 +62,10 @@ git checkout v1.14.0
 
 ```bash
 # From the EDS repo root:
-unzip -o /path/to/xaloqi-eds-developer-v1.14.0.zip
+unzip -o /path/to/xaloqi-eds-developer-v1.15.0.zip
 
 # Or for Professional:
-unzip -o /path/to/xaloqi-eds-professional-v1.14.0.zip
+unzip -o /path/to/xaloqi-eds-professional-v1.15.0.zip
 ```
 
 The `-o` flag overwrites existing files without prompting — required when updating an existing installation.
@@ -78,7 +78,7 @@ The `-o` flag overwrites existing files without prompting — required when upda
 >
 > ```bash
 > rm -f tools/templates tools/testgen.py tools/_license.py harness
-> unzip -o /path/to/xaloqi-eds-developer-v1.14.0.zip
+> unzip -o /path/to/xaloqi-eds-developer-v1.15.0.zip
 > ```
 
 This extracts the toolchain files directly into the repo tree. No separate directory. After extraction you will have:
@@ -204,7 +204,7 @@ Expected output:
 
 ```
 ========================================================================
-  Xaloqi EDS — Code Generator v1.14.0
+  Xaloqi EDS — Code Generator v1.15.0
 ========================================================================
   Config   : examples/bms_ecu/diagnostics_config.yaml
   ...

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Xaloqi Embedded Diagnostics Suite
 
 [![CI](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml/badge.svg)](https://github.com/Xaloqi/EDS/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-v1.14.0-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.14.0)
+[![Version](https://img.shields.io/badge/version-v1.15.0-blue)](https://github.com/Xaloqi/EDS/releases/tag/v1.15.0)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](LICENSE)
 [![Zephyr](https://img.shields.io/badge/Zephyr-v3.7%2B-brightgreen)](https://zephyrproject.org)
 
@@ -22,7 +22,7 @@ Zephyr's `native_sim`. No CAN hardware, no commercial license:
 
 ```bash
 pip install west
-west init -m https://github.com/Xaloqi/EDS --mr v1.14.0 eds-workspace
+west init -m https://github.com/Xaloqi/EDS --mr v1.15.0 eds-workspace
 cd eds-workspace && west update
 pip install -r tools/requirements.txt
 
@@ -166,7 +166,7 @@ manifest:
   projects:
     - name: EDS
       remote: xaloqi
-      revision: v1.14.0
+      revision: v1.15.0
       path: modules/eds
 ```
 
@@ -218,7 +218,7 @@ The `ZEPHYR_EDS_MODULE_DIR` variable is set automatically by west when the modul
 
 ```bash
 pip install west
-west init -m https://github.com/Xaloqi/EDS --mr v1.14.0 eds-workspace
+west init -m https://github.com/Xaloqi/EDS --mr v1.15.0 eds-workspace
 cd eds-workspace && west update
 pip install -r tools/requirements.txt
 ```
@@ -505,7 +505,7 @@ Unlike alternatives that use PolyForm Noncommercial (which prohibits production 
 **Just want to see an ECU run?**
 
 ```bash
-west init -m https://github.com/Xaloqi/EDS --mr v1.14.0 eds-workspace
+west init -m https://github.com/Xaloqi/EDS --mr v1.15.0 eds-workspace
 cd eds-workspace && west update
 west build -b native_sim examples/basic_ecu \
   -- -DDTC_OVERLAY_FILE=boards/native_sim/native_sim.overlay \

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@
 
 | Version | Security fixes |
 |---|---|
-| 1.14.x (current) | ✅ Yes |
+| 1.15.x (current) | ✅ Yes |
 | 1.11.x | ✅ Yes (critical only) |
-| < 1.13 | ❌ No — please upgrade |
+| < 1.14 | ❌ No — please upgrade |
 
 Only the current release branch receives routine security fixes. Pre-release and
 modified versions are not supported. Update to the latest tagged release before

--- a/core/uds_types.h
+++ b/core/uds_types.h
@@ -35,11 +35,11 @@ extern "C" {
  * Bumped to 1.12.0 for the v1.12.0 release.
  * -------------------------------------------------------------------------- */
 #define UDS_SUITE_VERSION_MAJOR  (1U)
-#define UDS_SUITE_VERSION_MINOR  (14U)
+#define UDS_SUITE_VERSION_MINOR  (15U)
 #define UDS_SUITE_VERSION_PATCH  (0U)
 
 /** Compile-time version string — matches UDS_STACK_VERSION in safety_config.h. */
-#define UDS_SUITE_VERSION_STRING "1.14.0"
+#define UDS_SUITE_VERSION_STRING "1.15.0"
 
 /* --------------------------------------------------------------------------
  * Buffer and protocol sizing constants

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -13,7 +13,7 @@ ISO 15765-2 (ISO-TP) diagnostics stack for embedded RTOS targets. It is YAML-dri
 describe your DIDs, DTCs, and routines in YAML, run the code generator, and receive
 ASIL-B safety-wrapped C code ready to compile into your ECU firmware.
 
-**Version:** v1.14.0
+**Version:** v1.15.0
 **Target RTOS:** Zephyr v3.7+ · FreeRTOS (any version with static allocation support)
 **Target boards:** native_sim (CI/dev) · STM32 Nucleo-H743ZI2 (Cortex-M7) · NXP FRDM-MCX-N947 (MCX N947, Cortex-M33) · NXP MR-CANHUBK3 (S32K344, Cortex-M7) · QEMU ARM Cortex-M4 (FreeRTOS CI)
 **Transport:** ISO-TP over CAN (default) · DoIP over Ethernet/TCP (v1.6.0+)
@@ -1038,5 +1038,5 @@ tooling and lives in EDS-toolchain — it is not part of this repo's public CI.)
 
 ---
 
-*EDS v1.14.0 — Developer €690/yr · Professional €1,990/yr — xaloqi.com*
+*EDS v1.15.0 — Developer €690/yr · Professional €1,990/yr — xaloqi.com*
 *Runtime: GPL v2 · Examples: Apache 2.0 · Tools + IDE + GUI: Commercial*

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture — Xaloqi EDS
 
-**Version:** v1.14.0  
+**Version:** v1.15.0  
 **Status:** Production-ready. All CI jobs passing.
 
 ---

--- a/docs/CODEGEN_ARCHITECTURE.md
+++ b/docs/CODEGEN_ARCHITECTURE.md
@@ -571,7 +571,7 @@ SDV tooling, OEM SOVD clients, or any tool that understands the OpenSOVD
 ```json
 {
   "sovdVersion": "1.0.0",
-  "generatedBy":  "Xaloqi EDS codegen v1.14.0",
+  "generatedBy":  "Xaloqi EDS codegen v1.15.0",
   "generatedAt":  "<ISO 8601 UTC>",
   "ecuIdentification": {
     "name":    "<ecu_name>",

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -61,7 +61,7 @@ west --version   # must print 1.2 or newer
 mkdir eds-workspace && cd eds-workspace
 
 # Initialise the workspace from the EDS repository
-west init -m https://github.com/Xaloqi/EDS --mr v1.14.0 .
+west init -m https://github.com/Xaloqi/EDS --mr v1.15.0 .
 
 # Pull Zephyr and all dependencies (this downloads ~500 MB, takes 2-4 min)
 west update

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -1,10 +1,10 @@
 # Integration Guide
 
-## Xaloqi EDS — Zephyr RTOS, FreeRTOS, DoIP, and SOVD (v1.14.0)
+## Xaloqi EDS — Zephyr RTOS, FreeRTOS, DoIP, and SOVD (v1.15.0)
 
 | Field | Value |
 |---|---|
-| Stack version | 1.14.0 |
+| Stack version | 1.15.0 |
 | Zephyr version | v3.7.0 (pinned in `west.yml`) |
 | FreeRTOS version | FreeRTOS-Kernel (any recent release; tested with HEAD) |
 | ISO standard | ISO 14229-1:2020 (UDS), ISO 15765-2:2016 (ISO-TP), ISO 13400-2 (DoIP) |
@@ -186,7 +186,7 @@ manifest:
 
     - name: embedded-diagnostics-suite
       url: https://github.com/your-org/embedded-diagnostics-suite
-      revision: v1.14.0            # pin to a release tag
+      revision: v1.15.0            # pin to a release tag
       path: eds
 ```
 
@@ -1256,7 +1256,7 @@ The flag is opt-in — omitting it leaves all existing behaviour unchanged.
 ```json
 {
   "sovdVersion": "1.0.0",
-  "generatedBy": "Xaloqi EDS codegen v1.14.0",
+  "generatedBy": "Xaloqi EDS codegen v1.15.0",
   "generatedAt": "2026-05-20T10:00:00Z",
   "ecuIdentification": {
     "name": "BasicECU",

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -1,6 +1,6 @@
 # Testing Strategy — Xaloqi EDS
 
-**Version:** v1.14.0  
+**Version:** v1.15.0  
 **Status:** 45/45 unit test modules passing. 23/23 CI jobs green. 68/68 harness
 tests passing — **Professional tier only**: `harness/` sources are a gitignored
 commercial deliverable (#68), absent from a Developer-tier checkout (every
@@ -20,7 +20,7 @@ all covered.
 EDS uses a four-layer testing strategy: unit tests, harness tests, integration tests, and system
 tests. All four layers run automatically in CI on every push and pull request.
 
-**Current test counts (v1.14.0):**
+**Current test counts (v1.15.0):**
 
 | Layer | Count | Framework | Status |
 |---|---|---|---|
@@ -40,7 +40,7 @@ tests. All four layers run automatically in CI on every push and pull request.
 ### What "the generated pytest suite" (row above) actually runs on a clean checkout
 
 `cd examples/basic_ecu/generated/tests && pytest --collect-only -q` reports **632 tests
-collected** for `basic_ecu` (v1.14.0). That is a *collection* count, not a claim that
+collected** for `basic_ecu` (v1.15.0). That is a *collection* count, not a claim that
 632 tests execute — and pass — right after `pip install -r tools/requirements.txt`. A
 meaningful share need TestLab (the commercial `xaloqi-tester` package), the
 (not-publicly-included) `firmware_bus` harness, or the commercial `tools/templates/`

--- a/examples/ardep_ecu/generated/safety_config.h
+++ b/examples/ardep_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.14.0"
+#define UDS_STACK_VERSION "1.15.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu/generated/safety_config.h
+++ b/examples/basic_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.14.0"
+#define UDS_STACK_VERSION "1.15.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu_doip/generated/safety_config.h
+++ b/examples/basic_ecu_doip/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.14.0"
+#define UDS_STACK_VERSION "1.15.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu_doip_freertos/generated/safety_config.h
+++ b/examples/basic_ecu_doip_freertos/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.14.0"
+#define UDS_STACK_VERSION "1.15.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/basic_ecu_freertos/generated/safety_config.h
+++ b/examples/basic_ecu_freertos/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.14.0"
+#define UDS_STACK_VERSION "1.15.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/bms_ecu/generated/safety_config.h
+++ b/examples/bms_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.14.0"
+#define UDS_STACK_VERSION "1.15.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/motor_controller_ecu/generated/safety_config.h
+++ b/examples/motor_controller_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.14.0"
+#define UDS_STACK_VERSION "1.15.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/robot_joint_controller_ecu/generated/safety_config.h
+++ b/examples/robot_joint_controller_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.14.0"
+#define UDS_STACK_VERSION "1.15.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/safeboot_ecu/generated/safety_config.h
+++ b/examples/safeboot_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.14.0"
+#define UDS_STACK_VERSION "1.15.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/safeboot_freertos_ecu/generated/safety_config.h
+++ b/examples/safeboot_freertos_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.14.0"
+#define UDS_STACK_VERSION "1.15.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/sensor_ecu/generated/safety_config.h
+++ b/examples/sensor_ecu/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.14.0"
+#define UDS_STACK_VERSION "1.15.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/examples/sensor_ecu_freertos/generated/safety_config.h
+++ b/examples/sensor_ecu_freertos/generated/safety_config.h
@@ -40,7 +40,7 @@
 #ifndef SAFETY_CONFIG_H
 #define SAFETY_CONFIG_H
 
-#define UDS_STACK_VERSION "1.14.0"
+#define UDS_STACK_VERSION "1.15.0"
 
 /* =============================================================================
  * ASIL level identification

--- a/sbom.json
+++ b/sbom.json
@@ -4,7 +4,7 @@
   "serialNumber": "urn:uuid:7b3c9a5d-1f2e-4c8b-a6d0-8e4f2b1c5a3d",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-09-07T00:00:00Z",
+    "timestamp": "2026-09-11T00:00:00Z",
     "tools": [
       {
         "vendor": "Xaloqi",
@@ -14,9 +14,9 @@
     ],
     "component": {
       "type": "firmware",
-      "bom-ref": "xaloqi-eds@1.14.0",
+      "bom-ref": "xaloqi-eds@1.15.0",
       "name": "Xaloqi EDS",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "description": "Production-grade UDS/ISO-TP/DoIP diagnostics stack for automotive ECUs (ASIL-B candidate, ISO 14229 / ISO 15765-2 / ISO 13400-2)",
       "licenses": [
         {

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -100,7 +100,7 @@ except ImportError:
     print("ERROR: Jinja2 is required.  pip install jinja2", file=sys.stderr)
     sys.exit(2)
 
-__version__ = "1.14.0"
+__version__ = "1.15.0"
 
 # =============================================================================
 # Constants


### PR DESCRIPTION
Cuts **v1.15.0**. Minor, not patch: `[Unreleased]` carries an `### Added` entry — real DoIP traffic on QEMU for `examples/basic_ecu_doip_freertos`, via a new lwIP port and a guest-side LAN9118 driver (#267).

Rolled by `xaloqi-knowledge/scripts/bump_release_version.py 1.15.0` across 4 repos / 46 files. This repo's share: CHANGELOG roll, `codegen.py __version__` (CI-guarded equal to the top CHANGELOG entry), `core/uds_types.h`'s 4 macros, `CMakeLists.txt`, `SECURITY.md`, README badge, `INSTALL.md` (every occurrence), and all 12 committed `examples/*/generated/safety_config.h` `UDS_STACK_VERSION` lines.

## Why this release matters to customers

**This is the first release whose delivery ZIPs are built from the fixed `build_release.sh`.** Since at least v1.13.2 the ZIPs reverted four merged fixes in all 8 specialist examples on `unzip -o`, and shipped `examples/safeboot_ecu/src/main.c` as a copy of `basic_ecu`'s — no `boot_write_img_confirmed()`, so every OTA update on the flagship secure-boot example would roll back on the next power cycle. The release gate reported PASS throughout; it is now unscoped (EDS-toolchain#109).

Also ships: `tools/requirements.txt` single-sourced (#274), codegen C escaping (#275), FreeRTOS vector tables and BOARD rejection (#271, #273), MISRA Rule 20.9 (#270).

## Verification (release-runbook step 1)

- `check_versions.py` — no drift in either product repo.
- `check_release_docs.py --expected-version 1.15.0` — no hard version/badge drift. The 2 remaining warnings are the script quoting its own explanatory prose; both predate this campaign.
- **Spot-check against real codegen**, per the runbook: regenerated `bms_ecu` and `basic_ecu` with `codegen.py --template-dir <toolchain>/tools/templates` and diffed against what the bump script wrote — **timestamp-only**, `UDS_STACK_VERSION "1.15.0"` from both paths. This is the run-014 habit applied to the bump: confirm the targeted literal edit matches what real generation produces.

## After merge

Tag `v1.15.0`, then `build_release.sh` + release gate against the tag (**not** `main`), then founder uploads to Polar. Companion PRs: `Xaloqi/EDS-toolchain`, `Xaloqi/automation`, `Xaloqi/website`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)